### PR TITLE
[LWDM] feat(solana): bring the generic-path logic up to the legacy bridge

### DIFF
--- a/.changeset/coin-solana-generic-logic.md
+++ b/.changeset/coin-solana-generic-logic.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+Bring the Solana coin-module logic the generic coin framework calls up to what the legacy bridge already does: transaction crafting, fee estimation, intent validation, operation listing, balances and stakes. Reached only through `api/index.ts`, which the framework flag gates, so the legacy Solana bridge is unaffected.

--- a/libs/coin-modules/coin-solana/src/helpers/token.ts
+++ b/libs/coin-modules/coin-solana/src/helpers/token.ts
@@ -119,3 +119,67 @@ export function calculateToken2022TransferFees({
       .toNumber(),
   };
 }
+
+/**
+ * Computes Token-2022 transfer fees for the "send all" case.
+ *
+ * Unlike `calculateToken2022TransferFees` which works from net → gross, this
+ * function works from gross → net: the total deducted from the sender's ATA
+ * equals the full token balance, and the fee is derived from that total.
+ *
+ * Formula: `fee = min( ceil(total × bps / 10 000), maximumFee )`
+ *
+ * Selects the active fee schedule based on `currentEpoch` vs the
+ * `newerTransferFee.epoch` threshold.
+ */
+export function computeTransferFeeFromTotal(
+  totalAmount: BigNumber.Value,
+  config: Pick<TransferFeeConfigExt["state"], "newerTransferFee" | "olderTransferFee">,
+  currentEpoch: number,
+): TransferFeeCalculated {
+  const { newerTransferFee, olderTransferFee } = config;
+  const feeConfig = currentEpoch >= newerTransferFee.epoch ? newerTransferFee : olderTransferFee;
+  const { maximumFee, transferFeeBasisPoints } = feeConfig;
+  const feePercent = bpsToPercent(transferFeeBasisPoints);
+
+  const totalBn = BigNumber(totalAmount);
+  const maxFeeBn = BigNumber(maximumFee);
+  let transferFeeBn = totalBn
+    .times(transferFeeBasisPoints)
+    .div(10000)
+    .decimalPlaces(0, BigNumber.ROUND_CEIL);
+  if (transferFeeBn.gt(maxFeeBn)) {
+    transferFeeBn = maxFeeBn;
+  }
+
+  return {
+    feePercent,
+    maxTransferFee: maximumFee,
+    transferFee: transferFeeBn.toNumber(),
+    feeBps: transferFeeBasisPoints,
+    transferAmountIncludingFee: totalBn.toNumber(),
+    transferAmountExcludingFee: totalBn.minus(transferFeeBn).toNumber(),
+  };
+}
+
+/**
+ * Transfer fee for an intent, picking the right direction: a send-all amount is the total leaving
+ * the account, any other amount is what the recipient should receive.
+ */
+export function transferFeeForIntent(
+  amount: bigint,
+  useAllAmount: boolean | undefined,
+  transferFeeConfigState: Pick<
+    TransferFeeConfigExt["state"],
+    "newerTransferFee" | "olderTransferFee"
+  >,
+  currentEpoch: number,
+): TransferFeeCalculated {
+  return useAllAmount
+    ? computeTransferFeeFromTotal(amount.toString(), transferFeeConfigState, currentEpoch)
+    : calculateToken2022TransferFees({
+        transferAmount: Number(amount),
+        transferFeeConfigState,
+        currentEpoch,
+      });
+}

--- a/libs/coin-modules/coin-solana/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/logic/craftTransaction.ts
@@ -15,14 +15,10 @@ import {
   TransactionMessage,
   BlockhashWithExpiryBlockHeight,
 } from "@solana/web3.js";
-import BigNumber from "bignumber.js";
-import { bpsToPercent, calculateToken2022TransferFees } from "../helpers/token";
+import { transferFeeForIntent } from "../helpers/token";
 import { isValidBase58Address } from "../logic";
 import type { ChainAPI } from "../network";
-import type {
-  TransferFeeConfigExt,
-  TransferFeeConfigState,
-} from "../network/chain/account/tokenExtensions";
+import type { TransferFeeConfigExt } from "../network/chain/account/tokenExtensions";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import {
   buildTransferInstructions,
@@ -36,27 +32,29 @@ import {
   buildStakeWithdrawInstructions,
   buildStakeSplitInstructions,
   findAssociatedTokenAccountPubkey,
-  getMaybeMintAccount,
   getMaybeTokenAccount,
-  getMaybeTokenMintProgram,
+  getMaybeTokenMint,
   getStakeAccountAddressWithSeed,
   getStakeAccountMinimumBalanceForRentExemption,
 } from "../network/chain/web3";
 import { UserInputType } from "../signer";
+import { withdrawableFromStake } from "../logic";
+import { getStakeAccounts } from "../network/chain/stake-activation/rpc";
 import { createStakeAccountSeed } from "../stakeAccountSeed";
 import type {
   Command,
   StakeCreateAccountCommand,
   StakeDelegateCommand,
   StakeUndelegateCommand,
+  StakeSplitCommand,
   StakeWithdrawCommand,
   TokenTransferCommand,
   TransferCommand,
-  TransferFeeCalculated,
   Transaction,
   SolanaTokenProgram,
+  SolanaTxData,
 } from "../types";
-import { assertUnreachable, DUMMY_SIGNATURE } from "../utils";
+import { assertUnreachable, DUMMY_SIGNATURE, ZERO_FILLED_DUMMY_SIGNATURE } from "../utils";
 
 // ---------------------------------------------------------------------------
 // Coin Module API: craft a transaction from a TransactionIntent
@@ -64,11 +62,20 @@ import { assertUnreachable, DUMMY_SIGNATURE } from "../utils";
 
 export async function craftTransaction(
   api: ChainAPI,
-  intent: TransactionIntent<StringMemo | MemoNotSupported> | StakingTransactionIntent,
+  intent: (TransactionIntent<StringMemo | MemoNotSupported> | StakingTransactionIntent) & {
+    data?: { type: string };
+  },
   customFees?: FeeEstimation,
 ): Promise<CraftedTransaction> {
   if (!isValidBase58Address(intent.sender)) {
     throw new Error("Invalid sender address");
+  }
+
+  if (intent.data?.type === "solana") {
+    const data = intent.data as SolanaTxData;
+    if (data.raw) {
+      return craftPrebuiltTransaction(api, { ...data, raw: data.raw }, intent.sender, customFees);
+    }
   }
 
   if (intent.type === "stake.withdraw") {
@@ -91,7 +98,97 @@ export async function craftTransaction(
     return craftUndelegateFromIntent(api, intent as StakingTransactionIntent, customFees);
   }
 
+  if (intent.type === "stake.split") {
+    return craftSplitStakeFromIntent(
+      api,
+      intent as StakingTransactionIntent<StringMemo | MemoNotSupported>,
+      customFees,
+    );
+  }
+
+  if (
+    intent.type === "token.createATA" ||
+    intent.type === "token.approve" ||
+    intent.type === "token.revoke"
+  ) {
+    return craftTokenAuthorityFromIntent(api, intent, customFees);
+  }
+
   return craftSendTransactionFromIntent(api, intent, customFees);
+}
+
+/**
+ * A transaction a partner already built: the bytes are the transaction, so nothing is derived from
+ * the intent. Only the blockhash is refreshed, and only while the transaction is still unsigned —
+ * mirroring what `buildVersionedTransaction` does for the same payload on the legacy path.
+ */
+async function craftPrebuiltTransaction(
+  api: ChainAPI,
+  data: SolanaTxData & { raw: string },
+  sender: string,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  let transaction: VersionedTransaction;
+  try {
+    transaction = VersionedTransaction.deserialize(Buffer.from(data.raw, "base64"));
+  } catch {
+    throw new Error("Invalid or unsupported raw transaction");
+  }
+
+  const feePayer = transaction.message.staticAccountKeys[0]?.toBase58();
+  if (feePayer && feePayer !== sender) {
+    throw new Error("Sender does not match transaction fee payer");
+  }
+
+  const recentBlockhash = await api.getLatestBlockhash();
+  // Both fills mean "not signed yet" -- `signOperation.ts` reads them the same way. A partner's
+  // transaction arrives zero-filled, so checking only `DUMMY_SIGNATURE` would leave it on a
+  // blockhash that may already have expired.
+  const unsigned = transaction.signatures.every(sig => {
+    const buf = Buffer.from(sig);
+    return buf.equals(DUMMY_SIGNATURE) || buf.equals(ZERO_FILLED_DUMMY_SIGNATURE);
+  });
+  if (unsigned) {
+    transaction.message.recentBlockhash = recentBlockhash.blockhash;
+  }
+
+  const fee = customFees
+    ? customFees.value
+    : BigInt((await api.getFeeForMessage(transaction.message)) ?? 5000);
+
+  return {
+    transaction: Buffer.from(transaction.serialize()).toString("base64"),
+    details: {
+      recentBlockhash: transaction.message.recentBlockhash,
+      lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+      estimatedFee: fee.toString(),
+    },
+  };
+}
+
+/**
+ * Read live: withdrawing the synced amount off a grown account leaves a residue under the
+ * rent-exempt reserve, which the stake program rejects. `undefined` if the account is gone.
+ */
+async function liveWithdrawable(
+  api: ChainAPI,
+  intent: StakingTransactionIntent,
+): Promise<number | undefined> {
+  const stakeAccounts = await getStakeAccounts(api, intent.sender);
+  const stakeAccount = stakeAccounts.find(
+    ({ account }) => account.onChainAcc.pubkey.toBase58() === intent.recipient,
+  );
+  if (!stakeAccount) return undefined;
+
+  const { account, activation } = stakeAccount;
+  return Math.max(
+    0,
+    withdrawableFromStake({
+      stakeAccBalance: account.onChainAcc.account.lamports,
+      activation,
+      rentExemptReserve: account.info.meta.rentExemptReserve.toNumber(),
+    }),
+  );
 }
 
 async function craftWithdrawTransaction(
@@ -99,12 +196,13 @@ async function craftWithdrawTransaction(
   intent: StakingTransactionIntent,
   customFees?: FeeEstimation,
 ): Promise<CraftedTransaction> {
+  const withdrawable = await liveWithdrawable(api, intent);
   const command: StakeWithdrawCommand = {
     kind: "stake.withdraw",
     authorizedAccAddr: intent.sender,
     stakeAccAddr: intent.recipient,
     toAccAddr: intent.sender,
-    amount: Number(intent.amount),
+    amount: withdrawable ?? Number(intent.amount),
   };
   const instructions = await buildInstructionsForCommand(api, command);
   const recentBlockhash = await api.getLatestBlockhash();
@@ -140,7 +238,7 @@ async function craftCreateStakeAccountFromIntent(
   intent: StakingTransactionIntent,
   customFees?: FeeEstimation,
 ): Promise<CraftedTransaction> {
-  const seed = createStakeAccountSeed();
+  const seed = stakeAccountSeedOfIntent(intent) ?? createStakeAccountSeed();
   const stakeAccAddress = await getStakeAccountAddressWithSeed({
     fromAddress: intent.sender,
     seed,
@@ -167,9 +265,12 @@ async function craftDelegateFromIntent(
   customFees?: FeeEstimation,
 ): Promise<CraftedTransaction> {
   const valAddress = "valAddress" in intent ? intent.valAddress : undefined;
-  const stakeAccAddr = "memo" in intent ? intent.memo.value : intent.recipient;
+  // The framework always sets a memo, `{ type: "none" }` at worst, so a `"memo" in intent` guard
+  // would never fall through -- read the value and let an absent one be the error.
+  const memo = "memo" in intent ? intent.memo : undefined;
+  const stakeAccAddr = memo?.type === "string" ? memo.value : undefined;
   if (!stakeAccAddr) {
-    throw new Error("stake.delegate requires a stake account address (via recipient)");
+    throw new Error("stake.delegate requires a stake account address (via the memo)");
   }
   const voteAccAddr = valAddress ?? intent.recipient;
   const command: StakeDelegateCommand = {
@@ -191,6 +292,91 @@ async function craftUndelegateFromIntent(
     authorizedAccAddr: intent.sender,
     stakeAccAddr: intent.recipient,
   };
+  return craftCommandToTransaction(api, command, intent.sender, customFees);
+}
+
+/**
+ * Splitting a stake account moves part of it into a new one, derived from a fresh seed here the
+ * same way `stake.createAccount` derives its own.
+ */
+async function craftSplitStakeFromIntent(
+  api: ChainAPI,
+  intent: StakingTransactionIntent<StringMemo | MemoNotSupported>,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  const memo = "memo" in intent ? intent.memo : undefined;
+  const stakeAccAddr = memo?.type === "string" ? memo.value : intent.recipient;
+  if (!stakeAccAddr) {
+    throw new Error("stake.split requires a stake account address");
+  }
+
+  const seed = stakeAccountSeedOfIntent(intent) ?? createStakeAccountSeed();
+  const command: StakeSplitCommand = {
+    kind: "stake.split",
+    authorizedAccAddr: intent.sender,
+    stakeAccAddr,
+    amount: Number(intent.amount),
+    seed,
+    splitStakeAccAddr: await getStakeAccountAddressWithSeed({ fromAddress: intent.sender, seed }),
+  };
+  return craftCommandToTransaction(api, command, intent.sender, customFees);
+}
+
+/**
+ * Opening a token account, delegating spending authority over one, and taking that authority back.
+ * Only a live app reaches these; no first-party screen builds them. The addresses the instructions
+ * need are derived from the chain, exactly as the legacy `deriveCommandDescriptor` did -- the wallet
+ * API carries only the token and the delegate.
+ */
+async function craftTokenAuthorityFromIntent(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  const mintAddress = getTokenMintAddress(intent);
+  if (!mintAddress) {
+    throw new Error(`${intent.type} requires a token asset`);
+  }
+
+  const mint = await getMaybeTokenMint(mintAddress, api);
+  if (!mint || mint instanceof Error) {
+    throw new Error(`Cannot resolve mint account for ${mintAddress}`);
+  }
+  const tokenProgram: SolanaTokenProgram =
+    mint.onChainAcc.data.program === PARSED_PROGRAMS.SPL_TOKEN_2022
+      ? PARSED_PROGRAMS.SPL_TOKEN_2022
+      : PARSED_PROGRAMS.SPL_TOKEN;
+
+  const ownerAta = (
+    await findAssociatedTokenAccountPubkey(intent.sender, mintAddress, tokenProgram)
+  ).toBase58();
+
+  const command: Command =
+    intent.type === "token.createATA"
+      ? {
+          kind: "token.createATA",
+          owner: intent.sender,
+          mint: mintAddress,
+          associatedTokenAccountAddress: ownerAta,
+        }
+      : intent.type === "token.revoke"
+        ? { kind: "token.revoke", account: ownerAta, owner: intent.sender, tokenProgram }
+        : {
+            kind: "token.approve",
+            account: ownerAta,
+            mintAddress,
+            recipientDescriptor: await resolveRecipientDescriptor(
+              api,
+              intent.recipient,
+              mintAddress,
+              tokenProgram,
+            ),
+            owner: intent.sender,
+            amount: Number(intent.amount),
+            decimals: mint.info.decimals,
+            tokenProgram,
+          };
+
   return craftCommandToTransaction(api, command, intent.sender, customFees);
 }
 
@@ -402,6 +588,11 @@ function resolveNativeTransferCommand(intent: TransactionIntent, memo?: string):
   };
 }
 
+export function stakeAccountSeedOfIntent(intent: unknown): string | undefined {
+  const data = (intent as { data?: SolanaTxData } | undefined)?.data;
+  return data?.type === "solana" ? data.stakeAccountSeed : undefined;
+}
+
 function getTokenMintAddress(intent: TransactionIntent): string | undefined {
   if (intent.asset.type === "native") return undefined;
   if ("assetReference" in intent.asset && intent.asset.assetReference) {
@@ -410,22 +601,56 @@ function getTokenMintAddress(intent: TransactionIntent): string | undefined {
   return undefined;
 }
 
+// The recipient may be a token account rather than a wallet: deriving an associated account from
+// one throws `TokenOwnerOffCurveError`, an ATA being off the ed25519 curve.
+export async function resolveRecipientDescriptor(
+  api: ChainAPI,
+  recipient: string,
+  mintAddress: string,
+  tokenProgram: SolanaTokenProgram,
+): Promise<TokenTransferCommand["recipientDescriptor"]> {
+  const recipientTokenAccount = await getMaybeTokenAccount(recipient, api);
+  if (recipientTokenAccount && !(recipientTokenAccount instanceof Error)) {
+    return {
+      walletAddress: recipientTokenAccount.owner.toBase58(),
+      tokenAccAddress: recipient,
+      shouldCreateAsAssociatedTokenAccount: false,
+      userInputType: UserInputType.ATA,
+    };
+  }
+
+  const associatedAddress = (
+    await findAssociatedTokenAccountPubkey(recipient, mintAddress, tokenProgram)
+  ).toBase58();
+  const associatedAccount = await getMaybeTokenAccount(associatedAddress, api);
+
+  return {
+    walletAddress: recipient,
+    tokenAccAddress: associatedAddress,
+    shouldCreateAsAssociatedTokenAccount:
+      associatedAccount === undefined || associatedAccount instanceof Error,
+    userInputType: UserInputType.SOL,
+  };
+}
+
 async function resolveTokenTransferCommand(
   api: ChainAPI,
   intent: TransactionIntent,
   mintAddress: string,
   memo?: string,
 ): Promise<TokenTransferCommand> {
-  const [mintAccount, mintProgram] = await Promise.all([
-    getMaybeMintAccount(mintAddress, api),
-    getMaybeTokenMintProgram(mintAddress, api),
-  ]);
-  if (!mintAccount || mintAccount instanceof Error) {
+  // One read, not two: `getMaybeTokenMint` carries both the parsed mint and the program that owns
+  // it, where `getMaybeMintAccount` and `getMaybeTokenMintProgram` each fetched the same account.
+  const mint = await getMaybeTokenMint(mintAddress, api);
+  if (!mint || mint instanceof Error) {
     throw new Error(`Cannot resolve mint account for ${mintAddress}`);
   }
 
+  const mintAccount = mint.info;
   const resolvedProgram: SolanaTokenProgram =
-    mintProgram && !(mintProgram instanceof Error) ? mintProgram : "spl-token";
+    mint.onChainAcc.data.program === PARSED_PROGRAMS.SPL_TOKEN_2022
+      ? PARSED_PROGRAMS.SPL_TOKEN_2022
+      : PARSED_PROGRAMS.SPL_TOKEN;
   const mintDecimals = mintAccount.decimals;
 
   const senderAta = await findAssociatedTokenAccountPubkey(
@@ -434,27 +659,16 @@ async function resolveTokenTransferCommand(
     resolvedProgram,
   );
 
-  const recipientAta = await findAssociatedTokenAccountPubkey(
-    intent.recipient,
-    mintAddress,
-    resolvedProgram,
-  );
-  const recipientAtaAddress = recipientAta.toBase58();
-
-  const recipientTokenAccount = await getMaybeTokenAccount(recipientAtaAddress, api);
-  const shouldCreateAta =
-    recipientTokenAccount === undefined || recipientTokenAccount instanceof Error;
-
   const command: TokenTransferCommand = {
     kind: "token.transfer",
     ownerAddress: intent.sender,
     ownerAssociatedTokenAccountAddress: senderAta.toBase58(),
-    recipientDescriptor: {
-      walletAddress: intent.recipient,
-      tokenAccAddress: recipientAtaAddress,
-      shouldCreateAsAssociatedTokenAccount: shouldCreateAta,
-      userInputType: UserInputType.SOL,
-    },
+    recipientDescriptor: await resolveRecipientDescriptor(
+      api,
+      intent.recipient,
+      mintAddress,
+      resolvedProgram,
+    ),
     amount: Number(intent.amount),
     mintAddress,
     mintDecimals,
@@ -479,67 +693,16 @@ async function resolveTokenTransferCommand(
     );
     if (transferFeeConfigExt) {
       const { epoch } = await api.getEpochInfo();
-      if (intent.useAllAmount) {
-        command.extensions = {
-          transferFee: computeTransferFeeFromTotal(
-            intent.amount.toString(),
-            transferFeeConfigExt.state,
-            epoch,
-          ),
-        };
-      } else {
-        command.extensions = {
-          transferFee: calculateToken2022TransferFees({
-            transferAmount: Number(intent.amount),
-            transferFeeConfigState: transferFeeConfigExt.state,
-            currentEpoch: epoch,
-          }),
-        };
-      }
+      command.extensions = {
+        transferFee: transferFeeForIntent(
+          intent.amount,
+          intent.useAllAmount,
+          transferFeeConfigExt.state,
+          epoch,
+        ),
+      };
     }
   }
 
   return command;
-}
-
-/**
- * Computes Token-2022 transfer fees for the "send all" case.
- *
- * Unlike `calculateToken2022TransferFees` which works from net → gross, this
- * function works from gross → net: the total deducted from the sender's ATA
- * equals the full token balance, and the fee is derived from that total.
- *
- * Formula: `fee = min( ceil(total × bps / 10 000), maximumFee )`
- *
- * Selects the active fee schedule based on `currentEpoch` vs the
- * `newerTransferFee.epoch` threshold.
- */
-function computeTransferFeeFromTotal(
-  totalAmount: BigNumber.Value,
-  config: Pick<TransferFeeConfigState, "newerTransferFee" | "olderTransferFee">,
-  currentEpoch: number,
-): TransferFeeCalculated {
-  const { newerTransferFee, olderTransferFee } = config;
-  const feeConfig = currentEpoch >= newerTransferFee.epoch ? newerTransferFee : olderTransferFee;
-  const { maximumFee, transferFeeBasisPoints } = feeConfig;
-  const feePercent = bpsToPercent(transferFeeBasisPoints);
-
-  const totalBn = BigNumber(totalAmount);
-  const maxFeeBn = BigNumber(maximumFee);
-  let transferFeeBn = totalBn
-    .times(transferFeeBasisPoints)
-    .div(10000)
-    .decimalPlaces(0, BigNumber.ROUND_CEIL);
-  if (transferFeeBn.gt(maxFeeBn)) {
-    transferFeeBn = maxFeeBn;
-  }
-
-  return {
-    feePercent,
-    maxTransferFee: maximumFee,
-    transferFee: transferFeeBn.toNumber(),
-    feeBps: transferFeeBasisPoints,
-    transferAmountIncludingFee: totalBn.toNumber(),
-    transferAmountExcludingFee: totalBn.minus(transferFeeBn).toNumber(),
-  };
 }

--- a/libs/coin-modules/coin-solana/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-solana/src/logic/estimateFees.ts
@@ -8,14 +8,29 @@ import { log } from "@ledgerhq/logs";
 import { VersionedTransaction as OnChainTransaction } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
 import { isSolanaStakingTransactionIntent } from "../logic";
+import { stakeAccountSeedOfIntent } from "./craftTransaction";
 import { ChainAPI } from "../network";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
-import { getStakeAccountAddressWithSeed } from "../network/chain/web3";
+import {
+  getMaybeTokenMint,
+  getStakeAccountAddressWithSeed,
+  getStakeAccountMinimumBalanceForRentExemption,
+  type ParsedOnChainMintWithInfo,
+} from "../network/chain/web3";
+import type { TransferFeeConfigExt } from "../network/chain/account/tokenExtensions";
+import { getAtaDataLengthForMint, transferFeeForIntent } from "../helpers/token";
 import { UserInputType } from "../signer";
-import type { SolanaTokenProgram, TokenTransferCommand } from "../types";
-import { Transaction, TransactionModel } from "../types";
+import type {
+  SolanaTokenProgram,
+  SolanaTxData,
+  TokenTransferCommand,
+  Transaction,
+  TransactionModel,
+  TransferFeeCalculated,
+} from "../types";
 import { LEDGER_VALIDATOR_DEFAULT, assertUnreachable } from "../utils";
-import { buildVersionedTransaction } from "./craftTransaction";
+import { buildVersionedTransaction, resolveRecipientDescriptor } from "./craftTransaction";
+import { findAssociatedTokenAccountPubkey } from "../network/chain/web3";
 
 const DEFAULT_TX_FEE = 5000;
 
@@ -36,13 +51,164 @@ const BASE_TRANSACTION: Transaction = {
  */
 export async function estimateFees(
   api: ChainAPI,
-  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  intent: TransactionIntent<StringMemo | MemoNotSupported> & { data?: { type: string } },
   _customFeesParameters?: FeeEstimation["parameters"],
 ): Promise<FeeEstimation> {
+  // A partner-built transaction is measured as-is; there is nothing to derive from the intent.
+  const solanaData = intent.data?.type === "solana" ? (intent.data as SolanaTxData) : undefined;
+  if (solanaData?.raw) {
+    const { raw } = solanaData;
+    const message = OnChainTransaction.deserialize(Buffer.from(raw, "base64")).message;
+    return { value: BigInt((await api.getFeeForMessage(message)) ?? DEFAULT_TX_FEE) };
+  }
+
   const kind = mapIntentToTxKind(intent);
-  const tokenProgram = resolveTokenProgramFromAsset(intent.asset);
-  const fee = await estimateTxFee(api, intent.sender, kind, tokenProgram);
-  return { value: BigInt(fee) };
+  const fee = await estimateTxFee(api, intent.sender, kind);
+
+  // The token-authority commands act on the owner's own associated account, and the device names it
+  // -- it is derived from the chain, so the wallet cannot work it out on its own.
+  if (TOKEN_AUTHORITY_TYPES.has(intent.type)) {
+    const ownerTokenAccount = await ownerAssociatedTokenAccount(api, intent);
+    // Opening an account costs its rent, which leaves the wallet like the fee does and is an order
+    // of magnitude larger. Approving and revoking open nothing. The legacy bridge charged the same
+    // (`estimateMaxSpendable.ts`, `token.createATA`).
+    const ataRent = intent.type === "token.createATA" ? await ownerAtaRent(api, intent) : 0n;
+    return {
+      value: BigInt(fee) + ataRent,
+      ...(ownerTokenAccount ? { parameters: { ownerTokenAccount } } : {}),
+    };
+  }
+
+  // Both open a stake account at an address derived from a seed, and the device names it, so the
+  // wallet has to derive the same one to show the same row. Keyed on `intent.type`: a split is
+  // priced as a plain transfer, so it never reaches `kind`.
+  const opensStakeAccount = intent.type === "stake.createAccount" || intent.type === "stake.split";
+  if (opensStakeAccount) {
+    const isCreation = intent.type === "stake.createAccount";
+    const seed = stakeAccountSeedOfIntent(intent);
+    const [stakeAccountAddress, stakeAccountRent, reserve] = await Promise.all([
+      seed ? getStakeAccountAddressWithSeed({ fromAddress: intent.sender, seed }) : undefined,
+      isCreation ? getStakeAccountMinimumBalanceForRentExemption(api) : undefined,
+      isCreation ? unstakeReserve(api, intent.sender) : 0n,
+    ]);
+    return {
+      value: BigInt(fee),
+      parameters: {
+        // Only a creation pays the rent on top of the delegated amount; a split moves lamports that
+        // already cover it.
+        ...(stakeAccountRent !== undefined
+          ? {
+              stakeAccountRent: BigInt(stakeAccountRent),
+              // Send-max has to leave the future undelegate and withdraw affordable, or a first-time
+              // staker signs away every lamport and cannot unstake. The rent is not held back: it
+              // rides inside the amount, which `craftCreateStakeAccountFromIntent` splits.
+              reserve: BigInt(fee) + reserve,
+            }
+          : {}),
+        ...(stakeAccountAddress ? { stakeAccountAddress } : {}),
+      },
+    };
+  }
+
+  // The mint is the only authority on a token's transfer fee: `asset.type` comes from the CAL id,
+  // which spells every Solana token `spl` -- Token-2022 ones included.
+  const mint = await getMaybeMintOfIntent(api, intent);
+  const transferFee = mint && (await getMaybeTransferFee(api, intent, mint));
+  const ataRent = mint ? await recipientAtaRent(api, intent, mint) : 0n;
+  return {
+    value: BigInt(fee) + ataRent,
+    ...(transferFee ? { parameters: { transferFee } } : {}),
+  };
+}
+
+/**
+ * What the eventual undelegate and withdraw of a stake account will cost. Read from the chain, so a
+ * failure here must not block the flow -- it only makes send-max marginally less generous.
+ */
+export async function unstakeReserve(api: ChainAPI, sender: string): Promise<bigint> {
+  try {
+    const [undelegateFee, withdrawFee] = await Promise.all([
+      estimateTxFee(api, sender, "stake.undelegate"),
+      estimateTxFee(api, sender, "stake.withdraw"),
+    ]);
+    return BigInt(undelegateFee + withdrawFee);
+  } catch {
+    return 0n;
+  }
+}
+
+/** Rent for the associated token account the sender is opening for itself. */
+async function ownerAtaRent(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+): Promise<bigint> {
+  const mint = await getMaybeMintOfIntent(api, intent);
+  if (!mint) return 0n;
+  return BigInt(await api.getMinimumBalanceForRentExemption(getAtaDataLengthForMint(mint)));
+}
+
+/**
+ * Rent for the recipient's associated token account, when the transfer has to create it. It is not
+ * a network fee, but it leaves the sender's account all the same, and the legacy bridge reported it
+ * here (`prepareTransaction.ts` returned `fee + assocAccRentExempt`) -- leaving it out understates
+ * the cost by roughly 2M lamports on the confirmation screen.
+ */
+async function recipientAtaRent(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  mint: ParsedOnChainMintWithInfo,
+): Promise<bigint> {
+  if (!intent.recipient) return 0n;
+  const mintAddress = "assetReference" in intent.asset ? intent.asset.assetReference : undefined;
+  if (!mintAddress) return 0n;
+
+  const descriptor = await resolveRecipientDescriptor(
+    api,
+    intent.recipient,
+    mintAddress,
+    tokenProgramOfMint(mint),
+  );
+  if (!descriptor.shouldCreateAsAssociatedTokenAccount) return 0n;
+
+  return BigInt(await api.getMinimumBalanceForRentExemption(getAtaDataLengthForMint(mint)));
+}
+
+/** The mint an intent transfers, when it transfers a token at all. */
+async function getMaybeMintOfIntent(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+): Promise<ParsedOnChainMintWithInfo | undefined> {
+  const mintAddress = "assetReference" in intent.asset ? intent.asset.assetReference : undefined;
+  if (intent.asset.type === "native" || !mintAddress) return undefined;
+
+  const mint = await getMaybeTokenMint(mintAddress, api);
+  return !mint || mint instanceof Error ? undefined : mint;
+}
+
+function tokenProgramOfMint(mint: ParsedOnChainMintWithInfo): SolanaTokenProgram {
+  return mint.onChainAcc.data.program === PARSED_PROGRAMS.SPL_TOKEN_2022
+    ? PARSED_PROGRAMS.SPL_TOKEN_2022
+    : PARSED_PROGRAMS.SPL_TOKEN;
+}
+
+/** The fee a Token-2022 mint levies on transfers; it changes at epoch boundaries. */
+async function getMaybeTransferFee(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  mint: ParsedOnChainMintWithInfo,
+): Promise<TransferFeeCalculated | undefined> {
+  const transferFeeConfigExt = mint.info.extensions?.find(
+    tokenExt => tokenExt.extension === "transferFeeConfig",
+  ) as TransferFeeConfigExt | undefined;
+  if (!transferFeeConfigExt) return undefined;
+
+  const { epoch } = await api.getEpochInfo();
+  return transferFeeForIntent(
+    intent.amount,
+    intent.useAllAmount,
+    transferFeeConfigExt.state,
+    epoch,
+  );
 }
 
 export async function estimateTxFee(
@@ -202,6 +368,9 @@ const createDummyStakeWithdrawTx = (address: string): Transaction => {
   };
 };
 
+// Callers must leave `tokenProgram` at its default: the Token-2022 branch resolves the mint on
+// chain, and this transaction carries a random one. It exists only to be measured, and the fee
+// Solana quotes is per signature, so the instruction variant does not change it anyway.
 const createDummyTokenTransferTx = (
   address: string,
   tokenProgram: SolanaTokenProgram = PARSED_PROGRAMS.SPL_TOKEN,
@@ -347,27 +516,50 @@ async function waitNextBlockhash(api: ChainAPI, currentBlockhash: string) {
   throw new Error("next blockhash timeout");
 }
 
+const TOKEN_AUTHORITY_TYPES = new Set(["token.createATA", "token.approve", "token.revoke"]);
+
+/** The associated token account the sender owns for the intent's mint. */
+async function ownerAssociatedTokenAccount(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+): Promise<string | undefined> {
+  const mint = await getMaybeMintOfIntent(api, intent);
+  const mintAddress = "assetReference" in intent.asset ? intent.asset.assetReference : undefined;
+  if (!mint || !mintAddress) return undefined;
+
+  const ata = await findAssociatedTokenAccountPubkey(
+    intent.sender,
+    mintAddress,
+    tokenProgramOfMint(mint),
+  );
+  return ata.toBase58();
+}
+
+/** Kinds `createDummyTx` can build; the rest are measured as a plain transfer. */
+const MEASURABLE_KINDS = new Set<string>([
+  "transfer",
+  "token.transfer",
+  "token.approve",
+  "token.revoke",
+  "stake.createAccount",
+  "stake.delegate",
+  "stake.undelegate",
+  "stake.withdraw",
+]);
+
 function mapIntentToTxKind(
   intent: TransactionIntent<StringMemo | MemoNotSupported>,
 ): TransactionModel["kind"] {
-  if (isSolanaStakingTransactionIntent(intent)) {
+  // `stake.split` and `token.createATA` have no dummy transaction. Solana prices a transaction per
+  // signature, so measuring them as a plain transfer costs the same answer.
+  if (!MEASURABLE_KINDS.has(intent.type)) {
+    return intent.asset.type === "native" ? "transfer" : "token.transfer";
+  }
+  if (isSolanaStakingTransactionIntent(intent) || intent.type.startsWith("token.")) {
     return intent.type as TransactionModel["kind"];
   }
   if (intent.asset.type !== "native") {
     return "token.transfer";
   }
   return "transfer";
-}
-
-/**
- * Maps the intent asset type to the Solana token program identifier.
- * Token-2022 assets produce a different instruction variant
- * (transferCheckedWithFee) that affects compute-unit consumption.
- */
-function resolveTokenProgramFromAsset(
-  asset: TransactionIntent["asset"],
-): SolanaTokenProgram | undefined {
-  if (asset.type === "native") return undefined;
-  if (asset.type === PARSED_PROGRAMS.SPL_TOKEN_2022) return PARSED_PROGRAMS.SPL_TOKEN_2022;
-  return PARSED_PROGRAMS.SPL_TOKEN;
 }

--- a/libs/coin-modules/coin-solana/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getBalance.ts
@@ -1,12 +1,15 @@
-import type { Balance, Stake, StakeState } from "@ledgerhq/coin-module-framework/api/index";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { PublicKey } from "@solana/web3.js";
+import type { Balance } from "@ledgerhq/coin-module-framework/api/index";
 import type { ChainAPI } from "../network";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import type { ParsedOnChainTokenAccount } from "../network/chain/web3";
+import { getTokenAccountProgramId } from "../helpers/token";
 import type { SolanaTokenProgram } from "../types";
 import {
-  computeFrameworkStakeActions,
   computeUnstakeReserve,
   getStakeAccounts,
+  mapStakeAccountToFrameworkStake,
   type StakeAccount,
 } from "./getStakes";
 
@@ -76,57 +79,54 @@ function mapStakeAccountsToBalances(
   mainAccountAddress: string,
   epoch: number,
 ): Balance[] {
-  return stakeAccounts.map(stakeAccount => {
-    const { account, activation } = stakeAccount;
-    const delegation = account.info.stake?.delegation;
-    const delegateAddress = delegation?.voter.toBase58();
-    const amount = BigInt(account.onChainAcc.account.lamports);
-
-    const stake: Stake = {
-      uid: account.onChainAcc.pubkey.toBase58(),
-      address: account.onChainAcc.pubkey.toBase58(),
-      state: activation.state as StakeState,
-      asset: { type: "native" },
-      amount,
-      actions: computeFrameworkStakeActions(stakeAccount, mainAccountAddress, epoch),
-    };
-
-    if (delegateAddress) {
-      stake.delegate = delegateAddress;
-    }
-    if (delegation) {
-      const deposited = BigInt(delegation.stake.toString());
-      stake.amountDeposited = deposited;
-      stake.amountRewarded = amount > deposited ? amount - deposited : 0n;
-    }
-
-    return {
-      value: amount,
-      asset: { type: "native" as const },
-      stake,
-    };
-  });
+  return stakeAccounts.map(stakeAccount => ({
+    // `value` stays the stake account's full lamports (what the account actually holds); the
+    // delegated principal the framework sums into `stakingResources` lives on `stake.amount`.
+    value: BigInt(stakeAccount.account.onChainAcc.account.lamports),
+    asset: { type: "native" as const },
+    stake: mapStakeAccountToFrameworkStake(stakeAccount, mainAccountAddress, epoch),
+  }));
 }
 
+/**
+ * A wallet can own several token accounts for the same mint, but only the canonical associated
+ * one is reachable: `craftTransaction` derives it from (owner, mint, program) rather than reading
+ * it off the sub-account. Counting the others would report a balance the bridge cannot spend, and
+ * a send-max built on it fails at broadcast.
+ *
+ * This is what the legacy bridge did too — `synchronization.ts:toAssociatedTokenAccount` keeps the
+ * associated account and drops the mint entirely when there is none.
+ */
 function mapTokenAccountsToBalances(
   accounts: ReadonlyArray<ParsedOnChainTokenAccount>,
   tokenProgram: SolanaTokenProgram,
   ownerAddress: string,
 ): Balance[] {
-  const balancesByMint = new Map<string, bigint>();
+  const owner = new PublicKey(ownerAddress);
+  const programId = getTokenAccountProgramId(tokenProgram);
 
-  for (const { account } of accounts) {
-    const { mint, tokenAmount } = account.data.parsed.info;
-    const amount = BigInt(tokenAmount.amount);
-    balancesByMint.set(mint, (balancesByMint.get(mint) ?? 0n) + amount);
-  }
+  return accounts.flatMap(({ pubkey, account }) => {
+    const { mint, tokenAmount, state } = account.data.parsed.info;
+    const associatedAddress = getAssociatedTokenAddressSync(
+      new PublicKey(mint),
+      owner,
+      undefined,
+      programId,
+    );
+    if (!associatedAddress.equals(pubkey)) return [];
 
-  return Array.from(balancesByMint.entries()).map(([mint, value]) => ({
-    value,
-    asset: {
-      type: tokenProgram,
-      assetReference: mint,
-      assetOwner: ownerAddress,
-    },
-  }));
+    const value = BigInt(tokenAmount.amount);
+    return [
+      {
+        value,
+        asset: {
+          type: tokenProgram,
+          assetReference: mint,
+          assetOwner: ownerAddress,
+        },
+        // A frozen token account holds funds that cannot be transferred at all.
+        ...(state === "frozen" ? { locked: value } : {}),
+      },
+    ];
+  });
 }

--- a/libs/coin-modules/coin-solana/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getStakes.ts
@@ -1,10 +1,4 @@
-import type {
-  Cursor,
-  Page,
-  Stake,
-  StakeAction,
-  StakeState,
-} from "@ledgerhq/coin-module-framework/api/types";
+import type { Cursor, Page, Stake, StakeAction } from "@ledgerhq/coin-module-framework/api/types";
 import { isStakeLockUpInForce, withdrawableFromStake } from "../logic";
 import type { ChainAPI } from "../network";
 import { getStakeAccounts, type StakeAccount } from "../network/chain/stake-activation/rpc";
@@ -23,68 +17,114 @@ export async function getStakes(
     api.getEpochInfo(),
   ]);
 
-  const items: Stake[] = stakeAccounts.map(stakeAccount => {
-    const { account, activation } = stakeAccount;
-    const delegation = account.info.stake?.delegation;
-    const delegateAddress = delegation?.voter.toBase58();
-
-    const stake: Stake = {
-      uid: account.onChainAcc.pubkey.toBase58(),
-      address: account.onChainAcc.pubkey.toBase58(),
-      state: activation.state as StakeState,
-      asset: { type: "native" },
-      amount: BigInt(account.onChainAcc.account.lamports),
-      actions: computeFrameworkStakeActions(stakeAccount, address, epoch),
-      details: {
-        activationEpoch: delegation?.activationEpoch.toString(),
-        deactivationEpoch: delegation?.deactivationEpoch.toString(),
-        rentExemptReserve: account.info.meta.rentExemptReserve.toString(),
-        activeStake: activation.active,
-        inactiveStake: activation.inactive,
-      },
-    };
-
-    if (delegateAddress) {
-      stake.delegate = delegateAddress;
-    }
-    if (delegation) {
-      const deposited = BigInt(delegation.stake.toString());
-      stake.amountDeposited = deposited;
-      stake.amountRewarded = stake.amount > deposited ? stake.amount - deposited : 0n;
-    }
-
-    return stake;
-  });
+  const items: Stake[] = stakeAccounts.map(stakeAccount =>
+    mapStakeAccountToFrameworkStake(stakeAccount, address, epoch),
+  );
 
   return { items };
 }
 
-export function computeFrameworkStakeActions(
+/**
+ * Build the framework {@link Stake} for one on-chain stake account.
+ *
+ * Shared by {@link getStakes} and `getBalance` — the generic bridge derives `stakingResources`
+ * from the latter, so the two must not drift.
+ *
+ * `amount` carries the **delegated principal**, not the stake account's lamports: the framework
+ * sums it into `delegatedBalance`/`unbondingBalance` (see `coin-cosmos`'s `toStakes`, which
+ * documents the same contract). The rent-exempt reserve is therefore not reported as a reward,
+ * and a fully deactivated or never-delegated stake contributes 0 — matching the legacy bridge.
+ */
+export function mapStakeAccountToFrameworkStake(
   stakeAccount: StakeAccount,
-  mainAccountAddress: string,
+  mainAccAddress: string,
   epoch: number,
-): StakeAction[] {
+): Stake {
+  const { account, activation } = stakeAccount;
+  const { meta } = account.info;
+  const delegation = account.info.stake?.delegation;
+  const delegateAddress = delegation?.voter.toBase58();
+  const rentExemptReserve = meta.rentExemptReserve.toNumber();
+
+  const { hasStakeAuth, hasWithdrawAuth, withdrawable } = stakeAuthorities(
+    stakeAccount,
+    mainAccAddress,
+    epoch,
+    rentExemptReserve,
+  );
+
+  const delegated =
+    delegation === undefined || activation.state === "inactive"
+      ? 0n
+      : BigInt(delegation.stake.toString());
+
+  const stake: Stake = {
+    uid: account.onChainAcc.pubkey.toBase58(),
+    address: account.onChainAcc.pubkey.toBase58(),
+    state: activation.state,
+    asset: { type: "native" },
+    amount: delegated,
+    amountDeposited: delegated,
+    // Solana compounds rewards into the delegated stake; there is no separately claimable
+    // pending reward (the RPC layer always reports `reward: null`).
+    amountRewarded: 0n,
+    actions: computeFrameworkStakeActions(activation.state, withdrawable),
+    details: {
+      activationEpoch: delegation?.activationEpoch.toString(),
+      deactivationEpoch: delegation?.deactivationEpoch.toString(),
+      activeAmount: activation.active,
+      inactiveAmount: activation.inactive,
+      withdrawableAmount: withdrawable,
+      lockedReserve: rentExemptReserve,
+      canStake: hasStakeAuth,
+      canWithdraw: hasWithdrawAuth,
+    },
+  };
+
+  if (delegateAddress) {
+    stake.delegate = delegateAddress;
+  }
+
+  return stake;
+}
+
+/**
+ * The two authorities and the withdrawable amount, resolved together: `canWithdraw` and
+ * `withdrawable` share the same lockup check, and `canStake` reads the staker authority alongside.
+ */
+function stakeAuthorities(
+  stakeAccount: StakeAccount,
+  mainAccAddress: string,
+  epoch: number,
+  rentExemptReserve: number,
+): { hasStakeAuth: boolean; hasWithdrawAuth: boolean; withdrawable: number } {
   const { account, activation } = stakeAccount;
   const { meta } = account.info;
   const hasWithdrawAuth =
-    meta.authorized.withdrawer.toBase58() === mainAccountAddress &&
-    !isStakeLockUpInForce({
-      lockup: meta.lockup,
-      custodianAddress: mainAccountAddress,
-      epoch,
-    });
-  const withdrawable = hasWithdrawAuth
-    ? withdrawableFromStake({
-        stakeAccBalance: account.onChainAcc.account.lamports,
-        activation,
-        rentExemptReserve: meta.rentExemptReserve.toNumber(),
-      })
-    : 0;
+    meta.authorized.withdrawer.toBase58() === mainAccAddress &&
+    !isStakeLockUpInForce({ lockup: meta.lockup, custodianAddress: mainAccAddress, epoch });
 
+  return {
+    hasStakeAuth: meta.authorized.staker.toBase58() === mainAccAddress,
+    hasWithdrawAuth,
+    withdrawable: hasWithdrawAuth
+      ? withdrawableFromStake({
+          stakeAccBalance: account.onChainAcc.account.lamports,
+          activation,
+          rentExemptReserve,
+        })
+      : 0,
+  };
+}
+
+function computeFrameworkStakeActions(
+  state: SolanaStake["activation"]["state"],
+  withdrawable: number,
+): StakeAction[] {
   const actions: StakeAction[] = [];
   if (withdrawable > 0) actions.push("claim_reward");
 
-  switch (activation.state) {
+  switch (state) {
     case "active":
     case "activating":
       actions.push("undelegate");

--- a/libs/coin-modules/coin-solana/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-solana/src/logic/listOperations.ts
@@ -30,13 +30,41 @@ export async function listOperations(
   }
 
   const rpcLimit = limit ?? 100;
-  const opts: SignaturesForAddressOptions = { limit: rpcLimit };
+  const before = decodeCursor(cursor, address);
+  // The cursor names the streams that still have pages, so only the first call has to discover them.
+  const activeSources = cursor ? Object.keys(before) : await signatureSources(api, address);
 
-  if (cursor) {
-    opts.before = cursor;
+  const perSource = await Promise.all(
+    activeSources.map(async source => ({
+      source,
+      signatures: await api.getSignaturesForAddress(source, {
+        limit: rpcLimit,
+        ...(before[source] ? { before: before[source] } : {}),
+      } satisfies SignaturesForAddressOptions),
+    })),
+  );
+
+  const signatures: ConfirmedSignatureInfo[] = [];
+  const seen = new Set<string>();
+  // A transaction the wallet takes part in belongs to the wallet's stream, whichever stream reaches
+  // it first here. Any other would emit it a second time, on another page.
+  const fromTokenStreamOnly = new Set<string>();
+  const nextCursors: Record<string, string> = {};
+  for (const { source, signatures: sourceSignatures } of perSource) {
+    if (sourceSignatures.length === 0) continue;
+
+    const last = sourceSignatures[sourceSignatures.length - 1];
+    // A stream carries on only while it fills a page and stays above the resume height.
+    if (sourceSignatures.length === rpcLimit && !(minHeight > 0 && last.slot < minHeight)) {
+      nextCursors[source] = last.signature;
+    }
+    for (const signature of sourceSignatures) {
+      if (seen.has(signature.signature)) continue;
+      seen.add(signature.signature);
+      if (source !== address) fromTokenStreamOnly.add(signature.signature);
+      signatures.push(signature);
+    }
   }
-
-  const signatures = await api.getSignaturesForAddress(address, opts);
 
   if (signatures.length === 0) {
     return { items: [], next: undefined };
@@ -53,6 +81,9 @@ export async function listOperations(
 
     if (minHeight > 0 && sig.slot < minHeight) continue;
 
+    // The wallet's own stream owns it, and returns it on a page of its own.
+    if (fromTokenStreamOnly.has(sig.signature) && mentions(tx, address)) continue;
+
     const txMeta = buildTxMeta(sig, tx);
 
     const nativeOps = parseNativeOperations(address, tx, txMeta);
@@ -61,12 +92,52 @@ export async function listOperations(
     items.push(...nativeOps, ...tokenOps);
   }
 
-  const lastSig = signatures[signatures.length - 1];
-  const hasMore = signatures.length === rpcLimit;
-  const reachedMinHeightBoundary = minHeight > 0 && lastSig.slot < minHeight;
-  const next = hasMore && !reachedMinHeightBoundary ? lastSig.signature : undefined;
+  return { items, next: encodeCursor(nextCursors) };
+}
 
-  return { items, next };
+function mentions(tx: ParsedTransactionWithMeta, address: string): boolean {
+  return tx.transaction.message.accountKeys.some(key => key.pubkey.toBase58() === address);
+}
+
+/**
+ * Every signature stream the account shows up in: the wallet, plus each of its token accounts. An
+ * SPL transfer into an existing token account names neither the recipient wallet nor its fee payer,
+ * so the wallet's own history never sees it -- which is why the legacy bridge queried each token
+ * account separately (`synchronization.ts:100`).
+ */
+async function signatureSources(api: ChainAPI, address: string): Promise<string[]> {
+  const [splTokenAccounts, token2022Accounts] = await Promise.all([
+    api.getParsedTokenAccountsByOwner(address).then(res => res.value),
+    api.getParsedToken2022AccountsByOwner(address).then(res => res.value),
+  ]);
+
+  return [
+    address,
+    ...[...splTokenAccounts, ...token2022Accounts].map(({ pubkey }) => pubkey.toBase58()),
+  ];
+}
+
+/**
+ * One `before` signature per stream. The framework only feeds the cursor back, so its shape is ours
+ * to choose; a bare signature is read as the wallet's, so a cursor from before this existed still
+ * resumes rather than restarting the history.
+ */
+function decodeCursor(cursor: string | undefined, address: string): Record<string, string> {
+  if (!cursor) return {};
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // Not one of ours: fall through to the bare-signature reading.
+  }
+  return { [address]: cursor };
+}
+
+function encodeCursor(cursors: Record<string, string>): string | undefined {
+  if (Object.keys(cursors).length === 0) return undefined;
+  return Buffer.from(JSON.stringify(cursors)).toString("base64");
 }
 
 /** JSON-RPC batch responses are not order-guaranteed, so pairing by array position is unsafe. */
@@ -84,6 +155,7 @@ function indexTransactionsBySignature(
 }
 
 type TxMeta = {
+  memo?: string;
   hash: string;
   slot: number;
   blockTime: number;
@@ -97,8 +169,17 @@ type TxMeta = {
  * normalising types (e.g. fee → bigint) so downstream helpers don't depend on RPC shapes.
  * Callers guarantee that `sig.blockTime` and `tx.meta` are non-null before calling.
  */
+/**
+ * The RPC prefixes a memo with its byte length (`[5] hello`). Dropping the matched prefix rather
+ * than slicing by the declared length, which counts bytes where `String` indexes UTF-16 units.
+ */
+export function dropMemoLengthPrefixIfAny(memo: string): string {
+  return memo.replace(/^\[\d+\]\s/, "");
+}
+
 function buildTxMeta(sig: ConfirmedSignatureInfo, tx: ParsedTransactionWithMeta): TxMeta {
   return {
+    ...(sig.memo ? { memo: dropMemoLengthPrefixIfAny(sig.memo) } : {}),
     hash: sig.signature,
     slot: sig.slot,
     blockTime: sig.blockTime!,
@@ -132,7 +213,11 @@ function makeOperation(params: MakeOperationParams): Operation {
     recipients,
     value,
     asset,
-    ...(details ? { details } : {}),
+    // The memo belongs to the whole transaction, so every operation it produces carries it — the
+    // same shape the account details drawer reads (`extra.memo`).
+    ...(details || meta.memo
+      ? { details: { ...details, ...(meta.memo ? { memo: meta.memo } : {}) } }
+      : {}),
     tx: {
       hash: meta.hash,
       block: {
@@ -186,10 +271,28 @@ function parseNativeOperations(
   }
 
   const isFeePayer = accountIndex === 0;
+
+  const accountOpType = detectAccountOperation(tx, isFeePayer);
+  if (accountOpType) {
+    return [
+      makeOperation({
+        address,
+        opType: accountOpType,
+        // The whole delta, fee included: the framework only adds the fee back for transfer and
+        // delegation types, so these carry it themselves -- as they did on the legacy path.
+        value: balanceDelta < 0n ? -balanceDelta : balanceDelta,
+        senders: [],
+        recipients: [],
+        asset: { type: "native" },
+        meta,
+        operationIndex: 0,
+      }),
+    ];
+  }
+
   const { opType, value } = classifyNativeTransfer(balanceDelta, isFeePayer, meta.fee);
 
-  const counterparty = findNativeCounterparty(message.accountKeys, accountIndex, txMeta);
-  const { senders, recipients } = buildParties(opType, address, counterparty);
+  const { senders, recipients } = nativeParties(tx, opType, address, meta.fee);
 
   return [
     makeOperation({
@@ -203,6 +306,38 @@ function parseNativeOperations(
       operationIndex: 0,
     }),
   ];
+}
+
+/**
+ * Opting a token account in or out, freezing or thawing one. Ported from the legacy
+ * `getMainAccOperationTypeFromTx`; without it an ATA creation reads as a plain fee payment.
+ */
+function detectAccountOperation(
+  tx: ParsedTransactionWithMeta,
+  isFeePayer: boolean,
+): string | undefined {
+  const ixs = getParsedInstructions(tx);
+  if (ixs.length !== 1) return undefined;
+
+  const [ix] = ixs;
+  switch (ix.program) {
+    case PARSED_PROGRAMS.SPL_ASSOCIATED_TOKEN_ACCOUNT:
+      // The fee payer is the one funding someone else's account; anyone else is opting in.
+      return ix.type === "associate" ? (isFeePayer ? "OPT_OUT" : "OPT_IN") : undefined;
+    case PARSED_PROGRAMS.SPL_TOKEN:
+    case PARSED_PROGRAMS.SPL_TOKEN_2022:
+      switch (ix.type) {
+        case "closeAccount":
+          return "OPT_OUT";
+        case "freezeAccount":
+          return "FREEZE";
+        case "thawAccount":
+          return "UNFREEZE";
+      }
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -229,43 +364,86 @@ function classifyNativeTransfer(
   return { opType: "NONE", value: 0n };
 }
 
-/**
- * Heuristic counterparty: first account whose lamport balance changed.
- * May be inaccurate for complex multi-account transactions.
- */
-function findNativeCounterparty(
-  accountKeys: ParsedTransactionWithMeta["transaction"]["message"]["accountKeys"],
-  accountIndex: number,
-  txMeta: NonNullable<ParsedTransactionWithMeta["meta"]>,
-): string | undefined {
-  const { preBalances, postBalances } = txMeta;
-  const idx = accountKeys.findIndex(
-    (_k, i) => i !== accountIndex && BigInt(postBalances[i]) - BigInt(preBalances[i]) !== 0n,
-  );
-  return idx >= 0 ? accountKeys[idx].pubkey.toBase58() : undefined;
-}
+type Parties = { senders: string[]; recipients: string[] };
 
-function buildParties(
+/**
+ * Every account the transaction debited or credited, not just the first one -- a batched transfer
+ * pays several recipients, and keeping one silently drops the rest. Ported from the legacy
+ * `getMainSendersRecipients`.
+ */
+function nativeParties(
+  tx: ParsedTransactionWithMeta,
   opType: string,
   address: string,
-  counterparty: string | undefined,
-): { senders: string[]; recipients: string[] } {
-  const otherParty = counterparty ? [counterparty] : [];
+  txFee: bigint,
+): Parties {
+  const txMeta = tx.meta!;
 
-  const isSender = opType === "OUT" || opType === "FEES";
-  const senders = isSender ? [address] : otherParty;
+  // An SPL transfer to an account that already exists shows up on the main account as a fee
+  // payment; the parties worth naming are the token's, not the lamports'.
+  if (opType === "FEES") return tokenParties(tx);
 
-  const recipients = opType === "IN" ? [address] : otherParty;
+  if (opType === "OPT_IN") {
+    const incoming = (txMeta.postTokenBalances ?? []).filter(b => b.owner === address);
+    return {
+      senders: incoming.map(b => b.mint),
+      recipients: incoming.map(
+        b => tx.transaction.message.accountKeys[b.accountIndex]?.pubkey.toBase58() ?? address,
+      ),
+    };
+  }
 
-  return { senders, recipients };
+  if (opType !== "IN" && opType !== "OUT") return { senders: [], recipients: [] };
+
+  const { preBalances, postBalances } = txMeta;
+  return tx.transaction.message.accountKeys.reduce<Parties>(
+    (acc, account, i) => {
+      const delta = BigInt(postBalances[i]) - BigInt(preBalances[i]);
+      if (delta < 0n) {
+        // The fee payer is not a sender when the fee is all it spent.
+        if (i !== 0 || -delta !== txFee) acc.senders.push(account.pubkey.toBase58());
+      } else if (delta > 0n) {
+        acc.recipients.push(account.pubkey.toBase58());
+      }
+      return acc;
+    },
+    { senders: [], recipients: [] },
+  );
+}
+
+/** Same enumeration over token balances: every owner whose token holding moved. */
+function tokenParties(tx: ParsedTransactionWithMeta): Parties {
+  const txMeta = tx.meta!;
+  const { preTokenBalances, postTokenBalances } = txMeta;
+
+  return tx.transaction.message.accountKeys.reduce<Parties>(
+    (acc, account, i) => {
+      const pre = preTokenBalances?.find(b => b.accountIndex === i);
+      const post = postTokenBalances?.find(b => b.accountIndex === i);
+      if (!pre && !post) return acc;
+
+      const delta =
+        BigInt(post?.uiTokenAmount.amount ?? 0) - BigInt(pre?.uiTokenAmount.amount ?? 0);
+      const party = post?.owner ?? account.pubkey.toBase58();
+      if (delta < 0n) acc.senders.push(party);
+      else if (delta > 0n) acc.recipients.push(party);
+      return acc;
+    },
+    { senders: [], recipients: [] },
+  );
 }
 
 type ParsedIx = { program: string; type: string; info: Record<string, unknown> | undefined };
 
+/**
+ * Parsed instructions, memos excluded: the shape checks below count instructions, and a memo is
+ * the user's, not the transaction's intent. Legacy filtered the same way (`parseTxInstructions`).
+ */
 function getParsedInstructions(tx: ParsedTransactionWithMeta): ParsedIx[] {
   const results: ParsedIx[] = [];
   for (const ix of tx.transaction.message.instructions) {
     if (!("parsed" in ix)) continue;
+    if ((ix as { program?: string }).program === PARSED_PROGRAMS.SPL_MEMO) continue;
     const raw = ix as { program?: string; parsed?: unknown };
     if (typeof raw.parsed !== "object" || raw.parsed === null) continue;
     const parsed = raw.parsed as { type?: string; info?: Record<string, unknown> };
@@ -387,17 +565,23 @@ function parseTokenOperations(
   );
   const ops: Operation[] = [];
   let operationIndex = 1;
+  const burned = isBurnTransaction(tx);
+  // Invariant across the loop below: it reads the transaction, never the change.
+  const parties = tokenParties(tx);
+  // Freezing or thawing leaves the balance untouched, so the change carries a zero delta. Legacy
+  // emitted an operation for every transaction reaching the token account, zero delta included --
+  // and with it a `NONE` for each one that merely brushed past. Only these two are worth a row.
+  const frozenOpType = detectTokenAccountState(tx);
 
   for (const [, change] of tokenChanges) {
-    if (change.delta === 0n) continue;
+    if (change.delta === 0n && !frozenOpType) continue;
     const op = buildTokenOperation(
       address,
       change,
-      preTokenBalances,
-      postTokenBalances,
-      accountKeys,
       meta,
       operationIndex,
+      parties,
+      frozenOpType ?? (burned ? "BURN" : undefined),
     );
     ops.push(op);
     operationIndex++;
@@ -409,11 +593,10 @@ function parseTokenOperations(
 function buildTokenOperation(
   address: string,
   change: TokenChange,
-  preTokenBalances: TokenBalance[],
-  postTokenBalances: TokenBalance[],
-  accountKeys: string[],
   meta: TxMeta,
   operationIndex: number,
+  parties: Parties,
+  opTypeOverride?: string,
 ): Operation {
   const { mint, delta, tokenType, owner } = change;
   // Emit the operation against the wallet owner (not the queried address): when
@@ -421,17 +604,12 @@ function buildTokenOperation(
   // assetOwner must still resolve to the wallet, matching a wallet-address query.
   const asset: AssetInfo = { type: tokenType, assetReference: mint, assetOwner: owner };
 
-  const opType = delta > 0n ? "IN" : "OUT";
+  // Burning leaves the account like a send would, but the tokens go nowhere -- legacy typed it
+  // `BURN` (`getTokenAccOperationType`) and the history reads wrong without it.
+  const opType = opTypeOverride ?? (delta > 0n ? "IN" : "OUT");
   const value = delta > 0n ? delta : -delta;
 
-  const counterparty = findTokenCounterparty(
-    owner,
-    mint,
-    preTokenBalances,
-    postTokenBalances,
-    accountKeys,
-  );
-  const { senders, recipients } = buildParties(opType, owner, counterparty);
+  const { senders, recipients } = parties;
 
   return makeOperation({
     address,
@@ -539,26 +717,25 @@ function computeTokenBalanceDeltas(
   return changes;
 }
 
-/**
- * Best-effort counterparty detection for token transfers.
- *
- * Searches both post and pre token balance arrays for another wallet owner
- * of the same mint. Post is checked first because the recipient may not exist
- * in pre when their ATA is created in the same transaction.
- *
- * Falls back to the first different account key when neither array has an
- * owner-populated entry for a counterparty.
- */
-function findTokenCounterparty(
-  ownerAddress: string,
-  mint: string,
-  preTokenBalances: TokenBalance[],
-  postTokenBalances: TokenBalance[],
-  accountKeys: string[],
-): string | undefined {
-  for (const balances of [postTokenBalances, preTokenBalances]) {
-    const entry = balances.find(b => b.owner && b.owner !== ownerAddress && b.mint === mint);
-    if (entry?.owner) return entry.owner;
+/** A lone freeze or thaw: the authority locks or unlocks the account without moving anything. */
+function detectTokenAccountState(tx: ParsedTransactionWithMeta): string | undefined {
+  const ixs = getParsedInstructions(tx);
+  if (ixs.length !== 1) return undefined;
+  const [ix] = ixs;
+  if (ix.program !== PARSED_PROGRAMS.SPL_TOKEN && ix.program !== PARSED_PROGRAMS.SPL_TOKEN_2022) {
+    return undefined;
   }
-  return accountKeys.find(k => k !== ownerAddress);
+  if (ix.type === "freezeAccount") return "FREEZE";
+  return ix.type === "thawAccount" ? "UNFREEZE" : undefined;
+}
+
+/** A lone `burn` instruction: the tokens leave the account without a recipient. */
+function isBurnTransaction(tx: ParsedTransactionWithMeta): boolean {
+  const ixs = getParsedInstructions(tx);
+  if (ixs.length !== 1) return false;
+  const [ix] = ixs;
+  return (
+    (ix.program === PARSED_PROGRAMS.SPL_TOKEN || ix.program === PARSED_PROGRAMS.SPL_TOKEN_2022) &&
+    (ix.type === "burn" || ix.type === "burnChecked")
+  );
 }

--- a/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
@@ -20,12 +20,36 @@ import {
   buildStakeWithdrawInstructions,
   getMaybeMintAccount,
   getMaybeTokenMintProgram,
+  getMaybeTokenMint,
   getMaybeTokenAccount,
   findAssociatedTokenAccountPubkey,
 } from "../../network/chain/web3";
 import type { SolanaTokenProgram, Transaction } from "../../types";
 import { DUMMY_SIGNATURE } from "../../utils";
 import { buildVersionedTransaction, craftTransaction } from "../craftTransaction";
+import BigNumber from "bignumber.js";
+import { getStakeAccounts, type StakeAccount } from "../../network/chain/stake-activation/rpc";
+
+/** The slice `liveWithdrawable` reads; inactive unless told otherwise. */
+function stakeAccountFixture({
+  address,
+  lamports,
+  rentExemptReserve,
+  activation = { state: "inactive", active: 0, activating: 0 },
+}: {
+  address: string;
+  lamports: number;
+  rentExemptReserve: number;
+  activation?: { state: string; active: number; activating: number };
+}): StakeAccount {
+  return {
+    account: {
+      onChainAcc: { pubkey: new PublicKey(address), account: { lamports } },
+      info: { meta: { rentExemptReserve: new BigNumber(rentExemptReserve) } },
+    },
+    activation,
+  } as unknown as StakeAccount;
+}
 
 jest.mock("../../network/chain/web3", () => ({
   ...jest.requireActual("../../network/chain/web3"),
@@ -41,12 +65,18 @@ jest.mock("../../network/chain/web3", () => ({
   getStakeAccountMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(2_282_880),
   getMaybeMintAccount: jest.fn(),
   getMaybeTokenMintProgram: jest.fn(),
+  getMaybeTokenMint: jest.fn(),
   getMaybeTokenAccount: jest.fn(),
   findAssociatedTokenAccountPubkey: jest.fn(),
 }));
 
 jest.mock("../../stakeAccountSeed", () => ({
   createStakeAccountSeed: jest.fn().mockReturnValue("test-seed-123"),
+}));
+
+// No account resolves by default, so the intent's amount stands.
+jest.mock("../../network/chain/stake-activation/rpc", () => ({
+  getStakeAccounts: jest.fn().mockResolvedValue([]),
 }));
 
 const mockedBuildTransferInstructions = jest.mocked(buildTransferInstructions);
@@ -59,6 +89,14 @@ const mockedGetMaybeMintAccount = getMaybeMintAccount as jest.MockedFunction<
   DeepPartialReturn<typeof getMaybeMintAccount>
 >;
 const mockedGetMaybeTokenMintProgram = jest.mocked(getMaybeTokenMintProgram);
+const mockedGetMaybeTokenMint = getMaybeTokenMint as unknown as jest.MockedFunction<
+  DeepPartialReturn<(address: string, api: ChainAPI) => ReturnType<typeof getMaybeTokenMint>>
+>;
+
+/** One read now carries both the parsed mint and the program that owns it. */
+function mintOf(info: Record<string, unknown>, program = "spl-token") {
+  return { info, onChainAcc: { data: { program } } } as never;
+}
 const mockedGetMaybeTokenAccount = getMaybeTokenAccount as jest.MockedFunction<
   DeepPartialReturn<typeof getMaybeTokenAccount>
 >;
@@ -71,6 +109,83 @@ const TEST_BLOCKHASH = "EEbZs6DmDyDjucyYbo3LwVJU7pQYuVopYcYTSEZXskW3";
 // ---------------------------------------------------------------------------
 // craftTransaction
 // ---------------------------------------------------------------------------
+
+const PREBUILT_TX =
+  "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=";
+const PREBUILT_FEE_PAYER = "4iWtrn54zi89sHQv6xHyYwDsrPJvqcSKRJGBLrbErCsx";
+
+// A partner-built transaction (LiFi's swap payload) reaches the coin module through `intent.data`.
+describe("craftTransaction — partner-built transaction", () => {
+  const mockGetLatestBlockhash = jest.fn() as jest.MockedFunction<ChainAPI["getLatestBlockhash"]>;
+  const mockGetFeeForMessage = jest.fn() as jest.MockedFunction<ChainAPI["getFeeForMessage"]>;
+  const api = {
+    getLatestBlockhash: mockGetLatestBlockhash,
+    getFeeForMessage: mockGetFeeForMessage,
+  } as unknown as ChainAPI;
+
+  const intent = {
+    intentType: "transaction",
+    type: "send",
+    sender: PREBUILT_FEE_PAYER,
+    // The intent's recipient and amount are placeholders: the bytes are the transaction.
+    recipient: "",
+    amount: 0n,
+    asset: { type: "native" },
+    data: { type: "solana", raw: PREBUILT_TX },
+  } as unknown as TransactionIntent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetLatestBlockhash.mockResolvedValue({
+      blockhash: TEST_BLOCKHASH,
+      lastValidBlockHeight: 280064048,
+    });
+    mockGetFeeForMessage.mockResolvedValue(5000);
+  });
+
+  it("signs the partner's bytes rather than crafting from the intent", async () => {
+    const result = await craftTransaction(api, intent);
+
+    const deserialized = VersionedTransaction.deserialize(
+      Buffer.from(result.transaction, "base64"),
+    );
+    expect(deserialized.message.staticAccountKeys[0].toBase58()).toBe(PREBUILT_FEE_PAYER);
+    expect(result.details?.estimatedFee).toBe("5000");
+    expect(buildTransferInstructions).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the blockhash while the transaction is still unsigned", async () => {
+    const result = await craftTransaction(api, intent);
+
+    const deserialized = VersionedTransaction.deserialize(
+      Buffer.from(result.transaction, "base64"),
+    );
+    expect(deserialized.message.recentBlockhash).toBe(TEST_BLOCKHASH);
+    expect(result.details?.recentBlockhash).toBe(TEST_BLOCKHASH);
+  });
+
+  it("honours custom fees without asking the chain", async () => {
+    const result = await craftTransaction(api, intent, { value: 12345n });
+
+    expect(result.details?.estimatedFee).toBe("12345");
+    expect(mockGetFeeForMessage).not.toHaveBeenCalled();
+  });
+
+  it("refuses a transaction whose fee payer is not the sender", async () => {
+    await expect(
+      craftTransaction(api, { ...intent, sender: TEST_ADDRESS } as TransactionIntent),
+    ).rejects.toThrow("Sender does not match transaction fee payer");
+  });
+
+  it("refuses bytes it cannot deserialize", async () => {
+    await expect(
+      craftTransaction(api, {
+        ...intent,
+        data: { type: "solana", raw: "bm90LWEtdHJhbnNhY3Rpb24=" },
+      } as unknown as TransactionIntent),
+    ).rejects.toThrow("Invalid or unsupported raw transaction");
+  });
+});
 
 describe("craftTransaction", () => {
   const mockGetLatestBlockhash = jest.fn() as jest.MockedFunction<ChainAPI["getLatestBlockhash"]>;
@@ -267,17 +382,22 @@ describe("craftTransaction", () => {
           ]
         : undefined;
 
-      mockedGetMaybeMintAccount.mockResolvedValue({
-        decimals: mintDecimals,
-        supply: "1000000000",
-        isInitialized: true,
-        mintAuthority: null,
-        freezeAuthority: null,
-        extensions,
-      });
-      mockedGetMaybeTokenMintProgram.mockResolvedValue(tokenProgram);
-      mockedGetMaybeTokenAccount.mockResolvedValue(
-        recipientAtaExists ? { mint: CWIF_MINT } : undefined,
+      mockedGetMaybeTokenMint.mockResolvedValue(
+        mintOf(
+          {
+            decimals: mintDecimals,
+            supply: "1000000000",
+            isInitialized: true,
+            mintAuthority: null,
+            freezeAuthority: null,
+            extensions,
+          },
+          tokenProgram,
+        ),
+      );
+      // The recipient here is a wallet address, so only its derived associated account resolves.
+      mockedGetMaybeTokenAccount.mockImplementation(async address =>
+        address === TEST_RECIPIENT || !recipientAtaExists ? undefined : { mint: CWIF_MINT },
       );
       mockedFindAssociatedTokenAccountPubkey.mockResolvedValue(SENDER_ATA);
       mockedBuildTokenTransferInstructions.mockResolvedValue([]);
@@ -909,16 +1029,22 @@ describe("craftTransaction – staking", () => {
   });
 
   describe("stake.delegate", () => {
-    it("should craft a delegate command using valAddress and recipient", async () => {
+    // `delegateTransaction()` puts the validator on `recipient` and the stake account in the memo.
+    it("should craft a delegate command from the memo and the validator", async () => {
       await craftTransaction(api, {
         intentType: "staking",
         type: "stake.delegate",
         sender: TEST_ADDRESS,
-        recipient: "StakeAccXYZ111111111111111111111111111111111",
+        recipient: TEST_RECIPIENT,
         valAddress: TEST_RECIPIENT,
+        memo: {
+          type: "string",
+          kind: "STAKE_ACCOUNT",
+          value: "StakeAccXYZ111111111111111111111111111111111",
+        },
         amount: 0n,
         asset: { type: "native" },
-      } as StakingTransactionIntent);
+      } as unknown as StakingTransactionIntent);
 
       expect(mockedBuildStakeDelegateInstructions).toHaveBeenCalledWith(
         api,
@@ -931,18 +1057,20 @@ describe("craftTransaction – staking", () => {
       );
     });
 
-    it("should throw when no stake account address is provided via recipient", async () => {
+    // The framework always sets a memo; `{ type: "none" }` is how it says there is none.
+    it("should throw when the intent carries no stake account memo", async () => {
       await expect(
         craftTransaction(api, {
           intentType: "staking",
           type: "stake.delegate",
           sender: TEST_ADDRESS,
-          recipient: "",
+          recipient: TEST_RECIPIENT,
           valAddress: TEST_RECIPIENT,
+          memo: { type: "none" },
           amount: 0n,
           asset: { type: "native" },
-        } as StakingTransactionIntent),
-      ).rejects.toThrow("stake.delegate requires a stake account address (via recipient)");
+        } as unknown as StakingTransactionIntent),
+      ).rejects.toThrow("stake.delegate requires a stake account address (via the memo)");
     });
   });
 
@@ -990,6 +1118,56 @@ describe("craftTransaction – staking", () => {
         }),
       );
     });
+
+    // Observed on mainnet: the stale figure left 4_507 lamports behind, under the reserve.
+    it("empties an inactive stake account whose lamports grew since the last sync", async () => {
+      jest.mocked(getStakeAccounts).mockResolvedValueOnce([
+        stakeAccountFixture({
+          address: "StakeAccAddr1111111111111111111111111111111",
+          lamports: 24_552_851,
+          rentExemptReserve: 2_282_880,
+        }),
+      ]);
+
+      await craftTransaction(api, {
+        intentType: "transaction",
+        type: "stake.withdraw",
+        sender: TEST_ADDRESS,
+        recipient: "StakeAccAddr1111111111111111111111111111111",
+        amount: 24_548_344n,
+        asset: { type: "native" },
+      } as StakingTransactionIntent);
+
+      expect(mockedBuildStakeWithdrawInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({ amount: 24_552_851 }),
+      );
+    });
+
+    it("withdraws only the excess of an active stake account", async () => {
+      jest.mocked(getStakeAccounts).mockResolvedValueOnce([
+        stakeAccountFixture({
+          address: "StakeAccAddr1111111111111111111111111111111",
+          lamports: 24_552_851,
+          rentExemptReserve: 2_282_880,
+          activation: { state: "active", active: 20_000_000, activating: 0 },
+        }),
+      ]);
+
+      await craftTransaction(api, {
+        intentType: "transaction",
+        type: "stake.withdraw",
+        sender: TEST_ADDRESS,
+        recipient: "StakeAccAddr1111111111111111111111111111111",
+        amount: 24_552_851n,
+        asset: { type: "native" },
+      } as StakingTransactionIntent);
+
+      expect(mockedBuildStakeWithdrawInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({ amount: 24_552_851 - 2_282_880 - 20_000_000 }),
+      );
+    });
   });
 });
 
@@ -1014,8 +1192,7 @@ describe("craftTransaction – token edge cases", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("should throw when getMaybeMintAccount returns an Error", async () => {
-    mockedGetMaybeMintAccount.mockResolvedValue(new Error("network failure"));
-    mockedGetMaybeTokenMintProgram.mockResolvedValue("spl-token");
+    mockedGetMaybeTokenMint.mockResolvedValue(new Error("network failure"));
 
     await expect(
       craftTransaction(api, {
@@ -1030,8 +1207,7 @@ describe("craftTransaction – token edge cases", () => {
   });
 
   it("should throw when getMaybeMintAccount returns undefined", async () => {
-    mockedGetMaybeMintAccount.mockResolvedValue(undefined);
-    mockedGetMaybeTokenMintProgram.mockResolvedValue("spl-token");
+    mockedGetMaybeTokenMint.mockResolvedValue(undefined);
 
     await expect(
       craftTransaction(api, {
@@ -1045,6 +1221,40 @@ describe("craftTransaction – token edge cases", () => {
     ).rejects.toThrow("Cannot resolve mint account");
   });
 
+  it("should send to a token account given as the recipient, without deriving one", async () => {
+    const RECIPIENT_ATA = "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T";
+    mockedGetMaybeTokenMint.mockResolvedValue(
+      mintOf({ decimals: 6, supply: "1000", isInitialized: true }),
+    );
+    mockedGetMaybeTokenAccount.mockResolvedValue({
+      mint: "SomeMint11111111111111111111111111111111111",
+      owner: new PublicKey(TEST_RECIPIENT),
+    });
+    mockedFindAssociatedTokenAccountPubkey.mockResolvedValue(new PublicKey(TEST_ADDRESS));
+    mockedBuildTokenTransferInstructions.mockResolvedValue([]);
+
+    await craftTransaction(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: RECIPIENT_ATA,
+      amount: 1000n,
+      asset: { type: "spl-token", assetReference: "SomeMint11111111111111111111111111111111111" },
+    });
+
+    expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      api,
+      expect.objectContaining({
+        recipientDescriptor: {
+          walletAddress: TEST_RECIPIENT,
+          tokenAccAddress: RECIPIENT_ATA,
+          shouldCreateAsAssociatedTokenAccount: false,
+          userInputType: "ata",
+        },
+      }),
+    );
+  });
+
   it("should fallback to spl-token when getMaybeTokenMintProgram returns an Error", async () => {
     mockedGetMaybeMintAccount.mockResolvedValue({
       decimals: 6,
@@ -1052,7 +1262,9 @@ describe("craftTransaction – token edge cases", () => {
       isInitialized: true,
     });
     mockedGetMaybeTokenMintProgram.mockResolvedValue(new Error("not found"));
-    mockedGetMaybeTokenAccount.mockResolvedValue({ mint: "x" });
+    mockedGetMaybeTokenAccount.mockImplementation(async address =>
+      address === TEST_RECIPIENT ? undefined : { mint: "x" },
+    );
     mockedFindAssociatedTokenAccountPubkey.mockResolvedValue(new PublicKey(TEST_RECIPIENT));
     mockedBuildTokenTransferInstructions.mockResolvedValue([]);
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
@@ -20,6 +20,31 @@ const { buildVersionedTransaction } = jest.requireMock("../craftTransaction");
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
 const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
 
+/** The on-chain mint account `getMaybeTokenMint` parses to resolve the token program. */
+function mintAccountInfo(program: string, extensions?: unknown[]) {
+  return {
+    data: {
+      parsed: {
+        type: "mint",
+        info: {
+          decimals: 6,
+          freezeAuthority: null,
+          isInitialized: true,
+          mintAuthority: null,
+          supply: "1000000000000",
+          ...(extensions ? { extensions } : {}),
+        },
+      },
+      program,
+      space: 82,
+    },
+    executable: false,
+    lamports: 1461600,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 0,
+  };
+}
+
 function createMockApi(feeResponses: (number | null)[] = [5000]): ChainAPI {
   let callIdx = 0;
   return {
@@ -35,6 +60,10 @@ function createMockApi(feeResponses: (number | null)[] = [5000]): ChainAPI {
       blockhash: "newBlockhash",
       lastValidBlockHeight: 100,
     }),
+    getAccountInfo: jest.fn().mockResolvedValue(null),
+    getEpochInfo: jest.fn().mockResolvedValue({ epoch: 0 }),
+    // Zero by default so the cases below measure the network fee alone; the ATA-rent case sets it.
+    getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(0),
   } as unknown as ChainAPI;
 }
 
@@ -85,6 +114,7 @@ describe("estimateFees", () => {
 
   it("should use spl-token program for standard SPL token intents", async () => {
     const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(mintAccountInfo("spl-token"));
     setupBuildMock();
 
     await estimateFees(api, {
@@ -102,8 +132,11 @@ describe("estimateFees", () => {
     expect(command.extensions).toBeUndefined();
   });
 
-  it("should use spl-token-2022 program and include dummy extensions for Token-2022 intents", async () => {
+  // The transaction measured here is a dummy carrying a random mint, so it stays on the spl-token
+  // instruction whatever the asset is -- the Token-2022 builder would resolve that mint on chain.
+  it("should measure a Token-2022 intent with the spl-token dummy transaction", async () => {
     const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(mintAccountInfo("spl-token-2022"));
     setupBuildMock();
 
     await estimateFees(api, {
@@ -112,21 +145,161 @@ describe("estimateFees", () => {
       sender: TEST_ADDRESS,
       recipient: TEST_RECIPIENT,
       amount: 1000000n,
-      asset: { type: "spl-token-2022", assetReference: "SomeMintAddress" },
+      asset: { type: "spl", assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
     } as TransactionIntent);
 
-    const tx = buildVersionedTransaction.mock.calls[0][1];
-    const command = tx.model.commandDescriptor.command;
-    expect(command.tokenProgram).toBe("spl-token-2022");
-    expect(command.extensions).not.toBeUndefined();
-    expect(command.extensions.transferFee).toEqual({
-      feePercent: 0,
-      maxTransferFee: 0,
-      transferFee: 0,
-      feeBps: 0,
-      transferAmountIncludingFee: 0,
-      transferAmountExcludingFee: 0,
-    });
+    const command = buildVersionedTransaction.mock.calls[0][1].model.commandDescriptor.command;
+    expect(command.tokenProgram).toBe("spl-token");
+    expect(command.extensions).toBeUndefined();
+  });
+
+  it("computes the transfer fee of a Token-2022 mint that levies one", async () => {
+    const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(
+      mintAccountInfo("spl-token-2022", [
+        {
+          extension: "transferFeeConfig",
+          state: {
+            newerTransferFee: { epoch: 0, maximumFee: 1000000, transferFeeBasisPoints: 100 },
+            olderTransferFee: { epoch: 0, maximumFee: 1000000, transferFeeBasisPoints: 100 },
+          },
+        },
+      ]),
+    );
+    (api.getEpochInfo as jest.Mock).mockResolvedValue({ epoch: 10 });
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "spl", assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+    } as TransactionIntent);
+
+    expect(result.parameters?.transferFee).toMatchObject({ feeBps: 100, maxTransferFee: 1000000 });
+    expect((result.parameters?.transferFee as { transferFee: number }).transferFee).toBeGreaterThan(
+      0,
+    );
+  });
+
+  // A partner-built transaction is measured as-is; nothing is derived from the intent.
+  it("measures a partner-built transaction rather than a dummy one", async () => {
+    const api = createMockApi([7000]);
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: "",
+      amount: 0n,
+      asset: { type: "native" },
+      data: {
+        type: "solana",
+        raw: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=",
+      },
+    } as unknown as TransactionIntent);
+
+    expect(result).toEqual({ value: 7000n });
+    expect(buildVersionedTransaction).not.toHaveBeenCalled();
+  });
+
+  // The rent is not a network fee, but it leaves the sender's account, and legacy reported it here.
+  it("adds the recipient's ATA rent when the transfer has to create it", async () => {
+    const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(mintAccountInfo("spl-token"));
+    (api.getMinimumBalanceForRentExemption as jest.Mock).mockResolvedValue(2_039_280);
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "spl", assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+    } as TransactionIntent);
+
+    expect(result.value).toBe(5000n + 2_039_280n);
+  });
+
+  // Opening a token account costs its rent, an order of magnitude over the fee. The legacy bridge
+  // charged it here; leaving it out lets a transaction the chain rejects pass validation.
+  it("charges the rent of the token account it opens", async () => {
+    const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(mintAccountInfo("spl-token"));
+    (api.getMinimumBalanceForRentExemption as jest.Mock).mockResolvedValue(2_039_280);
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "transaction",
+      type: "token.createATA",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 0n,
+      asset: {
+        type: "spl",
+        assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        assetOwner: TEST_ADDRESS,
+      },
+    } as unknown as TransactionIntent);
+
+    expect(result.value).toBe(5000n + 2_039_280n);
+  });
+
+  // Approving or revoking opens nothing, so neither pays a rent.
+  it("charges no rent to approve", async () => {
+    const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(mintAccountInfo("spl-token"));
+    (api.getMinimumBalanceForRentExemption as jest.Mock).mockResolvedValue(2_039_280);
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "transaction",
+      type: "token.approve",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000n,
+      asset: {
+        type: "spl",
+        assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        assetOwner: TEST_ADDRESS,
+      },
+    } as unknown as TransactionIntent);
+
+    expect(result.value).toBe(5000n);
+  });
+
+  // A Token-2022 ATA always carries ImmutableOwner, and a transfer-fee mint adds one more account
+  // extension, so its rent is sized from the mint rather than from the classic 165-byte account.
+  it("sizes the ATA rent from the mint's extensions", async () => {
+    const api = createMockApi([5000]);
+    (api.getAccountInfo as jest.Mock).mockResolvedValue(
+      mintAccountInfo("spl-token-2022", [
+        {
+          extension: "transferFeeConfig",
+          state: {
+            newerTransferFee: { epoch: 0, maximumFee: 0, transferFeeBasisPoints: 0 },
+            olderTransferFee: { epoch: 0, maximumFee: 0, transferFeeBasisPoints: 0 },
+          },
+        },
+      ]),
+    );
+    setupBuildMock();
+
+    await estimateFees(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "spl", assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+    } as TransactionIntent);
+
+    const [dataLength] = (api.getMinimumBalanceForRentExemption as jest.Mock).mock.calls[0];
+    expect(dataLength).toBeGreaterThan(165);
   });
 
   it("should propagate errors from estimateTxFee", async () => {
@@ -158,6 +331,67 @@ describe("estimateFees", () => {
       asset: { type: "native" },
     } as StakingTransactionIntent);
     expect(result.value).toBe(5000n);
+  });
+
+  // Send-max reads `reserve`: without it the whole balance is delegated and a first-time staker is
+  // left with nothing to pay the undelegate and the withdraw with. Legacy held the same back.
+  it("holds back the future undelegate and withdraw on a creation", async () => {
+    const api = createMockApi([5000]);
+    (api.getMinimumBalanceForRentExemption as jest.Mock).mockResolvedValue(2_282_880);
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "staking",
+      type: "stake.createAccount",
+      mode: "delegate",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      valAddress: TEST_RECIPIENT,
+      amount: 0n,
+      useAllAmount: true,
+      asset: { type: "native" },
+    } as StakingTransactionIntent);
+
+    // The fee, plus the two transactions unstaking will take. The rent is not held back -- it rides
+    // inside the amount, which the craft splits off.
+    expect(result.parameters?.reserve).toBe(5000n + 10000n);
+    expect(result.parameters?.stakeAccountRent).toBe(2_282_880n);
+  });
+
+  it("holds nothing back on a split, which opens no new reserve", async () => {
+    const api = createMockApi([5000]);
+    setupBuildMock();
+
+    const result = await estimateFees(api, {
+      intentType: "staking",
+      type: "stake.split",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000n,
+      asset: { type: "native" },
+    } as unknown as StakingTransactionIntent);
+
+    expect(result.parameters?.reserve).toBeUndefined();
+  });
+
+  // The device names the stake account a split opens, so the wallet has to derive the same address
+  // to show the same row. A split is priced as a plain transfer, so it never reaches `kind`.
+  it("resolves the stake account a split opens", async () => {
+    const api = createMockApi([5000]);
+
+    const result = await estimateFees(api, {
+      intentType: "staking",
+      type: "stake.split",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "native" },
+      data: { type: "solana", stakeAccountSeed: "seed-abc" },
+    } as unknown as StakingTransactionIntent);
+
+    expect(result.parameters?.stakeAccountAddress).toEqual(expect.any(String));
+    // A split moves lamports that already cover the rent; only a creation pays it.
+    expect(result.parameters?.stakeAccountRent).toBeUndefined();
   });
 });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
@@ -91,7 +91,8 @@ describe("getBalance (MSW integration)", () => {
 
     function splTokenAccount(mint: string, amount: string) {
       return {
-        pubkey: new PublicKey("AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ"),
+        // The owner's associated token account for this mint — the only one the bridge spends.
+        pubkey: new PublicKey("8fyZ7QVMYNQRv1DMVf3aka8wQx1GR59Jc3MHYp9Sz7pE"),
         account: {
           data: {
             parsed: {
@@ -259,7 +260,8 @@ describe("getBalance (MSW integration)", () => {
 
     function token2022Account(mint: string, amount: string) {
       return {
-        pubkey: new PublicKey("FvbvvXMY4Rf1AtGG7UHJUesjt8FFgPnPy6o83Dna9mXK"),
+        // The owner's associated token account for this mint — the only one the bridge spends.
+        pubkey: new PublicKey("7Pvn2JVBYY5SbxHTcZnzsGt677xkT8GsQ4oaN7QoVZx8"),
         account: {
           data: {
             parsed: {

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
@@ -1,22 +1,24 @@
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { PublicKey } from "@solana/web3.js";
 import type { DeepPartialReturn } from "@ledgerhq/coin-module-framework/test/utils";
+import { getTokenAccountProgramId } from "../../helpers/token";
+import { PARSED_PROGRAMS } from "../../network/chain/program/constants";
+import type { SolanaTokenProgram } from "../../types";
 import type { ChainAPI } from "../../network";
 import type { StakeAccount } from "../../network/chain/stake-activation/rpc";
 import { getBalance } from "../getBalance";
-import {
-  computeFrameworkStakeActions,
-  computeUnstakeReserve,
-  getStakeAccounts,
-} from "../getStakes";
+import { computeUnstakeReserve, getStakeAccounts } from "../getStakes";
 
+// Only the network-bound helpers are stubbed: `mapStakeAccountToFrameworkStake` is the code
+// under test here, so it runs for real.
 jest.mock("../getStakes", () => ({
+  ...jest.requireActual("../getStakes"),
   getStakeAccounts: jest.fn().mockResolvedValue([]),
   computeUnstakeReserve: jest.fn().mockResolvedValue(0),
-  computeFrameworkStakeActions: jest.fn().mockReturnValue([]),
 }));
 
 const mockGetStakeAccounts = jest.mocked(getStakeAccounts);
 const mockComputeUnstakeReserve = jest.mocked(computeUnstakeReserve);
-const mockComputeFrameworkStakeActions = jest.mocked(computeFrameworkStakeActions);
 
 const DEFAULT_RENT_EXEMPT_RESERVE = 2_282_880;
 
@@ -28,13 +30,17 @@ function makeStakeAccountStub(
     voter?: string;
     stake?: string;
     rentExemptReserve?: number;
+    staker?: string;
+    withdrawer?: string;
   },
 ) {
   const pubkey = options?.pubkey ?? "StakeAddr1111111111111111111111111111111111";
   const state = options?.state ?? "active";
   const voter = options?.voter ?? "Validator111111111111111111111111111111111111";
   const rentExemptReserve = options?.rentExemptReserve ?? DEFAULT_RENT_EXEMPT_RESERVE;
-  // On Solana delegation.stake includes the rent-exempt reserve (full amount deposited).
+  // On chain `delegation.stake` is the delegated principal and excludes the rent-exempt reserve.
+  // The default keeps it equal to the lamports for brevity; tests that care about the difference
+  // pass an explicit `stake`.
   const delegatedStake = options?.stake ?? String(lamports);
   return {
     account: {
@@ -43,7 +49,21 @@ function makeStakeAccountStub(
         account: { lamports },
       },
       info: {
-        meta: { rentExemptReserve: { toString: () => String(rentExemptReserve) } },
+        meta: {
+          rentExemptReserve: {
+            toString: () => String(rentExemptReserve),
+            toNumber: () => rentExemptReserve,
+          },
+          authorized: {
+            staker: { toBase58: () => options?.staker ?? TEST_ADDRESS },
+            withdrawer: { toBase58: () => options?.withdrawer ?? TEST_ADDRESS },
+          },
+          lockup: {
+            custodian: { toBase58: () => "Custodian11111111111111111111111111111111111" },
+            unixTimestamp: 0,
+            epoch: 0,
+          },
+        },
         stake: {
           delegation: {
             voter: { toBase58: () => voter },
@@ -59,6 +79,55 @@ function makeStakeAccountStub(
 }
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
+// A token account the wallet owns that is not the associated one for its mint.
+const OTHER_TOKEN_ACCOUNT = "35npQR1u7vycmAjRS8H2ozoY7uTXPeZqUCJAm34Kidv1";
+
+/**
+ * A parsed on-chain token account as the RPC returns it. Complete rather than minimal: the
+ * balance mapper validates it (superstruct) to read `state` and `extensions`.
+ */
+function parsedTokenAccount(
+  mint: string,
+  amount: string,
+  options?: {
+    state?: string;
+    extensions?: unknown[];
+    tokenProgram?: SolanaTokenProgram;
+    /** Defaults to the owner's associated token account — the only one the bridge can spend. */
+    pubkey?: PublicKey;
+  },
+) {
+  const tokenProgram = options?.tokenProgram ?? PARSED_PROGRAMS.SPL_TOKEN;
+  return {
+    pubkey:
+      options?.pubkey ??
+      getAssociatedTokenAddressSync(
+        new PublicKey(mint),
+        new PublicKey(TEST_ADDRESS),
+        undefined,
+        getTokenAccountProgramId(tokenProgram),
+      ),
+    account: {
+      data: {
+        parsed: {
+          info: {
+            mint,
+            owner: TEST_ADDRESS,
+            state: options?.state ?? "initialized",
+            isNative: false,
+            tokenAmount: {
+              amount,
+              decimals: 6,
+              uiAmount: Number(amount) / 1e6,
+              uiAmountString: String(Number(amount) / 1e6),
+            },
+            ...(options?.extensions ? { extensions: options.extensions } : {}),
+          },
+        },
+      },
+    },
+  };
+}
 
 describe("getBalance", () => {
   const mockGetBalance = jest.fn() as jest.MockedFunction<ChainAPI["getBalance"]>;
@@ -112,20 +181,7 @@ describe("getBalance", () => {
     mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
     const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
     mockGetParsedTokenAccountsByOwner.mockResolvedValue({
-      value: [
-        {
-          account: {
-            data: {
-              parsed: {
-                info: {
-                  mint: USDC_MINT,
-                  tokenAmount: { amount: "5000000" },
-                },
-              },
-            },
-          },
-        },
-      ],
+      value: [parsedTokenAccount(USDC_MINT, "5000000")],
     });
 
     const result = await getBalance(api, TEST_ADDRESS);
@@ -145,18 +201,9 @@ describe("getBalance", () => {
     mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
     mockGetParsedToken2022AccountsByOwner.mockResolvedValue({
       value: [
-        {
-          account: {
-            data: {
-              parsed: {
-                info: {
-                  mint: PYUSD_MINT,
-                  tokenAmount: { amount: "10000000" },
-                },
-              },
-            },
-          },
-        },
+        parsedTokenAccount(PYUSD_MINT, "10000000", {
+          tokenProgram: PARSED_PROGRAMS.SPL_TOKEN_2022,
+        }),
       ],
     });
 
@@ -170,32 +217,65 @@ describe("getBalance", () => {
     expect(mockGetParsedToken2022AccountsByOwner).toHaveBeenCalledWith(TEST_ADDRESS);
   });
 
-  it("should aggregate multiple token accounts for the same mint", async () => {
+  it("surfaces a frozen token account so the bridge can block spending", async () => {
+    mockGetBalance.mockResolvedValue(1_000_000_000);
+    mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    mockGetParsedTokenAccountsByOwner.mockResolvedValue({
+      value: [parsedTokenAccount(USDC_MINT, "5000000", { state: "frozen" })],
+    });
+
+    const result = await getBalance(api, TEST_ADDRESS);
+
+    // locked === value, so buildTokenAccount derives spendableBalance 0 and the send is blocked
+    expect(result[1].locked).toBe(5_000_000n);
+    expect(result[1].value).toBe(5_000_000n);
+  });
+
+  // `craftTransaction` derives the associated token account rather than reading it off the
+  // sub-account, so anything held elsewhere is unspendable — counting it would report a balance
+  // the bridge cannot honour. The legacy bridge dropped those accounts too.
+  it("ignores token accounts that are not the owner's associated one", async () => {
     mockGetBalance.mockResolvedValue(1_000_000_000);
     mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
     const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
     mockGetParsedTokenAccountsByOwner.mockResolvedValue({
       value: [
-        {
-          account: {
-            data: { parsed: { info: { mint: USDC_MINT, tokenAmount: { amount: "3000000" } } } },
-          },
-        },
-        {
-          account: {
-            data: { parsed: { info: { mint: USDC_MINT, tokenAmount: { amount: "7000000" } } } },
-          },
-        },
+        parsedTokenAccount(USDC_MINT, "7000000"),
+        parsedTokenAccount(USDC_MINT, "3000000", { pubkey: new PublicKey(OTHER_TOKEN_ACCOUNT) }),
       ],
     });
 
     const result = await getBalance(api, TEST_ADDRESS);
 
     expect(result).toHaveLength(2);
-    expect(result[1]).toEqual({
-      value: 10_000_000n,
-      asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
+    expect(result[1].value).toBe(7_000_000n);
+  });
+
+  it("reports no balance for a mint held only outside the associated token account", async () => {
+    mockGetBalance.mockResolvedValue(1_000_000_000);
+    mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    mockGetParsedTokenAccountsByOwner.mockResolvedValue({
+      value: [
+        parsedTokenAccount(USDC_MINT, "3000000", { pubkey: new PublicKey(OTHER_TOKEN_ACCOUNT) }),
+      ],
     });
+
+    expect(await getBalance(api, TEST_ADDRESS)).toHaveLength(1);
+  });
+
+  it("does not lock a healthy token account", async () => {
+    mockGetBalance.mockResolvedValue(1_000_000_000);
+    mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    mockGetParsedTokenAccountsByOwner.mockResolvedValue({
+      value: [parsedTokenAccount(USDC_MINT, "5000000")],
+    });
+
+    const result = await getBalance(api, TEST_ADDRESS);
+
+    expect(result[1].locked).toBeUndefined();
   });
 
   it("should propagate errors from getBalance", async () => {
@@ -254,7 +334,7 @@ describe("getBalance", () => {
       expect(stake.amount).toBe((stake.amountDeposited ?? 0n) + (stake.amountRewarded ?? 0n));
     });
 
-    it("should compute amountRewarded as the delta between lamports and delegated stake", async () => {
+    it("reports the delegated principal as amount, excluding the rent-exempt reserve", async () => {
       mockGetBalance.mockResolvedValue(1_000_000_000);
       mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
       mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
@@ -268,10 +348,15 @@ describe("getBalance", () => {
       const result = await getBalance(api, TEST_ADDRESS);
 
       const stake = result[1].stake!;
-      expect(stake.amount).toBe(BigInt(lamports));
+      // The framework sums `amount` into delegatedBalance, so it must be the delegated
+      // principal — not the account's lamports, which also cover the rent-exempt reserve.
+      expect(stake.amount).toBe(BigInt(delegated));
       expect(stake.amountDeposited).toBe(BigInt(delegated));
-      expect(stake.amountRewarded).toBe(BigInt(lamports - delegated));
+      // Solana compounds rewards into the delegation; nothing is separately claimable.
+      expect(stake.amountRewarded).toBe(0n);
       expect(stake.amount).toBe((stake.amountDeposited ?? 0n) + (stake.amountRewarded ?? 0n));
+      // `value` still carries what the stake account actually holds.
+      expect(result[1].value).toBe(BigInt(lamports));
     });
 
     it("should include unstakeReserve in locked", async () => {
@@ -311,24 +396,46 @@ describe("getBalance", () => {
       });
     });
 
-    it("populates stake.actions from computeFrameworkStakeActions", async () => {
+    it("populates stake.actions and the position details the generic bridge reads", async () => {
       mockGetBalance.mockResolvedValue(1_000_000_000);
       mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
       mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
-      const stakeAccount = makeStakeAccountStub(2_000_000_000);
+      const lamports = 2_000_000_000;
+      const active = lamports - DEFAULT_RENT_EXEMPT_RESERVE - 5_000_000;
+      const stakeAccount = makeStakeAccountStub(lamports, { stake: String(active) });
+      stakeAccount.activation.active = active;
       mockGetStakeAccounts.mockResolvedValue([stakeAccount] as StakeAccount[]);
-      mockComputeFrameworkStakeActions.mockReturnValueOnce(["claim_reward", "undelegate"]);
 
       const result = await getBalance(api, TEST_ADDRESS);
 
-      expect(result[1]).toMatchObject({
-        stake: { actions: ["claim_reward", "undelegate"] },
+      const stake = result[1].stake!;
+      // active stake with withdrawable lamports on top (e.g. Jito MEV rewards)
+      expect(stake.actions).toEqual(["claim_reward", "undelegate"]);
+      expect(stake.details).toMatchObject({
+        activeAmount: active,
+        inactiveAmount: 0,
+        withdrawableAmount: 5_000_000,
+        lockedReserve: DEFAULT_RENT_EXEMPT_RESERVE,
+        canStake: true,
+        canWithdraw: true,
       });
-      expect(mockComputeFrameworkStakeActions).toHaveBeenCalledWith(
-        stakeAccount,
-        TEST_ADDRESS,
-        400,
-      );
+    });
+
+    it("reports a fully deactivated stake as inactive, with nothing delegated", async () => {
+      mockGetBalance.mockResolvedValue(1_000_000_000);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      const stakeAccount = makeStakeAccountStub(2_000_000_000, { state: "inactive" });
+      stakeAccount.activation.active = 0;
+      stakeAccount.activation.inactive = 2_000_000_000;
+      mockGetStakeAccounts.mockResolvedValue([stakeAccount] as StakeAccount[]);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      const stake = result[1].stake!;
+      expect(stake.state).toBe("inactive");
+      expect(stake.amount).toBe(0n);
+      expect(stake.actions).toEqual(["claim_reward", "delegate"]);
     });
 
     it("should sum lamports across multiple stake accounts", async () => {

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.integ.test.ts
@@ -30,7 +30,9 @@ describe("getStakes (integration)", () => {
         expect(typeof stake.amountDeposited).toBe("bigint");
       }
       expect(stake.details).not.toBeUndefined();
-      expect(typeof stake.details?.rentExemptReserve).toBe("string");
+      expect(typeof stake.details?.lockedReserve).toBe("number");
+      expect(typeof stake.details?.canStake).toBe("boolean");
+      expect(typeof stake.details?.canWithdraw).toBe("boolean");
 
       for (const action of stake.actions) {
         expect(["delegate", "redelegate", "undelegate", "claim_reward"]).toContain(action);

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.test.ts
@@ -149,9 +149,9 @@ describe("getStakes (MSW integration)", () => {
     expect(stake.delegate).toBe(VOTER_ADDRESS);
     expect(stake.state).toBe("active");
     expect(stake.asset).toEqual({ type: "native" });
-    expect(stake.amount).toBe(BigInt(5_000_000_000));
+    expect(stake.amount).toBe(BigInt(4_997_717_120));
     expect(stake.amountDeposited).toBe(BigInt(4_997_717_120));
-    expect(stake.details?.rentExemptReserve).toBe("2282880");
+    expect(stake.details?.lockedReserve).toBe(2_282_880);
   });
 
   it("should return an inactive stake when deactivation epoch has passed", async () => {
@@ -181,6 +181,7 @@ describe("getStakes (MSW integration)", () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].state).toBe("inactive");
+    expect(result.items[0].amount).toBe(0n);
   });
 
   it("should propagate RPC errors", async () => {

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.unit.test.ts
@@ -97,10 +97,15 @@ describe("getStakes", () => {
     expect(stake.delegate).toBe(VOTER_PUBKEY.toBase58());
     expect(stake.state).toBe("active");
     expect(stake.asset).toEqual({ type: "native" });
-    expect(stake.amount).toBe(BigInt(5_000_000_000));
+    // `amount` is the delegated principal, not the stake account's 5_000_000_000 lamports:
+    // the 2_282_880 rent-exempt reserve is not delegated and must not count as a reward.
+    expect(stake.amount).toBe(BigInt(4_997_717_120));
     expect(stake.amountDeposited).toBe(BigInt(4_997_717_120));
-    expect(stake.details?.rentExemptReserve).toBe("2282880");
-    expect(stake.details?.activeStake).toBe(4_997_717_120);
+    expect(stake.amountRewarded).toBe(0n);
+    expect(stake.details?.lockedReserve).toBe(2_282_880);
+    expect(stake.details?.activeAmount).toBe(4_997_717_120);
+    expect(stake.details?.canStake).toBe(true);
+    expect(stake.details?.canWithdraw).toBe(true);
   });
 
   it("should map a deactivating stake account", async () => {
@@ -111,7 +116,7 @@ describe("getStakes", () => {
     const result = await getStakes(api, TEST_ADDRESS);
 
     expect(result.items[0].state).toBe("deactivating");
-    expect(result.items[0].details?.inactiveStake).toBe(2_997_717_120);
+    expect(result.items[0].details?.inactiveAmount).toBe(2_997_717_120);
   });
 
   it("should propagate errors from getStakeAccounts", async () => {

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
@@ -15,10 +15,25 @@ const LIVE_35047_USDC_ATA = getAssociatedTokenAddressSync(
   new PublicKey(LIVE_35047_WALLET),
 ).toBase58();
 
-const KNOWN_TYPES = ["IN", "OUT", "FEES", "NONE", "DELEGATE", "UNDELEGATE", "WITHDRAW_UNBONDED"];
+// Native and token alike: the token account streams are read alongside the wallet's, so a token
+// operation reaches this list too.
+const KNOWN_TYPES = [
+  "IN",
+  "OUT",
+  "FEES",
+  "NONE",
+  "DELEGATE",
+  "UNDELEGATE",
+  "WITHDRAW_UNBONDED",
+  "OPT_IN",
+  "OPT_OUT",
+  "FREEZE",
+  "UNFREEZE",
+  "BURN",
+];
 
-// Per-type coverage (all 7 types) is in listOperations.test.ts (MSW) and
-// listOperations.unit.test.ts. This file focuses on real-RPC smoke tests.
+// Per-type coverage is in listOperations.test.ts (MSW) and listOperations.unit.test.ts. This file
+// focuses on real-RPC smoke tests.
 describe("listOperations (integration)", () => {
   it("fetches operations for an active account", async () => {
     const result = await listOperations(api, ACTIVE_ADDRESS, {

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
@@ -2,7 +2,22 @@ import type { ParsedInstruction, PartiallyDecodedInstruction } from "@solana/web
 import { PublicKey } from "@solana/web3.js";
 import { http, HttpResponse } from "msw";
 import { listOperations } from "../listOperations";
-import { server, rpcHandler, createTestChainApi, TEST_ENDPOINT } from "./helpers/msw-rpc.mock";
+import {
+  server,
+  rpcHandler as baseRpcHandler,
+  createTestChainApi,
+  TEST_ENDPOINT,
+} from "./helpers/msw-rpc.mock";
+
+/**
+ * `listOperations` reads the account's token accounts on every call, to walk their signature
+ * histories alongside the wallet's. A case that says nothing about them owns none.
+ */
+const rpcHandler: typeof baseRpcHandler = handlers =>
+  baseRpcHandler({
+    getTokenAccountsByOwner: () => ({ context: { slot: 0 }, value: [] }),
+    ...handlers,
+  });
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
 const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
@@ -96,6 +111,12 @@ describe("listOperations (MSW integration)", () => {
             id: "1",
           });
         }
+        // The token accounts are read before any signature stream; this test is about the latter.
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          result: { context: { slot: 0 }, value: [] },
+          id: "1",
+        });
       }),
     );
 
@@ -215,6 +236,14 @@ describe("listOperations (MSW integration)", () => {
         const body = (await request.json()) as
           | { method: string; params: unknown[]; id: unknown }
           | { method: string; params: unknown[]; id: unknown }[];
+
+        if (!Array.isArray(body) && body.method === "getTokenAccountsByOwner") {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            result: { context: { slot: 0 }, value: [] },
+            id: body.id,
+          });
+        }
 
         if (!Array.isArray(body)) {
           return HttpResponse.json({
@@ -410,6 +439,17 @@ describe("listOperations (MSW integration)", () => {
                         amount: "1000000",
                         decimals: 6,
                         uiAmount: 1.0,
+                      },
+                    },
+                    {
+                      accountIndex: 0,
+                      mint: USDC_MINT,
+                      owner: TEST_RECIPIENT,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "9000000",
+                        decimals: 6,
+                        uiAmount: 9.0,
                       },
                     },
                   ],

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
@@ -1,7 +1,8 @@
 import type { DeepPartialReturn } from "@ledgerhq/coin-module-framework/test/utils";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import type { ChainAPI } from "../../network";
-import { listOperations } from "../listOperations";
+import { dropMemoLengthPrefixIfAny, listOperations } from "../listOperations";
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
 const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
@@ -15,13 +16,22 @@ describe("listOperations", () => {
     DeepPartialReturn<ChainAPI["getParsedTransactions"]>
   >;
 
+  // The wallet owns no token account by default, so the only signature stream is its own and the
+  // cases below read exactly as they did before token accounts were queried too.
+  const mockGetParsedTokenAccountsByOwner = jest.fn().mockResolvedValue({ value: [] });
+  const mockGetParsedToken2022AccountsByOwner = jest.fn().mockResolvedValue({ value: [] });
+
   const api = {
     getSignaturesForAddress: mockGetSignaturesForAddress,
     getParsedTransactions: mockGetParsedTransactions,
+    getParsedTokenAccountsByOwner: mockGetParsedTokenAccountsByOwner,
+    getParsedToken2022AccountsByOwner: mockGetParsedToken2022AccountsByOwner,
   } as unknown as ChainAPI;
 
   afterEach(() => {
     jest.clearAllMocks();
+    mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+    mockGetParsedToken2022AccountsByOwner.mockResolvedValue({ value: [] });
   });
 
   it("should return empty list when no signatures found", async () => {
@@ -31,6 +41,115 @@ describe("listOperations", () => {
 
     expect(result.items).toEqual([]);
     expect(result.next).toBeUndefined();
+  });
+
+  // A batched transfer credits several accounts; keeping only the first silently dropped the rest.
+  it("names every account the transaction credited", async () => {
+    const second = "4iWtrn54zi89sHQv6xHyYwDsrPJvqcSKRJGBLrbErCsx";
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+    ]);
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          signatures: ["sig1"],
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+              { pubkey: new PublicKey(TEST_RECIPIENT) },
+              { pubkey: new PublicKey(second) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000, 0, 0],
+          postBalances: [799_995_000, 100_000_000, 100_000_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items[0]).toMatchObject({
+      type: "OUT",
+      senders: [TEST_ADDRESS],
+      recipients: [TEST_RECIPIENT, second],
+    });
+  });
+
+  // Ported from the legacy `getMainAccOperationTypeFromTx`: without these an ATA creation reads as
+  // a plain fee payment, and a freeze as nothing at all.
+  describe("account operations beyond transfers", () => {
+    function singleInstruction(program: string, type: string) {
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        {
+          transaction: {
+            signatures: ["sig1"],
+            message: {
+              accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+              recentBlockhash: TEST_BLOCKHASH,
+              instructions: [{ program, parsed: { type, info: {} } }],
+            },
+          },
+          meta: { fee: 5000, preBalances: [1_000_000_000], postBalances: [999_995_000] },
+        },
+      ]);
+    }
+
+    it.each([
+      ["spl-associated-token-account", "associate", "OPT_OUT"],
+      ["spl-token", "closeAccount", "OPT_OUT"],
+      ["spl-token", "freezeAccount", "FREEZE"],
+      ["spl-token", "thawAccount", "UNFREEZE"],
+      ["spl-token-2022", "thawAccount", "UNFREEZE"],
+    ])("types a lone %s/%s instruction as %s", async (program, type, expected) => {
+      singleInstruction(program, type);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items[0]).toMatchObject({ type: expected, value: 5000n });
+    });
+
+    it("leaves a transfer alone", async () => {
+      singleInstruction("system", "transfer");
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items[0]).toMatchObject({ type: "FEES" });
+    });
+
+    // A memo rides alongside the real instruction; counting it would hide the operation's nature.
+    it("ignores a memo when counting instructions", async () => {
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        {
+          transaction: {
+            signatures: ["sig1"],
+            message: {
+              accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+              recentBlockhash: TEST_BLOCKHASH,
+              instructions: [
+                { program: "spl-token", parsed: { type: "freezeAccount", info: {} } },
+                { program: "spl-memo", parsed: { type: "memo", info: {} } },
+              ],
+            },
+          },
+          meta: { fee: 5000, preBalances: [1_000_000_000], postBalances: [999_995_000] },
+        },
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items[0]).toMatchObject({ type: "FREEZE" });
+    });
   });
 
   it("should return OUT operations from parsed transactions", async () => {
@@ -121,6 +240,99 @@ describe("listOperations", () => {
     expect(result.items[0].recipients).toEqual([TEST_ADDRESS]);
   });
 
+  // A third party sending SPL into an existing token account names neither the recipient wallet nor
+  // its fee payer, so the transaction is absent from the wallet's own signature history. The legacy
+  // bridge queried each token account for exactly this reason.
+  it("finds an incoming token transfer through the token account's own history", async () => {
+    const blockTime = 1700000000;
+    const ata = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi";
+    const mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    mockGetParsedTokenAccountsByOwner.mockResolvedValue({
+      value: [{ pubkey: new PublicKey(ata) }],
+    });
+    // Empty for the wallet, one signature for its token account.
+    mockGetSignaturesForAddress.mockImplementation(async (source: string) =>
+      source === ata ? [{ signature: "sig-ata", slot: 100, blockTime, err: null }] : [],
+    );
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          signatures: ["sig-ata"],
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_RECIPIENT) },
+              { pubkey: new PublicKey(ata) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000, 2_039_280],
+          postBalances: [999_995_000, 2_039_280],
+          preTokenBalances: [
+            {
+              accountIndex: 1,
+              mint,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID.toBase58(),
+              uiTokenAmount: { amount: "0" },
+            },
+          ],
+          postTokenBalances: [
+            {
+              accountIndex: 1,
+              mint,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID.toBase58(),
+              uiTokenAmount: { amount: "500" },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("IN");
+    expect(result.items[0].value).toBe(500n);
+  });
+
+  // Both streams return a transaction the wallet signed. It belongs to the wallet's, or the token
+  // stream would emit it again on another page.
+  it("emits a transaction reaching both streams only once", async () => {
+    const blockTime = 1700000000;
+    const ata = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi";
+
+    mockGetParsedTokenAccountsByOwner.mockResolvedValue({
+      value: [{ pubkey: new PublicKey(ata) }],
+    });
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          signatures: ["sig1"],
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }, { pubkey: new PublicKey(ata) }],
+            recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
+          },
+        },
+        meta: { fee: 5000, preBalances: [1_000_000, 0], postBalances: [995_000, 0] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+  });
+
   it("should detect FEES operations when fee payer has zero net change", async () => {
     const blockTime = 1700000000;
     mockGetSignaturesForAddress.mockResolvedValue([
@@ -192,7 +404,34 @@ describe("listOperations", () => {
 
     const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
 
-    expect(result.next).toBe("sig-99");
+    // The cursor carries one `before` per signature stream, so assert what it resumes rather than
+    // how it is encoded.
+    mockGetSignaturesForAddress.mockClear();
+    await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc", cursor: result.next });
+    expect(mockGetSignaturesForAddress).toHaveBeenCalledWith(
+      TEST_ADDRESS,
+      expect.objectContaining({ before: "sig-99" }),
+    );
+  });
+
+  // The cursor names the streams still to walk, so a paged sync must not re-read the token accounts.
+  it("discovers the signature streams once, not on every page", async () => {
+    const blockTime = 1700000000;
+    const sigs = Array.from({ length: 100 }, (_, i) => ({
+      signature: `sig-${i}`,
+      slot: 200 - i,
+      blockTime,
+      err: null,
+    }));
+    mockGetSignaturesForAddress.mockResolvedValue(sigs);
+    mockGetParsedTransactions.mockResolvedValue(sigs.map(() => null));
+
+    const first = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+    expect(mockGetParsedTokenAccountsByOwner).toHaveBeenCalledTimes(1);
+
+    await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc", cursor: first.next });
+
+    expect(mockGetParsedTokenAccountsByOwner).toHaveBeenCalledTimes(1);
   });
 
   it("should not set next cursor when result count is less than limit", async () => {
@@ -639,7 +878,12 @@ describe("listOperations", () => {
     const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
 
     expect(result.items).toEqual([]);
-    expect(result.next).toBe("sig-99");
+    mockGetSignaturesForAddress.mockClear();
+    await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc", cursor: result.next });
+    expect(mockGetSignaturesForAddress).toHaveBeenCalledWith(
+      TEST_ADDRESS,
+      expect.objectContaining({ before: "sig-99" }),
+    );
   });
 
   it("should throw when order is asc", async () => {
@@ -930,6 +1174,89 @@ describe("listOperations", () => {
       };
     }
 
+    // A burn empties the account like a send does, but the tokens go nowhere. Legacy typed it
+    // `BURN` (`getTokenAccOperationType`); without it the history shows a transfer to no one.
+    it("types a lone burn instruction as BURN", async () => {
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+      ]);
+      const tx = makeTxWithTokenBalances(
+        [
+          {
+            accountIndex: 0,
+            mint: USDC_MINT,
+            owner: TEST_ADDRESS,
+            programId: TOKEN_PROGRAM_ID_STR,
+            uiTokenAmount: { amount: "1000" },
+          },
+        ],
+        [
+          {
+            accountIndex: 0,
+            mint: USDC_MINT,
+            owner: TEST_ADDRESS,
+            programId: TOKEN_PROGRAM_ID_STR,
+            uiTokenAmount: { amount: "400" },
+          },
+        ],
+      );
+      tx.transaction.message.instructions = [
+        { program: "spl-token", parsed: { type: "burn", info: {} } },
+      ] as never;
+      mockGetParsedTransactions.mockResolvedValue([tx]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOp = result.items.find(op => op.asset.type !== "native");
+      expect(tokenOp).toMatchObject({ type: "BURN", value: 600n });
+    });
+
+    // Freezing moves nothing, so the change carries a zero delta and is normally skipped. Only a
+    // freeze or a thaw lifts that guard -- legacy also emitted a `NONE` for every idle touch.
+    it.each([
+      ["freezeAccount", "FREEZE"],
+      ["thawAccount", "UNFREEZE"],
+    ])("emits %s on the token account as %s", async (type, expected) => {
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+      ]);
+      const balance = {
+        accountIndex: 0,
+        mint: USDC_MINT,
+        owner: TEST_ADDRESS,
+        programId: TOKEN_PROGRAM_ID_STR,
+        uiTokenAmount: { amount: "1000" },
+      };
+      const tx = makeTxWithTokenBalances([balance], [balance]);
+      tx.transaction.message.instructions = [
+        { program: "spl-token", parsed: { type, info: {} } },
+      ] as never;
+      mockGetParsedTransactions.mockResolvedValue([tx]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOp = result.items.find(op => op.asset.type !== "native");
+      expect(tokenOp).toMatchObject({ type: expected, value: 0n });
+    });
+
+    it("still skips a token account the transaction left untouched", async () => {
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+      ]);
+      const balance = {
+        accountIndex: 0,
+        mint: USDC_MINT,
+        owner: TEST_ADDRESS,
+        programId: TOKEN_PROGRAM_ID_STR,
+        uiTokenAmount: { amount: "1000" },
+      };
+      mockGetParsedTransactions.mockResolvedValue([makeTxWithTokenBalances([balance], [balance])]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items.find(op => op.asset.type !== "native")).toBeUndefined();
+    });
+
     it("should detect a fully spent token (present in pre, absent from post)", async () => {
       const blockTime = 1700000000;
       mockGetSignaturesForAddress.mockResolvedValue([
@@ -1091,7 +1418,9 @@ describe("listOperations", () => {
       });
     });
 
-    it("should fall back to accountKeys for counterparty when not in token balances", async () => {
+    // No fallback to `accountKeys`: an account absent from the token balances did not receive
+    // anything, and the first one that isn't the owner is usually a program id.
+    it("names no recipient when none appears in the token balances", async () => {
       const blockTime = 1700000000;
       mockGetSignaturesForAddress.mockResolvedValue([
         { signature: "sig1", slot: 100, blockTime, err: null },
@@ -1125,7 +1454,8 @@ describe("listOperations", () => {
       const tokenOps = result.items.filter(op => op.asset.type !== "native");
       expect(tokenOps).toHaveLength(1);
       expect(tokenOps[0].type).toBe("OUT");
-      expect(tokenOps[0].recipients).toEqual([TEST_RECIPIENT]);
+      expect(tokenOps[0].recipients).toEqual([]);
+      expect(tokenOps[0].senders).toEqual([TEST_ADDRESS]);
     });
 
     it("should handle token operation with no counterparty (single account)", async () => {
@@ -1282,5 +1612,23 @@ describe("listOperations", () => {
       expect(tokenOps).toHaveLength(1);
       expect(tokenOps[0].details).toEqual(expect.objectContaining({ internal: true }));
     });
+  });
+
+  describe("dropMemoLengthPrefixIfAny", () => {
+    // The RPC prefixes the memo with its length in *bytes*, which cannot index a UTF-16 string.
+    it.each([
+      ["[5] hello", "hello"],
+      ["[6] héllo", "héllo"],
+      ["[11] 🚀 to moon", "🚀 to moon"],
+    ])("drops the length prefix of %s", (raw, expected) => {
+      expect(dropMemoLengthPrefixIfAny(raw)).toBe(expected);
+    });
+
+    it.each(["no prefix at all", "[not a number] x", "[5]no space"])(
+      "leaves %s untouched",
+      memo => {
+        expect(dropMemoLengthPrefixIfAny(memo)).toBe(memo);
+      },
+    );
   });
 });

--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
@@ -11,6 +11,7 @@ import { getChainAPI } from "../../network";
 import type { ChainAPI } from "../../network";
 import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/index";
 import { endpointByCurrencyId } from "../../utils";
+import { estimateFees } from "../estimateFees";
 import { validateIntent as validateIntentRaw } from "../validateIntent";
 import type { SolanaCoinConfig } from "../../config";
 
@@ -35,19 +36,14 @@ const SENDER = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
 
 const NETWORK_FEE = 5_000n;
 const MAIN_ACCOUNT_RENT_EXEMPT = 890_880n;
+const CLASSIC_ATA_SIZE = 165;
 
-// SIMD-0437 progressively reduces ATA rent (293 bytes = 165 data + 128 overhead):
-// Step 0 (pre-SIMD-0437): 6,960 × 293 = 2,039,280
-// Step 1 (Sep 2026):      6,333 × 293 = 1,855,569
-// Step 2 (mid-Sep 2026):  5,080 × 293 = 1,488,440
-// Step 3 (Nov 2026):      2,575 × 293 =   754,475
-// Step 4 (Nov 2026):      1,322 × 293 =   387,346
-// Step 5 (Nov 2026):        696 × 293 =   203,928
-const CLASSIC_ATA_RENT = 1_855_569n; // Step 1 active on mainnet; update to current step when SIMD-0437 advances
-
-// Exact reproducer from the bug report: native = 0.00293516 SOL, spendable
-// (value - locked) = classic 165-byte ATA rent + network fee.
-const BALANCE_AT_BUG_THRESHOLD = NETWORK_FEE + CLASSIC_ATA_RENT + MAIN_ACCOUNT_RENT_EXEMPT;
+// SIMD-0437 progressively reduces ATA rent through six steps, the last of them in Nov 2026, so a
+// pinned figure goes stale every few weeks. Read it from the chain instead and it never does.
+async function balanceAtBugThreshold(): Promise<bigint> {
+  const classicAtaRent = BigInt(await api.getMinimumBalanceForRentExemption(CLASSIC_ATA_SIZE));
+  return classicAtaRent + NETWORK_FEE + MAIN_ACCOUNT_RENT_EXEMPT;
+}
 const SPL_BALANCE = 10_000_000n;
 
 function makeNativeBalance(value: bigint, locked: bigint = MAIN_ACCOUNT_RENT_EXEMPT): Balance {
@@ -84,24 +80,35 @@ describe("validateIntent (integration)", () => {
   jest.setTimeout(30_000);
 
   describe("SPL Token-2022 transfer to recipient without ATA", () => {
+    // The rent is sized from the mint by `estimateFees`, whose result `prepareTransaction` puts on
+    // the transaction -- so the chain under test is estimate-then-validate, not validate alone.
     it("packs NotEnoughGas when spendable balance equals classic ATA rent + fee (the regression scenario)", async () => {
+      const intent = makeTokenIntent(VIBECODOOR_MINT);
+      const estimation = await estimateFees(api, intent);
+      const classicAtaRent = BigInt(await api.getMinimumBalanceForRentExemption(CLASSIC_ATA_SIZE));
+
       const result = await validateIntent(
-        makeTokenIntent(VIBECODOOR_MINT),
-        [makeNativeBalance(BALANCE_AT_BUG_THRESHOLD), makeTokenBalance(VIBECODOOR_MINT)],
-        { value: NETWORK_FEE },
+        intent,
+        [makeNativeBalance(await balanceAtBugThreshold()), makeTokenBalance(VIBECODOOR_MINT)],
+        estimation,
         api,
       );
 
       expect(result.errors.gasPrice).toBeInstanceOf(NotEnoughGas);
+      // A human-readable amount, not raw lamports -- and sized from the mint, so above what a
+      // classic token account would have cost.
       const fees = (result.errors.gasPrice as Error & { fees?: string }).fees;
-      expect(BigInt(fees ?? "0")).toBeGreaterThan(CLASSIC_ATA_RENT + NETWORK_FEE);
+      expect(Number(fees)).toBeGreaterThan(Number(classicAtaRent) / 1e9);
     });
 
     it("does not pack NotEnoughGas when spendable balance comfortably covers mint-aware ATA rent + fee", async () => {
+      const intent = makeTokenIntent(VIBECODOOR_MINT);
+      const estimation = await estimateFees(api, intent);
+
       const result = await validateIntent(
-        makeTokenIntent(VIBECODOOR_MINT),
+        intent,
         [makeNativeBalance(1_000_000_000n), makeTokenBalance(VIBECODOOR_MINT)],
-        { value: NETWORK_FEE },
+        estimation,
         api,
       );
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.unit.test.ts
@@ -1,5 +1,6 @@
 import type {
   Balance,
+  Stake,
   StakingTransactionIntent,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
@@ -11,9 +12,35 @@ import {
   NotEnoughBalance,
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
-import { NotEnoughGas, SolanaStakeAccountAmountTooLow } from "../../errors";
+import {
+  NotEnoughGas,
+  SolanaAccountNotFunded,
+  SolanaMemoIsTooLong,
+  SolanaMintAccountNotAllowed,
+  SolanaRecipientAccountNotFunded,
+  SolanaInvalidValidator,
+  SolanaStakeAccountAmountTooLow,
+  SolanaStakeAccountIsNotDelegatable,
+  SolanaStakeAccountIsNotUndelegatable,
+  SolanaStakeAccountNotFound,
+  SolanaStakeAccountNothingToWithdraw,
+  SolanaStakeAccountValidatorIsUnchangeable,
+  SolanaStakeNoStakeAuth,
+  SolanaStakeNoWithdrawAuth,
+  SolanaTokenAccountHoldsAnotherToken,
+  SolanaTokenAccountNotAllowed,
+  SolanaTokenNonTransferable,
+  SolanaTokenRecipientIsSenderATA,
+} from "../../errors";
+import { MAX_MEMO_LENGTH } from "../validateMemo";
+import { formatAPIValue } from "../../common";
 import type { ChainAPI } from "../../network";
-import { getMaybeTokenMint } from "../../network/chain/web3";
+import {
+  getMaybeMintAccount,
+  getMaybeTokenAccount,
+  getMaybeTokenMint,
+  getMaybeVoteAccount,
+} from "../../network/chain/web3";
 import { validateIntent as validateIntentRaw } from "../validateIntent";
 
 const SENDER = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
@@ -21,14 +48,41 @@ const RECIPIENT = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE";
 
 const STAKE_ACC_RENT_EXEMPT = 2_282_880;
 
+// Undelegate + withdraw both cost this; the reserve a fresh stake account needs is twice it.
+const UNSTAKE_TX_FEE = 5000;
+jest.mock("../estimateFees", () => ({
+  estimateTxFee: jest.fn().mockResolvedValue(5000),
+  // The undelegate and the withdraw it stands for, at the fee above; `jest.mock` is hoisted
+  // above the constants, so the figure is inlined.
+  unstakeReserve: jest.fn().mockResolvedValue(10000n),
+}));
+
 jest.mock("../../network/chain/web3", () => ({
   __esModule: true,
   getMaybeTokenMint: jest.fn(),
+  // Recipient checks default to "a plain wallet address": neither a token account nor a mint.
+  // `FakeAtaAddress` is the associated token account the fake api derives, and it does exist
+  // whenever a test says so, so `getTokenRecipient` can read its state.
+  getMaybeTokenAccount: jest.fn(async (address: string) =>
+    address === "FakeAtaAddress" ? { state: "initialized", extensions: undefined } : undefined,
+  ),
+  getMaybeMintAccount: jest.fn().mockResolvedValue(undefined),
+  // Staking flows resolve the validator on-chain; a known vote account by default.
+  getMaybeVoteAccount: jest.fn().mockResolvedValue({ voteAccAddr: "vote-acc" }),
   getStakeAccountMinimumBalanceForRentExemption: jest.fn((api: ChainAPI) =>
     api.getMinimumBalanceForRentExemption(200),
   ),
 }));
 const mockedGetMaybeTokenMint = getMaybeTokenMint as jest.MockedFunction<typeof getMaybeTokenMint>;
+const mockedGetMaybeTokenAccount = getMaybeTokenAccount as jest.MockedFunction<
+  typeof getMaybeTokenAccount
+>;
+const mockedGetMaybeMintAccount = getMaybeMintAccount as jest.MockedFunction<
+  typeof getMaybeMintAccount
+>;
+const mockedGetMaybeVoteAccount = getMaybeVoteAccount as jest.MockedFunction<
+  typeof getMaybeVoteAccount
+>;
 function makeApi(
   stakeMinimumDelegation = 1_000_000_000,
   stakeAccRentExempt: number = STAKE_ACC_RENT_EXEMPT,
@@ -36,7 +90,42 @@ function makeApi(
   return {
     getStakeMinimumDelegation: jest.fn().mockResolvedValue(stakeMinimumDelegation),
     getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(stakeAccRentExempt),
+    // Live lamports of the stake account, read by the withdraw validation.
+    getBalance: jest.fn().mockResolvedValue(STAKE_ACC_RENT_EXEMPT + 1_000_000_000),
   } as unknown as ChainAPI;
+}
+
+/**
+ * Balances carrying one stake account, the shape `getBalance` reports and the only place the
+ * staking validations can learn about a position from.
+ */
+function makeStakeBalances(
+  stakeOverrides: Partial<Stake> = {},
+  native = 5_000_000_000n,
+): Balance[] {
+  return [
+    ...makeBalances(native),
+    {
+      value: 1_000_000_000n,
+      asset: { type: "native" },
+      stake: {
+        uid: RECIPIENT,
+        address: RECIPIENT,
+        state: "active",
+        asset: { type: "native" },
+        amount: 1_000_000_000n,
+        delegate: RECIPIENT,
+        actions: [],
+        details: {
+          canStake: true,
+          canWithdraw: true,
+          activeAmount: 1_000_000_000,
+          lockedReserve: STAKE_ACC_RENT_EXEMPT,
+        },
+        ...stakeOverrides,
+      } as Stake,
+    },
+  ];
 }
 
 type IntentArg = Parameters<typeof validateIntentRaw>[1];
@@ -49,10 +138,20 @@ const validateIntent = (
   customFees?: FeesArg,
   api?: ChainAPI,
 ): ReturnType<typeof validateIntentRaw> => {
-  const resolvedApi =
-    api ?? (intent.intentType === "staking" ? makeApi() : (undefined as unknown as ChainAPI));
+  // `api` is never optional in production — it comes from `chainAPIFromContext` — so the default
+  // stands in for the real one rather than exercising an api-less path.
+  const resolvedApi = api ?? (intent.intentType === "staking" ? makeApi() : makeTransferApi());
   return validateIntentRaw(resolvedApi, intent, balances, customFees);
 };
+
+/** A funded, plain-wallet recipient — what the transfer cases below assume. */
+function makeTransferApi(): ChainAPI {
+  return {
+    getBalance: jest.fn().mockResolvedValue(1),
+    findAssocTokenAccAddress: jest.fn().mockResolvedValue("sender-ata"),
+    getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(2_039_280),
+  } as unknown as ChainAPI;
+}
 
 function makeIntent(overrides?: Partial<TransactionIntent>): TransactionIntent {
   return {
@@ -71,6 +170,49 @@ function makeBalances(native = 5_000_000_000n, locked = 890_880n): Balance[] {
 }
 
 describe("validateIntent", () => {
+  // A partner-built transaction describes itself; the intent's recipient and amount are
+  // placeholders, so validating them would reject a perfectly good payload.
+  describe("partner-built transaction", () => {
+    const prebuilt = makeIntent({
+      recipient: "",
+      amount: 0n,
+    }) as TransactionIntent & { data: { type: string; raw: string } };
+    prebuilt.data = { type: "solana", raw: "AQID" };
+
+    it("reports no error and no warning", async () => {
+      const result = await validateIntent(prebuilt, makeBalances(), { value: 5000n });
+
+      expect(result.errors).toEqual({});
+      expect(result.warnings).toEqual({});
+    });
+
+    it("spends exactly the fee", async () => {
+      const result = await validateIntent(prebuilt, makeBalances(), { value: 5000n });
+
+      expect(result).toMatchObject({ amount: 0n, estimatedFees: 5000n, totalSpent: 5000n });
+    });
+
+    it("still validates a transaction that carries no partner payload", async () => {
+      const result = await validateIntent(makeIntent({ recipient: "" }), makeBalances());
+
+      expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
+    });
+  });
+
+  // Recipient lookups default to "a plain wallet address"; individual tests override them.
+  beforeEach(() => {
+    mockedGetMaybeTokenAccount.mockImplementation(async (address: string) =>
+      address === "FakeAtaAddress"
+        ? ({ state: "initialized" } as unknown as Awaited<ReturnType<typeof getMaybeTokenAccount>>)
+        : undefined,
+    );
+    mockedGetMaybeMintAccount.mockResolvedValue(undefined);
+    mockedGetMaybeVoteAccount.mockResolvedValue({ voteAccAddr: "vote-acc" } as unknown as Awaited<
+      ReturnType<typeof getMaybeVoteAccount>
+    >);
+    mockedGetMaybeTokenMint.mockReset();
+  });
+
   afterEach(() => jest.clearAllMocks());
 
   it("should return valid result for a basic native transfer", async () => {
@@ -165,6 +307,56 @@ describe("validateIntent", () => {
     expect(result.totalSpent).toBe(1_000_000_000n);
   });
 
+  // Only a live app submits these. Legacy ran the same recipient checks a transfer gets; the
+  // generic bridge had narrowed them to a base58 test.
+  describe("token authority intents", () => {
+    const makeApproveIntent = (overrides?: Partial<TransactionIntent>): TransactionIntent => ({
+      ...makeIntent({ amount: 1000n, ...overrides }),
+      type: "token.approve",
+    });
+
+    it("rejects a mint address as the delegate", async () => {
+      mockedGetMaybeMintAccount.mockResolvedValueOnce(
+        {} as unknown as Awaited<ReturnType<typeof getMaybeMintAccount>>,
+      );
+
+      const result = await validateIntent(makeApproveIntent(), makeBalances(), { value: 5000n });
+
+      expect(result.errors.recipient).toBeInstanceOf(SolanaMintAccountNotAllowed);
+    });
+
+    it("rejects the sender as its own delegate", async () => {
+      const result = await validateIntent(
+        makeApproveIntent({ recipient: SENDER }),
+        makeBalances(),
+        {
+          value: 5000n,
+        },
+      );
+
+      expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseDestinationIsAlsoSource);
+    });
+
+    it("requires an amount to approve", async () => {
+      const result = await validateIntent(makeApproveIntent({ amount: 0n }), makeBalances(), {
+        value: 5000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+    });
+
+    // Revoking names no delegate, so the recipient is not checked -- only the fee is at stake.
+    it("accepts a revoke with no recipient", async () => {
+      const result = await validateIntent(
+        { ...makeIntent({ recipient: "", amount: 0n }), type: "token.revoke" },
+        makeBalances(),
+        { value: 5000n },
+      );
+
+      expect(result.errors).toEqual({});
+    });
+  });
+
   describe("staking intents", () => {
     describe("stake.createAccount", () => {
       function makeStakeIntent(
@@ -189,6 +381,47 @@ describe("validateIntent", () => {
         expect(result.errors).toEqual({});
         expect(result.amount).toBe(1_000_000_000n);
         expect(result.totalSpent).toBe(1_000_000_000n + 5000n);
+      });
+
+      // The seed rides in `data`, which also flags a partner-built payload; only the latter skips
+      // validation, or a delegation would be checked against nothing.
+      it("still validates an intent carrying the stake account seed", async () => {
+        const result = await validateIntent(
+          makeStakeIntent({
+            amount: 100_000_000_000n,
+            data: { type: "solana", stakeAccountSeed: "seed" },
+          } as Partial<StakingTransactionIntent>),
+          makeBalances(),
+          { value: 5000n },
+        );
+
+        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      });
+
+      // Legacy set aside the stake account's rent plus the fees of the eventual undelegate and
+      // withdraw (`estimateMaxSpendable.ts`), so the account is never left unable to unstake.
+      it("reserves the future undelegate and withdraw fees when sending all", async () => {
+        const available = 5_000_000_000n - 890_880n;
+
+        const result = await validateIntent(
+          makeStakeIntent({ useAllAmount: true }),
+          makeBalances(),
+          { value: 5000n },
+        );
+
+        expect(result.amount).toBe(available - 5000n - BigInt(2 * UNSTAKE_TX_FEE));
+      });
+
+      it("counts the stake account rent and that reserve against a typed amount", async () => {
+        const available = 5_000_000_000n - 890_880n;
+        // Just affordable without the reserve and the rent, short once both are counted.
+        const amount = available - 5000n - 1n;
+
+        const result = await validateIntent(makeStakeIntent({ amount }), makeBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
       });
 
       it("should error when recipient is missing", async () => {
@@ -235,7 +468,7 @@ describe("validateIntent", () => {
         );
 
         expect(result.errors).toEqual({});
-        expect(result.amount).toBe(2_000_000_000n - 890_880n - 5000n);
+        expect(result.amount).toBe(2_000_000_000n - 890_880n - 5000n - BigInt(2 * UNSTAKE_TX_FEE));
       });
 
       it("should clamp amount to 0 when useAllAmount and balance is insufficient", async () => {
@@ -395,24 +628,34 @@ describe("validateIntent", () => {
           valAddress: RECIPIENT,
           amount: 0n,
           asset: { type: "native", name: "Solana" },
+          // Delegating carries the stake account as a memo; the recipient is the validator.
+          memo: { type: "string", kind: "text", value: RECIPIENT },
           ...overrides,
-        };
+        } as StakingTransactionIntent;
       }
 
+      const delegatableBalances = (native = 5_000_000_000n) =>
+        makeStakeBalances({ state: "inactive" }, native);
+
       it("should set amount to 0 and totalSpent to fees", async () => {
-        const result = await validateIntent(makeDelegateIntent(), makeBalances(), { value: 5000n });
+        const result = await validateIntent(makeDelegateIntent(), delegatableBalances(), {
+          value: 5000n,
+        });
 
         expect(result.errors).toEqual({});
         expect(result.amount).toBe(0n);
         expect(result.totalSpent).toBe(5000n);
       });
 
-      it("should error when fees exceed available balance (value - locked)", async () => {
-        const result = await validateIntent(makeDelegateIntent(), makeBalances(10_000n, 8_000n), {
-          value: 5000n,
-        });
+      it("should error when fees exceed the liquid balance", async () => {
+        const result = await validateIntent(
+          makeDelegateIntent(),
+          makeStakeBalances({ state: "inactive" }, 10_000n),
+          { value: 5000n },
+        );
 
-        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+        // Keyed on `fee`: that is what the staking screens render.
+        expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
       });
     });
 
@@ -434,7 +677,7 @@ describe("validateIntent", () => {
       }
 
       it("should set amount to 0 and totalSpent to fees", async () => {
-        const result = await validateIntent(makeUndelegateIntent(), makeBalances(), {
+        const result = await validateIntent(makeUndelegateIntent(), makeStakeBalances(), {
           value: 5000n,
         });
 
@@ -443,12 +686,176 @@ describe("validateIntent", () => {
         expect(result.totalSpent).toBe(5000n);
       });
 
-      it("should error when fees exceed total native value (not available)", async () => {
-        const result = await validateIntent(makeUndelegateIntent(), makeBalances(3000n, 0n), {
+      it("should error when fees exceed the liquid balance", async () => {
+        const result = await validateIntent(makeUndelegateIntent(), makeStakeBalances({}, 3000n), {
           value: 5000n,
         });
 
-        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+        expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
+      });
+
+      // A fully deactivated stake delegates nothing, so `stake.amount` is 0 while the account still
+      // holds its lamports. Subtracting the principal rather than the position's value would count
+      // the whole stake account as liquid.
+      it("does not let a deactivated stake's lamports pay the fee", async () => {
+        const staked = 10_000_000_000n;
+        const balances: Balance[] = [
+          { value: staked, asset: { type: "native" }, locked: staked },
+          {
+            value: staked,
+            asset: { type: "native" },
+            stake: {
+              uid: RECIPIENT,
+              address: RECIPIENT,
+              state: "inactive",
+              asset: { type: "native" },
+              amount: 0n,
+              actions: [],
+            },
+          },
+        ];
+
+        const result = await validateIntent(makeUndelegateIntent(), balances, { value: 5000n });
+
+        expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
+      });
+
+      // `getBalance` reports the native value as liquid + staked, so comparing the fee against it
+      // could never fail: any stake account dwarfs a 5000-lamport fee.
+      it("does not let staked lamports pay the fee", async () => {
+        const balances = makeStakeBalances({}, 1_000_003_000n);
+
+        const result = await validateIntent(makeUndelegateIntent(), balances, { value: 5000n });
+
+        expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
+      });
+    });
+
+    describe("checks the legacy bridge used to run", () => {
+      const VOTE_ACC = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE";
+
+      const delegateIntent = (overrides: Record<string, unknown> = {}) =>
+        ({
+          intentType: "staking",
+          type: "stake.delegate",
+          mode: "delegate",
+          sender: SENDER,
+          recipient: VOTE_ACC,
+          valAddress: VOTE_ACC,
+          amount: 0n,
+          asset: { type: "native", name: "Solana" },
+          memo: { type: "string", kind: "text", value: RECIPIENT },
+          ...overrides,
+        }) as StakingTransactionIntent;
+
+      const undelegateIntent = () =>
+        ({
+          intentType: "staking",
+          type: "stake.undelegate",
+          mode: "undelegate",
+          sender: SENDER,
+          recipient: RECIPIENT,
+          valAddress: "",
+          amount: 0n,
+          asset: { type: "native", name: "Solana" },
+        }) as StakingTransactionIntent;
+
+      const withdrawIntent = () =>
+        makeIntent({
+          intentType: "transaction",
+          type: "stake.withdraw",
+          recipient: RECIPIENT,
+          amount: 1_000n,
+        } as Partial<TransactionIntent>);
+
+      it("rejects a stake account that is not among the account's positions", async () => {
+        const result = await validateIntent(delegateIntent(), makeBalances(), { value: 5000n });
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(SolanaStakeAccountNotFound);
+      });
+
+      it("rejects an unknown validator", async () => {
+        mockedGetMaybeVoteAccount.mockResolvedValue(undefined);
+
+        const result = await validateIntent(
+          delegateIntent(),
+          makeStakeBalances({ state: "inactive" }),
+          { value: 5000n },
+        );
+
+        expect(result.errors.voteAccAddr).toBeInstanceOf(SolanaInvalidValidator);
+      });
+
+      it("rejects delegating a stake that is already active", async () => {
+        const result = await validateIntent(delegateIntent(), makeStakeBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(SolanaStakeAccountIsNotDelegatable);
+      });
+
+      it("refuses to move a deactivating stake to another validator", async () => {
+        const result = await validateIntent(
+          delegateIntent(),
+          makeStakeBalances({ state: "deactivating", delegate: "AnotherValidator" }),
+          { value: 5000n },
+        );
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(
+          SolanaStakeAccountValidatorIsUnchangeable,
+        );
+      });
+
+      it("accepts reactivating a deactivating stake on the same validator", async () => {
+        const result = await validateIntent(
+          delegateIntent(),
+          makeStakeBalances({ state: "deactivating", delegate: VOTE_ACC }),
+          { value: 5000n },
+        );
+
+        expect(result.errors.stakeAccAddr).toBeUndefined();
+        expect(result.errors.voteAccAddr).toBeUndefined();
+      });
+
+      it("rejects delegating without the stake authority", async () => {
+        const result = await validateIntent(
+          delegateIntent(),
+          makeStakeBalances({
+            state: "inactive",
+            details: { canStake: false, canWithdraw: false },
+          }),
+          { value: 5000n },
+        );
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(SolanaStakeNoStakeAuth);
+      });
+
+      it("rejects deactivating a stake that is not active", async () => {
+        const result = await validateIntent(
+          undelegateIntent(),
+          makeStakeBalances({ state: "inactive" }),
+          { value: 5000n },
+        );
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(SolanaStakeAccountIsNotUndelegatable);
+      });
+
+      it("rejects withdrawing without the withdraw authority", async () => {
+        const result = await validateIntent(
+          withdrawIntent(),
+          makeStakeBalances({ state: "inactive", details: { canWithdraw: false } }),
+          { value: 5000n },
+        );
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(SolanaStakeNoWithdrawAuth);
+      });
+
+      it("rejects withdrawing from a stake with nothing free", async () => {
+        const result = await validateIntent(withdrawIntent(), makeStakeBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.stakeAccAddr).toBeInstanceOf(SolanaStakeAccountNothingToWithdraw);
       });
     });
 
@@ -466,7 +873,12 @@ describe("validateIntent", () => {
       }
 
       it("should use the provided amount", async () => {
-        const result = await validateIntent(makeWithdrawIntent(), makeBalances(), { value: 5000n });
+        // You withdraw from a stake that has finished deactivating, so its whole balance is free.
+        const result = await validateIntent(
+          makeWithdrawIntent(),
+          makeStakeBalances({ state: "inactive" }),
+          { value: 5000n },
+        );
 
         expect(result.errors).toEqual({});
         expect(result.amount).toBe(2_000_000_000n);
@@ -493,12 +905,12 @@ describe("validateIntent", () => {
         expect(result.amount).toBe(0n);
       });
 
-      it("should error when fees exceed total native value", async () => {
+      it("should error when fees exceed the liquid balance", async () => {
         const result = await validateIntent(makeWithdrawIntent(), makeBalances(3000n, 0n), {
           value: 5000n,
         });
 
-        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+        expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
       });
 
       it("keeps the returned amount clamped to 0 even when errors are set", async () => {
@@ -508,7 +920,7 @@ describe("validateIntent", () => {
           { value: 5000n },
         );
 
-        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+        expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
         expect(result.amount).toBe(0n);
         expect(result.totalSpent).toBe(5000n);
       });
@@ -531,6 +943,202 @@ describe("validateIntent", () => {
         { value: 10_000_000n, asset: { type: "spl-token", assetReference: USDC_MINT } },
       ];
     }
+
+    function makePartlyFrozenBalances(): Balance[] {
+      return [
+        { value: 5_000_000_000n, asset: { type: "native" }, locked: 890_880n },
+        {
+          value: 10_000_000n,
+          // 3 USDC sit in a frozen token account and cannot be transferred
+          locked: 3_000_000n,
+          asset: { type: "spl-token", assetReference: USDC_MINT },
+        },
+      ];
+    }
+
+    describe("recipient checks the legacy bridge used to run", () => {
+      // A token account typed in as the destination of a *native* transfer.
+      it("rejects a token account when the transfer is not a token transfer", async () => {
+        mockedGetMaybeTokenAccount.mockResolvedValueOnce({
+          state: "initialized",
+        } as unknown as Awaited<ReturnType<typeof getMaybeTokenAccount>>);
+
+        const result = await validateIntent(makeIntent({ amount: 1n }), makeBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.recipient).toBeInstanceOf(SolanaTokenAccountNotAllowed);
+      });
+
+      it("rejects a mint address as the recipient", async () => {
+        mockedGetMaybeMintAccount.mockResolvedValueOnce(
+          {} as unknown as Awaited<ReturnType<typeof getMaybeMintAccount>>,
+        );
+
+        const result = await validateIntent(makeIntent({ amount: 1n }), makeBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.recipient).toBeInstanceOf(SolanaMintAccountNotAllowed);
+      });
+
+      const unfundedRecipientApi = () =>
+        ({
+          getBalance: jest.fn().mockResolvedValue(0),
+          findAssocTokenAccAddress: jest.fn().mockResolvedValue("FakeAtaAddress"),
+          getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(890_880),
+        }) as unknown as ChainAPI;
+
+      it("warns when the recipient wallet is not funded, and rejects a dust amount", async () => {
+        const result = await validateIntent(
+          makeIntent({ amount: 1n }),
+          makeBalances(),
+          { value: 5000n },
+          unfundedRecipientApi(),
+        );
+
+        expect(result.errors.recipient).toBeUndefined();
+        expect(result.warnings.recipient).toBeInstanceOf(SolanaAccountNotFunded);
+        // 1 lamport cannot create the recipient account, which needs the rent-exempt minimum.
+        expect(result.errors.amount).toBeInstanceOf(SolanaRecipientAccountNotFunded);
+      });
+
+      it("accepts an unfunded recipient when the amount covers its rent", async () => {
+        const result = await validateIntent(
+          makeIntent({ amount: 890_880n }),
+          makeBalances(),
+          { value: 5000n },
+          unfundedRecipientApi(),
+        );
+
+        expect(result.errors.amount).toBeUndefined();
+        expect(result.warnings.recipient).toBeInstanceOf(SolanaAccountNotFunded);
+      });
+
+      // A real token account address is a PDA, so it is always off the ed25519 curve.
+      const OFF_CURVE_TOKEN_ACCOUNT = "35npQR1u7vycmAjRS8H2ozoY7uTXPeZqUCJAm34Kidv1";
+
+      it("reports a non-transferable mint as an error rather than throwing", async () => {
+        mockedGetMaybeTokenMint.mockResolvedValue({
+          onChainAcc: { data: { program: "spl-token-2022" } },
+          info: { extensions: [{ extension: "nonTransferable" }] },
+        } as unknown as Awaited<ReturnType<typeof getMaybeTokenMint>>);
+
+        const result = await validateIntent(makeTokenIntent({ amount: 1n }), makeTokenBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.amount).toBeInstanceOf(SolanaTokenNonTransferable);
+      });
+
+      // These parsers return an Error to mean "not that kind of account", which must not abort
+      // the whole status computation.
+      it("treats an unparseable recipient account as a plain address", async () => {
+        mockedGetMaybeTokenAccount.mockResolvedValue(new Error("not a token account"));
+        mockedGetMaybeMintAccount.mockResolvedValue(new Error("not a mint account"));
+
+        const result = await validateIntent(makeIntent({ amount: 1_000_000n }), makeBalances(), {
+          value: 5000n,
+        });
+
+        expect(result.errors.recipient).toBeUndefined();
+      });
+
+      it("rejects a token account that holds another mint", async () => {
+        mockedGetMaybeTokenMint.mockResolvedValue({
+          onChainAcc: { data: { program: "spl-token" } },
+          info: { extensions: [] },
+        } as unknown as Awaited<ReturnType<typeof getMaybeTokenMint>>);
+        // The recipient is a token account, but for a different mint than the one being sent.
+        mockedGetMaybeTokenAccount.mockResolvedValue({
+          state: "initialized",
+          mint: { toBase58: () => "AnotherMint11111111111111111111111111111111" },
+          owner: { toBase58: () => "SomeOwner" },
+        } as unknown as Awaited<ReturnType<typeof getMaybeTokenAccount>>);
+
+        const result = await validateIntent(
+          makeTokenIntent({ amount: 1n, recipient: OFF_CURVE_TOKEN_ACCOUNT }),
+          makeTokenBalances(),
+          { value: 5000n },
+        );
+
+        expect(result.errors.recipient).toBeInstanceOf(SolanaTokenAccountHoldsAnotherToken);
+      });
+
+      it("rejects sending a token to the sender's own associated token account", async () => {
+        mockedGetMaybeTokenMint.mockResolvedValue({
+          onChainAcc: { data: { program: "spl-token" } },
+          info: { extensions: [] },
+        } as unknown as Awaited<ReturnType<typeof getMaybeTokenMint>>);
+        const api = {
+          getBalance: jest.fn().mockResolvedValue(1),
+          findAssocTokenAccAddress: jest.fn().mockResolvedValue(RECIPIENT),
+          getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(2_039_280),
+        } as unknown as ChainAPI;
+
+        const result = await validateIntent(
+          makeTokenIntent({ amount: 1n }),
+          makeTokenBalances(),
+          { value: 5000n },
+          api,
+        );
+
+        expect(result.errors.recipient).toBeInstanceOf(SolanaTokenRecipientIsSenderATA);
+      });
+
+      it("rejects a memo longer than the on-chain limit", async () => {
+        const result = await validateIntent(
+          makeIntent({
+            amount: 1n,
+            memo: { type: "string", kind: "text", value: "a".repeat(MAX_MEMO_LENGTH + 1) },
+          } as Partial<TransactionIntent>),
+          makeBalances(),
+          { value: 5000n },
+        );
+
+        expect(result.errors.memo).toBeInstanceOf(SolanaMemoIsTooLong);
+        expect(result.errors.transaction).toBe(result.errors.memo);
+      });
+    });
+
+    it("rejects an amount that dips into the frozen share", async () => {
+      const result = await validateIntent(
+        makeTokenIntent({ amount: 8_000_000n }),
+        makePartlyFrozenBalances(),
+        { value: 5000n },
+      );
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("caps send-max at the unfrozen share", async () => {
+      const result = await validateIntent(
+        makeTokenIntent({ amount: 0n, useAllAmount: true }),
+        makePartlyFrozenBalances(),
+        { value: 5000n },
+      );
+
+      expect(result.amount).toBe(7_000_000n);
+      expect(result.errors).toEqual({});
+    });
+
+    it("refuses a send-max when the whole token balance is frozen", async () => {
+      const result = await validateIntent(
+        makeTokenIntent({ amount: 0n, useAllAmount: true }),
+        [
+          { value: 5_000_000_000n, asset: { type: "native" }, locked: 890_880n },
+          {
+            value: 10_000_000n,
+            locked: 10_000_000n,
+            asset: { type: "spl-token", assetReference: USDC_MINT },
+          },
+        ],
+        { value: 5000n },
+      );
+
+      expect(result.amount).toBe(0n);
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
 
     it("should validate a basic token transfer", async () => {
       const result = await validateIntent(
@@ -575,6 +1183,16 @@ describe("validateIntent", () => {
       expect(result.amount).toBe(0n);
     });
 
+    // Lamports against token units is meaningless, and the recipient's ATA rent rides in the fee,
+    // so this fired on every first transfer to a given recipient.
+    it("never warns that fees are too high on a token transfer", async () => {
+      const result = await validateIntent(makeTokenIntent({ amount: 1n }), makeBalances(), {
+        value: 2_044_280n,
+      });
+
+      expect(result.warnings.feeTooHigh).toBeUndefined();
+    });
+
     describe("native SOL coverage for ATA rent + fee (via api)", () => {
       const FEE = 5000n;
       const CLASSIC_ATA_RENT = 2_039_280n;
@@ -616,58 +1234,54 @@ describe("validateIntent", () => {
         mockedGetMaybeTokenMint.mockReset();
       });
 
-      it("packs NotEnoughGas when spendable equals classic ATA rent + fee but the Token-2022 ATA needs more SOL", async () => {
+      // `estimateFees` sizes the rent from the mint and folds it into the fee; this only checks
+      // that the fee it hands over is what the coverage check compares against.
+      it("packs NotEnoughGas when spendable cannot cover the fee the estimation reported", async () => {
         mockedGetMaybeTokenMint.mockResolvedValueOnce(
           makeMint("spl-token-2022", ["transferFeeConfig"]),
         );
-        const api = makeFakeApi({
-          ataExists: false,
-          rentLamports: Number(TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE),
-        });
+        const api = makeFakeApi({ ataExists: false, rentByDataLength: {} });
 
         const result = await validateIntent(
           makeTokenIntent({ amount: 1n }),
           balancesWithNative(2_935_160n),
-          { value: FEE },
+          { value: TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE + FEE },
           api,
         );
 
         expect(result.errors.gasPrice).toBeInstanceOf(NotEnoughGas);
-        expect((result.errors.gasPrice as Error & { fees?: string }).fees).toBe(
-          (TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE + FEE).toString(),
-        );
+        // The message interpolates a human-readable amount, not raw lamports.
+        expect(result.errors.gasPrice as Error & Record<string, unknown>).toMatchObject({
+          fees: formatAPIValue(TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE + FEE),
+          ticker: "SOL",
+          cryptoName: "Solana",
+        });
       });
 
-      it("does not pack NotEnoughGas when spendable covers mint-aware ATA rent + fee", async () => {
+      it("does not pack NotEnoughGas when spendable covers that fee", async () => {
         mockedGetMaybeTokenMint.mockResolvedValueOnce(
           makeMint("spl-token-2022", ["transferFeeConfig"]),
         );
-        const api = makeFakeApi({
-          ataExists: false,
-          rentLamports: Number(TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE),
-        });
+        const api = makeFakeApi({ ataExists: false, rentByDataLength: {} });
 
         const result = await validateIntent(
           makeTokenIntent({ amount: 1n }),
           balancesWithNative(TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE + FEE + 890_880n),
-          { value: FEE },
+          { value: TOKEN_2022_ATA_RENT_WITH_TRANSFER_FEE + FEE },
           api,
         );
 
         expect(result.errors.gasPrice).toBeUndefined();
       });
 
-      it("packs NotEnoughGas when classic SPL ATA needs to be created and spendable can't cover rent + fee", async () => {
+      it("packs NotEnoughGas when a classic SPL ATA has to be created and funds fall one short", async () => {
         mockedGetMaybeTokenMint.mockResolvedValueOnce(makeMint("spl-token"));
-        const api = makeFakeApi({
-          ataExists: false,
-          rentLamports: Number(CLASSIC_ATA_RENT),
-        });
+        const api = makeFakeApi({ ataExists: false, rentByDataLength: {} });
 
         const result = await validateIntent(
           makeTokenIntent({ amount: 1n }),
           balancesWithNative(CLASSIC_ATA_RENT + FEE - 1n + 890_880n),
-          { value: FEE },
+          { value: CLASSIC_ATA_RENT + FEE },
           api,
         );
 
@@ -707,17 +1321,6 @@ describe("validateIntent", () => {
         );
 
         expect(result.errors.gasPrice).toBeInstanceOf(NotEnoughGas);
-      });
-
-      it("skips the native coverage check when api is not provided (back-compat)", async () => {
-        const result = await validateIntent(
-          makeTokenIntent({ amount: 1n }),
-          balancesWithNative(0n),
-          { value: FEE },
-        );
-
-        expect(result.errors.gasPrice).toBeUndefined();
-        expect(mockedGetMaybeTokenMint).not.toHaveBeenCalled();
       });
 
       it("skips the native coverage check when recipient address is invalid", async () => {

--- a/libs/coin-modules/coin-solana/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-solana/src/logic/validateIntent.ts
@@ -5,6 +5,7 @@ import type {
   Balance,
   AssetInfo,
   MemoNotSupported,
+  Stake,
   StringMemo,
 } from "@ledgerhq/coin-module-framework/api/types";
 import {
@@ -15,20 +16,61 @@ import {
   NotEnoughBalance,
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
-import { formatAPIValueWithCode } from "../common";
-import { NotEnoughGas, SolanaStakeAccountAmountTooLow } from "../errors";
-import { isValidBase58Address, isSolanaStakingTransactionIntent } from "../logic";
-import { getAtaDataLengthForMint } from "../helpers/token";
+import { formatAPIValue, formatAPIValueWithCode, solanaUnit } from "../common";
 import {
+  isEd25519Address,
+  isSolanaStakingTransactionIntent,
+  isValidBase58Address,
+  withdrawableFromStake,
+} from "../logic";
+import { MAX_MEMO_LENGTH, validateMemo } from "./validateMemo";
+import {
+  NotEnoughGas,
+  SolanaStakeAccountAmountTooLow,
+  SolanaAccountNotFunded,
+  SolanaRecipientAccountNotFunded,
+  SolanaTokenNonTransferable,
+  SolanaAddressOffEd25519,
+  SolanaMemoIsTooLong,
+  SolanaMintAccountNotAllowed,
+  SolanaRecipientAssociatedTokenAccountWillBeFunded,
+  SolanaRecipientMemoIsRequired,
+  SolanaTokenAccounNotInitialized,
+  SolanaTokenAccountFrozen,
+  SolanaTokenAccountHoldsAnotherToken,
+  SolanaTokenAccountNotAllowed,
+  SolanaTokenAccountWarning,
+  SolanaInvalidValidator,
+  SolanaStakeAccountIsNotDelegatable,
+  SolanaStakeAccountIsNotUndelegatable,
+  SolanaStakeAccountNotFound,
+  SolanaStakeAccountNothingToWithdraw,
+  SolanaStakeAccountRequired,
+  SolanaStakeAccountValidatorIsUnchangeable,
+  SolanaStakeNoStakeAuth,
+  SolanaStakeNoWithdrawAuth,
+  SolanaTokenRecipientIsSenderATA,
+  SolanaValidatorRequired,
+} from "../errors";
+import type { TokenAccountInfo } from "../network/chain/account/token";
+import type { MemoTransferExt } from "../network/chain/account/tokenExtensions";
+import { UserInputType } from "../signer";
+import {
+  getMaybeMintAccount,
+  getMaybeTokenAccount,
   getMaybeTokenMint,
+  getMaybeVoteAccount,
   getStakeAccountMinimumBalanceForRentExemption,
 } from "../network/chain/web3";
-import type { SolanaTokenProgram } from "../types";
+import { unstakeReserve } from "./estimateFees";
+import type { SolanaTokenAccount, SolanaTokenProgram, TokenRecipientDescriptor } from "../types";
 import type { ChainAPI } from "../network";
 
 export async function validateIntent(
   api: ChainAPI,
-  transactionIntent: TransactionIntent<StringMemo | MemoNotSupported>,
+  transactionIntent: TransactionIntent<StringMemo | MemoNotSupported> & {
+    data?: { type: string; raw?: string };
+  },
   balances: Balance[],
   customFees?: FeeEstimation,
 ): Promise<TransactionValidation> {
@@ -36,29 +78,62 @@ export async function validateIntent(
   const warnings: Record<string, Error> = {};
 
   const estimatedFees = customFees?.value ?? 0n;
+
+  // A partner-built transaction describes itself; the intent's recipient and amount are
+  // placeholders, so validating them would reject a perfectly good payload. Legacy did the same.
+  // Keyed on `raw`, not on the family tag: `data` also carries the stake account seed of an intent
+  // the wallet built itself, which must still be validated.
+  if (transactionIntent.data?.type === "solana" && transactionIntent.data.raw) {
+    return { errors, warnings, estimatedFees, amount: 0n, totalSpent: estimatedFees };
+  }
+
   const isTokenTransfer = transactionIntent.asset.type !== "native";
 
-  if (isSolanaStakingTransactionIntent(transactionIntent)) {
+  if (
+    isSolanaStakingTransactionIntent(transactionIntent) ||
+    transactionIntent.type === "stake.split"
+  ) {
     return validateStakingIntent(api, transactionIntent, balances, estimatedFees);
   }
 
-  validateRecipient(transactionIntent, errors);
+  if (transactionIntent.type.startsWith("token.") && transactionIntent.type !== "token.transfer") {
+    return validateTokenAuthorityIntent(api, transactionIntent, balances, estimatedFees);
+  }
+
+  await validateRecipientCommon(
+    {
+      sender: transactionIntent.sender,
+      recipient: transactionIntent.recipient,
+      currencyName: transactionIntent.asset?.name ?? "Solana",
+      allowATA: isTokenTransfer,
+    },
+    errors,
+    warnings,
+    api,
+  );
+  validateTransactionMemo(transactionIntent, errors);
+
   const amount = computeAmount(transactionIntent, balances, estimatedFees, isTokenTransfer);
   validateAmount(transactionIntent, amount, balances, estimatedFees, isTokenTransfer, errors);
 
-  if (isTokenTransfer && api && transactionIntent.recipient && !errors.recipient) {
-    await validateTokenTransferNativeCoverage(
-      api,
-      transactionIntent,
-      balances,
-      estimatedFees,
-      errors,
-    );
+  if (isTokenTransfer && transactionIntent.recipient && !errors.recipient) {
+    await validateTokenTransfer(api, transactionIntent, balances, estimatedFees, errors, warnings);
   }
 
-  checkFeeTooHigh(amount, estimatedFees, warnings);
+  if (!isTokenTransfer) {
+    await validateUnfundedRecipientAmount(api, amount, warnings, errors);
+  }
 
-  const totalSpent = isTokenTransfer ? amount : amount + estimatedFees;
+  // Native only: `amount` is in the token's own units on the other branch, and comparing it to
+  // lamports is meaningless -- it flagged every first transfer to a recipient, whose fee carries
+  // the new account's rent.
+  if (!isTokenTransfer) {
+    checkFeeTooHigh(amount, estimatedFees, warnings);
+  }
+
+  const totalSpent = isTokenTransfer
+    ? tokenAmountLeavingTheAccount(amount, customFees)
+    : amount + estimatedFees;
 
   return {
     errors,
@@ -70,18 +145,55 @@ export async function validateIntent(
 }
 
 /**
- * SPL token transfers require enough native SOL to cover the network fee and,
- * when the recipient has no associated token account, its mint-aware rent. The
- * mint-aware size matters for Token-2022 mints with extensions, whose ATA is
- * larger than the classic 165-byte one and rents more SOL on-chain. If we miss
- * this check, prepareTransaction is happy off-chain but the broadcast fails.
+ * An unfunded recipient wallet has to be created on-chain, which costs the rent-exempt minimum for
+ * a zero-space account. Below that the transaction passes every local check and fails at broadcast.
  */
-async function validateTokenTransferNativeCoverage(
+async function validateUnfundedRecipientAmount(
+  api: ChainAPI,
+  amount: bigint,
+  warnings: Record<string, Error>,
+  errors: Record<string, Error>,
+): Promise<void> {
+  if (errors.amount || amount <= 0n || !(warnings.recipient instanceof SolanaAccountNotFunded)) {
+    return;
+  }
+  const recipientMinAmount = BigInt(await api.getMinimumBalanceForRentExemption(0));
+  if (amount < recipientMinAmount) {
+    errors.amount = new SolanaRecipientAccountNotFunded("", {
+      minimumAmount: formatAPIValueWithCode(recipientMinAmount),
+    });
+  }
+}
+
+/** The memo text an intent carries, if any: the framework models "no memo" as its own type. */
+function intentMemo(intent: TransactionIntent<StringMemo | MemoNotSupported>): string | undefined {
+  return "memo" in intent && intent.memo.type === "string" ? intent.memo.value : undefined;
+}
+
+/** Solana caps memos at `MAX_MEMO_LENGTH` bytes; the device rejects anything longer. */
+function validateTransactionMemo(
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  errors: Record<string, Error>,
+): void {
+  const memo = intentMemo(intent);
+  if (typeof memo === "string" && memo.length > 0 && !validateMemo(memo)) {
+    errors.transaction = errors.memo = new SolanaMemoIsTooLong(undefined, {
+      maxLength: MAX_MEMO_LENGTH,
+    });
+  }
+}
+
+/**
+ * Everything an SPL transfer needs the chain for, in one pass: where it lands, whether that
+ * destination accepts it, and whether the sender holds enough SOL for the fee.
+ */
+async function validateTokenTransfer(
   api: ChainAPI,
   intent: TransactionIntent<StringMemo | MemoNotSupported>,
   balances: Balance[],
   estimatedFees: bigint,
   errors: Record<string, Error>,
+  warnings: Record<string, Error>,
 ): Promise<void> {
   const mintAddress = "assetReference" in intent.asset ? intent.asset.assetReference : undefined;
   if (!mintAddress) return;
@@ -89,26 +201,98 @@ async function validateTokenTransferNativeCoverage(
   const mintOrError = await getMaybeTokenMint(mintAddress, api);
   if (!mintOrError || mintOrError instanceof Error) return;
 
+  // A Token-2022 mint can forbid transfers outright; nothing downstream can make one succeed.
+  if (mintOrError.info.extensions?.some(ext => ext.extension === "nonTransferable")) {
+    errors.amount = new SolanaTokenNonTransferable();
+    return;
+  }
+
   const tokenProgram = mintOrError.onChainAcc.data.program as SolanaTokenProgram;
-  const recipientAta = await api.findAssocTokenAccAddress(
+  const senderAta = await api.findAssocTokenAccAddress(intent.sender, mintAddress, tokenProgram);
+  if (intent.recipient === senderAta) {
+    errors.recipient = new SolanaTokenRecipientIsSenderATA();
+    return;
+  }
+
+  const recipientOrError = await getTokenRecipient(
     intent.recipient,
     mintAddress,
     tokenProgram,
+    api,
   );
-  const ataExists = (await api.getBalance(recipientAta)) > 0;
-  const ataRent = ataExists
-    ? 0n
-    : BigInt(await api.getMinimumBalanceForRentExemption(getAtaDataLengthForMint(mintOrError)));
+  if (recipientOrError instanceof Error) {
+    errors.recipient = recipientOrError;
+    return;
+  }
 
-  const requiredSol = ataRent + estimatedFees;
+  const { descriptor, recipientAccInfo } = recipientOrError;
+  if (recipientAccInfo) {
+    validateRecipientRequiredMemo(intentMemo(intent), recipientAccInfo, errors);
+  }
+  if (descriptor.shouldCreateAsAssociatedTokenAccount) {
+    warnings.recipient = new SolanaRecipientAssociatedTokenAccountWillBeFunded();
+  }
+
+  // `estimateFees` already folds the recipient's ATA rent into the fee, so it is counted here.
+  const requiredSol = estimatedFees;
   const native = balances.find(b => b.asset.type === "native");
   const spendable = (native?.value ?? 0n) - (native?.locked ?? 0n);
 
   if (spendable < requiredSol || spendable === 0n) {
+    // The message interpolates all four: a bare `fees` leaves `{{ticker}}` and `{{cryptoName}}`
+    // unresolved in the UI, and the amount reads in lamports.
     errors.gasPrice = new NotEnoughGas(undefined, {
-      fees: requiredSol.toString(),
+      fees: formatAPIValue(requiredSol),
+      ticker: solanaUnit.code,
+      cryptoName: solanaUnit.name,
+      links: ["ledgerlive://buy?"],
     });
   }
+}
+
+/**
+ * The three token-authority commands, which only a live app submits. Opening or closing an account
+ * moves no token, so only the native fee is at stake; approving one also names a delegate and an
+ * amount.
+ */
+async function validateTokenAuthorityIntent(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  balances: Balance[],
+  estimatedFees: bigint,
+): Promise<TransactionValidation> {
+  const errors: Record<string, Error> = {};
+  const warnings: Record<string, Error> = {};
+
+  if (intent.type === "token.approve") {
+    // The same chain checks a transfer recipient gets: a delegate that is a mint or an off-curve
+    // address is rejected here rather than at broadcast, as the legacy bridge did.
+    await validateRecipientCommon(
+      {
+        sender: intent.sender,
+        recipient: intent.recipient,
+        currencyName: intent.asset?.name ?? "Solana",
+        allowATA: true,
+      },
+      errors,
+      warnings,
+      api,
+    );
+    if (intent.amount <= 0n) {
+      errors.amount = new AmountRequired();
+    }
+  }
+
+  validateFeeCoverage(estimatedFees, liquidBalance(balances), errors);
+
+  return {
+    errors,
+    warnings,
+    estimatedFees,
+    // No token leaves the account: approving grants an allowance, it does not spend it.
+    amount: 0n,
+    totalSpent: estimatedFees,
+  };
 }
 
 async function validateStakingIntent(
@@ -124,31 +308,42 @@ async function validateStakingIntent(
 
   const nativeBalance = balances.find(b => b.asset.type === "native");
   const available = (nativeBalance?.value ?? 0n) - (nativeBalance?.locked ?? 0n);
-  const nativeValue = nativeBalance?.value ?? 0n;
+  const liquid = liquidBalance(balances);
 
   let amount: bigint;
   let totalSpent: bigint;
 
   switch (intent.type) {
     case "stake.createAccount": {
+      await validateValidator(intent.recipient, errors, api);
       amount = await computeCreateAccountAmount(api, intent, available, estimatedFees, errors);
       totalSpent = amount + estimatedFees;
       break;
     }
     case "stake.delegate":
+      await validateDelegate(api, intent, balances, errors);
       amount = 0n;
       totalSpent = estimatedFees;
-      validateFeeCoverage(estimatedFees, available, errors);
+      validateFeeCoverage(estimatedFees, liquid, errors);
       break;
     case "stake.undelegate":
+      validateUndelegate(intent, balances, errors);
       amount = 0n;
       totalSpent = estimatedFees;
-      validateFeeCoverage(estimatedFees, nativeValue, errors);
+      validateFeeCoverage(estimatedFees, liquid, errors);
       break;
     case "stake.withdraw":
+      await validateWithdraw(api, intent, balances, errors);
       amount = clampPositive(intent.amount);
       totalSpent = estimatedFees;
-      validateFeeCoverage(estimatedFees, nativeValue, errors);
+      validateFeeCoverage(estimatedFees, liquid, errors);
+      break;
+    case "stake.split":
+      // Splitting moves lamports between two accounts the wallet owns; only the fee leaves it.
+      resolveStakeAccount(intentMemo(intent) || intent.recipient, balances, errors);
+      amount = clampPositive(intent.amount);
+      totalSpent = estimatedFees;
+      validateFeeCoverage(estimatedFees, liquid, errors);
       break;
     default:
       amount = intent.amount;
@@ -163,6 +358,164 @@ async function validateStakingIntent(
     amount,
     totalSpent,
   };
+}
+
+/** The stake account an intent acts on, as `getBalance` reported it. */
+function findStakeBalance(balances: Balance[], stakeAccAddr: string): Stake | undefined {
+  return balances.find(b => b.stake?.uid === stakeAccAddr)?.stake;
+}
+
+/** Resolves the stake account an intent targets, recording why it is unusable when it is. */
+function resolveStakeAccount(
+  stakeAccAddr: string | undefined,
+  balances: Balance[],
+  errors: Record<string, Error>,
+): Stake | undefined {
+  if (!stakeAccAddr) {
+    errors.stakeAccAddr = new SolanaStakeAccountRequired();
+    return undefined;
+  }
+  if (!isValidBase58Address(stakeAccAddr)) {
+    errors.stakeAccAddr = new InvalidAddress("", { currencyName: "Solana" });
+    return undefined;
+  }
+  const stake = findStakeBalance(balances, stakeAccAddr);
+  if (!stake) {
+    errors.stakeAccAddr = new SolanaStakeAccountNotFound();
+  }
+  return stake;
+}
+
+function stakeAuthority(stake: Stake): { canStake: boolean; canWithdraw: boolean } {
+  return {
+    canStake: stake.details?.canStake !== false,
+    canWithdraw: stake.details?.canWithdraw !== false,
+  };
+}
+
+async function validateValidator(
+  voteAccAddr: string | undefined,
+  errors: Record<string, Error>,
+  api: ChainAPI,
+): Promise<void> {
+  if (!voteAccAddr) {
+    errors.voteAccAddr = new SolanaValidatorRequired();
+    return;
+  }
+  if (!isValidBase58Address(voteAccAddr)) {
+    errors.voteAccAddr = new InvalidAddress("", { currencyName: "Solana" });
+    return;
+  }
+  const voteAcc = await getMaybeVoteAccount(voteAccAddr, api);
+  if (voteAcc instanceof Error || voteAcc === undefined) {
+    errors.voteAccAddr = new SolanaInvalidValidator();
+  }
+}
+
+/**
+ * Delegating covers both Activate (a never-delegated stake) and Reactivate (one still cooling
+ * down). Solana only lets the latter go back to the validator it is leaving.
+ */
+async function validateDelegate(
+  api: ChainAPI,
+  intent: TransactionIntent<StringMemo | MemoNotSupported>,
+  balances: Balance[],
+  errors: Record<string, Error>,
+): Promise<void> {
+  const stakeAccAddr = intentMemo(intent);
+  const stake = resolveStakeAccount(stakeAccAddr, balances, errors);
+
+  const { canStake, canWithdraw } = stake
+    ? stakeAuthority(stake)
+    : { canStake: true, canWithdraw: true };
+  if (stake && !canStake && !canWithdraw) {
+    errors.stakeAccAddr = new SolanaStakeNoStakeAuth();
+  }
+
+  // `craftDelegateFromIntent` prefers `valAddress` over `recipient`; validate what will be signed.
+  const valAddress = (intent as { valAddress?: string }).valAddress;
+  const voteAccAddr = valAddress || intent.recipient;
+  await validateValidator(voteAccAddr, errors, api);
+
+  if (!errors.voteAccAddr && stake) {
+    switch (stake.state) {
+      case "active":
+      case "activating":
+        errors.stakeAccAddr = new SolanaStakeAccountIsNotDelegatable();
+        break;
+      case "deactivating":
+        if (stake.delegate !== voteAccAddr) {
+          errors.stakeAccAddr = new SolanaStakeAccountValidatorIsUnchangeable();
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function validateUndelegate(
+  intent: TransactionIntent,
+  balances: Balance[],
+  errors: Record<string, Error>,
+): void {
+  const stake = resolveStakeAccount(intent.recipient, balances, errors);
+  if (!stake) return;
+
+  if (stake.state !== "active" && stake.state !== "activating") {
+    errors.stakeAccAddr = new SolanaStakeAccountIsNotUndelegatable();
+    return;
+  }
+  const { canStake, canWithdraw } = stakeAuthority(stake);
+  if (!canStake && !canWithdraw) {
+    errors.stakeAccAddr = new SolanaStakeNoStakeAuth();
+  }
+}
+
+async function validateWithdraw(
+  api: ChainAPI,
+  intent: TransactionIntent,
+  balances: Balance[],
+  errors: Record<string, Error>,
+): Promise<void> {
+  const stake = resolveStakeAccount(intent.recipient, balances, errors);
+  if (!stake || errors.stakeAccAddr) return;
+
+  if (!stakeAuthority(stake).canWithdraw) {
+    errors.stakeAccAddr = new SolanaStakeNoWithdrawAuth();
+    return;
+  }
+
+  // Read the live lamports rather than the synced ones: a stake account drained since the last
+  // sync would otherwise look withdrawable.
+  const stakeAccBalance = Number(await api.getBalance(intent.recipient));
+  const withdrawable = Math.max(
+    0,
+    withdrawableFromStake({
+      stakeAccBalance,
+      activation: {
+        // The framework also declares `withdrawable`, which on Solana means fully deactivated.
+        state: stake.state === "withdrawable" ? "inactive" : stake.state,
+        active: numericDetail(stake.details?.activeAmount),
+        // What the position holds beyond its effective stake is still warming up, as the legacy
+        // bridge derived it.
+        activating: Math.max(0, Number(stake.amount) - numericDetail(stake.details?.activeAmount)),
+      },
+      rentExemptReserve: numericDetail(stake.details?.lockedReserve),
+    }),
+  );
+  if (withdrawable <= 0) {
+    errors.stakeAccAddr = new SolanaStakeAccountNothingToWithdraw();
+  }
+}
+
+/** Parser helpers report a schema mismatch as an `Error`; that just means "not this kind". */
+function asAccountOrUndefined<T>(value: T | undefined | Error): T | undefined {
+  return value instanceof Error ? undefined : value;
+}
+
+function numericDetail(value: unknown): number {
+  return typeof value === "number" ? value : Number(value ?? 0);
 }
 
 function validateStakingRecipient(intent: TransactionIntent, errors: Record<string, Error>): void {
@@ -205,8 +558,14 @@ async function computeCreateAccountAmount(
     }
   };
 
+  // The reserve only covers the stake accounts the account already has (it is 0 when there
+  // are none), so the one being created needs its own or a first-time staker cannot unstake.
+  const reserve = await unstakeReserve(api, intent.sender);
+
   if (intent.useAllAmount) {
-    const allAmount = clampPositive(available - estimatedFees);
+    // The rent exemption is already inside this amount: `craftCreateStakeAccountFromIntent`
+    // subtracts it to get the delegated part.
+    const allAmount = clampPositive(available - estimatedFees - reserve);
     if (!errors.recipient && !errors.amount && allAmount > 0n) {
       const [stakeMinimumDelegation, stakeAccRentExempt] = await Promise.all([
         fetchStakeMinimumDelegation(),
@@ -225,7 +584,11 @@ async function computeCreateAccountAmount(
   }
   if (intent.amount <= 0n) {
     errors.amount = new AmountRequired();
-  } else if (intent.amount + estimatedFees > available) {
+  } else if (
+    // A typed amount is the delegated part; the stake account's rent sits on top of it.
+    intent.amount + estimatedFees + reserve + ((await fetchStakeAccountRentExempt()) ?? 0n) >
+    available
+  ) {
     errors.amount = new NotEnoughBalance();
   } else if (!errors.recipient) {
     const stakeMinimumDelegation = await fetchStakeMinimumDelegation();
@@ -236,30 +599,44 @@ async function computeCreateAccountAmount(
   return intent.amount;
 }
 
+/**
+ * What a token transfer really costs the sender: a Token-2022 mint levies its fee on top of the
+ * amount received, and both leave this account. `estimateFees` already computed it.
+ */
+function tokenAmountLeavingTheAccount(amount: bigint, customFees?: FeeEstimation): bigint {
+  const transferFee = customFees?.parameters?.transferFee as
+    | { feeBps?: number; transferAmountIncludingFee?: number }
+    | undefined;
+  if (!transferFee?.feeBps || transferFee.transferAmountIncludingFee === undefined) return amount;
+  return BigInt(transferFee.transferAmountIncludingFee);
+}
+
+/**
+ * Lamports the account actually holds, stake accounts excluded. `value` counts them in and `locked`
+ * takes out the reserve that exists to pay these very fees, so neither answers "can this account
+ * afford the fee". The account's rent exemption is not deducted -- it is not exposed here, and
+ * erring on the permissive side only risks a chain-side failure, where erring the other way would
+ * block a legitimate undelegate.
+ */
+function liquidBalance(balances: Balance[]): bigint {
+  const native = balances.find(b => b.asset.type === "native");
+  const staked = balances.reduce((sum, b) => (b.stake ? sum + b.value : sum), 0n);
+  return (native?.value ?? 0n) - staked;
+}
+
+/** Keyed on `fee`, which is what the staking screens render (`StepValidator`, `StepAmount`). */
 function validateFeeCoverage(
   estimatedFees: bigint,
   balance: bigint,
   errors: Record<string, Error>,
 ): void {
   if (estimatedFees > balance) {
-    errors.amount = new NotEnoughBalance();
+    errors.fee = new NotEnoughBalance();
   }
 }
 
 function clampPositive(value: bigint): bigint {
   return value > 0n ? value : 0n;
-}
-
-function validateRecipient(intent: TransactionIntent, errors: Record<string, Error>): void {
-  if (!intent.recipient) {
-    errors.recipient = new RecipientRequired("");
-  } else if (intent.sender === intent.recipient) {
-    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
-  } else if (!isValidBase58Address(intent.recipient)) {
-    errors.recipient = new InvalidAddress("", {
-      currencyName: intent.asset?.name ?? "Solana",
-    });
-  }
 }
 
 function computeAmount(
@@ -273,7 +650,8 @@ function computeAmount(
   }
 
   if (isTokenTransfer) {
-    return findBalance(intent.asset, balances).value;
+    const tokenBalance = findBalance(intent.asset, balances);
+    return tokenBalance.value - (tokenBalance.locked ?? 0n);
   }
 
   const nativeBalance = balances.find(b => b.asset.type === "native");
@@ -296,7 +674,11 @@ function validateAmount(
   }
 
   if (isTokenTransfer) {
-    if (amount > findBalance(intent.asset, balances).value) {
+    // `locked` covers a frozen token account, whose funds cannot be transferred at all.
+    // `amount <= 0n` is reachable on a send-all whose whole balance is frozen: the guard above
+    // lets `useAllAmount` through, and the native branch only catches it via the fee comparison.
+    const tokenBalance = findBalance(intent.asset, balances);
+    if (amount <= 0n || amount > tokenBalance.value - (tokenBalance.locked ?? 0n)) {
       errors.amount = new NotEnoughBalance();
     }
   } else {
@@ -328,4 +710,170 @@ function assetsAreEqual(asset1: AssetInfo, asset2: AssetInfo): boolean {
 
 function findBalance(asset: AssetInfo, balances: Balance[]): Balance {
   return balances.find(b => assetsAreEqual(b.asset, asset)) ?? { asset, value: 0n };
+}
+
+async function isAccountFunded(address: string, api: ChainAPI): Promise<boolean> {
+  return (await api.getBalance(address)) > 0;
+}
+
+function validateAssociatedTokenAccountState(
+  tokenAcc: SolanaTokenAccount | TokenAccountInfo,
+): undefined | Error {
+  if (tokenAcc.state === "frozen") {
+    return new SolanaTokenAccountFrozen();
+  }
+  // do not check initialized state on ledger accounts
+  if (!("id" in tokenAcc) && tokenAcc.state !== "initialized") {
+    return new SolanaTokenAccounNotInitialized();
+  }
+}
+
+function validateRecipientRequiredMemo(
+  memo: string | undefined,
+  recipientAccInfo: TokenAccountInfo,
+  errors: Record<string, Error>,
+): void {
+  if (!recipientAccInfo.extensions) return;
+
+  const isRecipientMemoRequired = recipientAccInfo.extensions.some(
+    ext =>
+      ext.extension === "memoTransfer" &&
+      (ext as MemoTransferExt).state.requireIncomingTransferMemos,
+  );
+  if (isRecipientMemoRequired && !memo) {
+    errors.memo = new SolanaRecipientMemoIsRequired();
+    // LLM expects <transaction> as error key to disable continue button
+    errors.transaction = errors.memo;
+  }
+}
+
+/**
+ * Recipient checks common to native and token transfers: reject token and mint accounts typed in
+ * as a wallet address, and warn about an unfunded or off-curve destination.
+ *
+ * `allowATA` is true for token transfers, where an associated token account is a legitimate
+ * destination as long as it is not itself a wallet address.
+ */
+async function validateRecipientCommon(
+  {
+    sender,
+    recipient,
+    currencyName,
+    allowATA,
+  }: { sender: string; recipient: string; currencyName: string; allowATA: boolean },
+  errors: Record<string, Error>,
+  warnings: Record<string, Error>,
+  api: ChainAPI,
+): Promise<void> {
+  if (!recipient) {
+    errors.recipient = new RecipientRequired();
+    return;
+  }
+  if (sender === recipient) {
+    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+    return;
+  }
+  if (!isValidBase58Address(recipient)) {
+    errors.recipient = new InvalidAddress("", { currencyName });
+    return;
+  }
+
+  const recipientWalletIsUnfunded = !(await isAccountFunded(recipient, api));
+
+  // An `Error` from these parsers means the account did not match the schema — it simply is not a
+  // token/mint account. Throwing would abort the whole status computation over an ordinary address.
+  const recipientTokenAccount = asAccountOrUndefined(await getMaybeTokenAccount(recipient, api));
+
+  if (recipientTokenAccount) {
+    if (allowATA && !isEd25519Address(recipient)) {
+      warnings.recipient = new SolanaTokenAccountWarning();
+    } else {
+      errors.recipient = new SolanaTokenAccountNotAllowed();
+    }
+  }
+
+  const mintTokenAccount = asAccountOrUndefined(await getMaybeMintAccount(recipient, api));
+  if (mintTokenAccount) {
+    errors.recipient = new SolanaMintAccountNotAllowed();
+  }
+
+  if (recipientWalletIsUnfunded) {
+    warnings.recipient = new SolanaAccountNotFunded();
+  }
+  if (!isEd25519Address(recipient)) {
+    warnings.recipientOffCurve = new SolanaAddressOffEd25519();
+  }
+}
+
+/**
+ * Resolves where an SPL transfer should actually land: the recipient's own token account when one
+ * was typed in, or its associated token account otherwise — creating the latter if it is missing.
+ */
+async function getTokenRecipient(
+  recipientAddress: string,
+  mintAddress: string,
+  tokenProgram: SolanaTokenProgram,
+  api: ChainAPI,
+): Promise<
+  { descriptor: TokenRecipientDescriptor; recipientAccInfo: TokenAccountInfo | undefined } | Error
+> {
+  const recipientTokenAccount = asAccountOrUndefined(
+    await getMaybeTokenAccount(recipientAddress, api),
+  );
+
+  if (recipientTokenAccount === undefined) {
+    if (!isEd25519Address(recipientAddress)) {
+      return new SolanaAddressOffEd25519();
+    }
+
+    const recipientAssociatedTokenAccountAddress = await api.findAssocTokenAccAddress(
+      recipientAddress,
+      mintAddress,
+      tokenProgram,
+    );
+
+    const shouldCreateAsAssociatedTokenAccount = !(await isAccountFunded(
+      recipientAssociatedTokenAccountAddress,
+      api,
+    ));
+
+    let associatedTokenAccount;
+
+    if (!shouldCreateAsAssociatedTokenAccount) {
+      associatedTokenAccount = asAccountOrUndefined(
+        await getMaybeTokenAccount(recipientAssociatedTokenAccountAddress, api),
+      );
+      // The account is funded, so it exists; if it cannot be read there is no state to object to.
+      const stateErrorOrUndefined = associatedTokenAccount
+        ? validateAssociatedTokenAccountState(associatedTokenAccount)
+        : undefined;
+      if (stateErrorOrUndefined) return stateErrorOrUndefined;
+    }
+
+    return {
+      descriptor: {
+        walletAddress: recipientAddress,
+        shouldCreateAsAssociatedTokenAccount,
+        tokenAccAddress: recipientAssociatedTokenAccountAddress,
+        userInputType: UserInputType.SOL,
+      },
+      recipientAccInfo: associatedTokenAccount,
+    };
+  }
+
+  if (recipientTokenAccount.mint.toBase58() !== mintAddress) {
+    return new SolanaTokenAccountHoldsAnotherToken();
+  }
+  const stateErrorOrUndefined = validateAssociatedTokenAccountState(recipientTokenAccount);
+  if (stateErrorOrUndefined) return stateErrorOrUndefined;
+
+  return {
+    descriptor: {
+      walletAddress: recipientTokenAccount.owner.toBase58(),
+      shouldCreateAsAssociatedTokenAccount: false,
+      tokenAccAddress: recipientAddress,
+      userInputType: UserInputType.ATA,
+    },
+    recipientAccInfo: recipientTokenAccount,
+  };
 }

--- a/libs/coin-modules/coin-solana/src/types.ts
+++ b/libs/coin-modules/coin-solana/src/types.ts
@@ -11,6 +11,7 @@ import {
   TransactionStatusCommon,
   TransactionStatusCommonRaw,
 } from "@ledgerhq/types-live";
+import type { TxData } from "@ledgerhq/coin-module-framework/api/index";
 import BigNumber from "bignumber.js";
 import { TokenAccountState } from "./network/chain/account/token";
 import { PARSED_PROGRAMS } from "./network/chain/program/constants";
@@ -361,3 +362,21 @@ export type SolanaExtraDeviceTransactionField = {
   type: "solana.token.transferFee";
   label: string;
 };
+
+/**
+ * Carries a transaction a partner already built — today LiFi's swap payload, reached through
+ * `Transaction.raw`. The intent's `type`, `recipient` and `amount` describe nothing in that case:
+ * the bytes are the transaction, and crafting only refreshes their blockhash.
+ *
+ * `type: "solana"` satisfies the framework's `TxData` discriminant; the send/staking intents keep
+ * emitting `{ type: "none" }`.
+ */
+export interface SolanaTxData extends TxData {
+  type: "solana";
+  /** Base64 `VersionedTransaction`. Absent when the data only carries the seed below. */
+  raw?: string;
+  /** Round-trip carrier for the partner's template id; nothing in coin-solana reads it. */
+  templateId?: string;
+  /** Seed the fee estimation drew, so the craft derives the address the wallet displayed. */
+  stakeAccountSeed?: string;
+}


### PR DESCRIPTION
### 📝 Description

Split out of #21231, the largest independent slice: the Solana coin-module logic the generic coin framework calls — crafting, fee estimation, intent validation, operation listing, balances and stakes — brought up to what the legacy bridge already does.

**Why this is safe to merge on its own.** Every module here is reached only through `api/index.ts`, and `bridge/impl.ts:52` gates that path behind `shouldUseGenericCoinFrameworkBridge`. With `solana: false` it is never taken, so none of this runs for Solana today.

That claim was checked per entry point rather than assumed. The legacy bridge does import from three files in this diff, and in each case the symbol it imports is untouched:

| module | legacy imports | changed here |
|---|---|---|
| `logic/estimateFees` | `estimateTxFee` | no — byte-identical |
| `logic/craftTransaction` | `buildVersionedTransaction` | no — byte-identical |
| `logic/validateMemo` | `MAX_MEMO_LENGTH`, `validateMemo` | file not in this PR |

`logic/broadcast`, `synchronization.ts` and `logic/tokenAccountShapes` do change legacy-visible behaviour, so they stay in #21231.

`types.ts` gains `SolanaTxData` only. The removal of `SolanaExtraDeviceTransactionField` belongs with the legacy `deviceTransactionConfig.ts` deletion and stays in #21231 too.

Caveat worth stating plainly: inert also means unexercised. This lands on `develop` without anything running it until the family flag flips.

### 🔗 Conflict with #21593

`validateIntent.integ.test.ts` conflicted with #21593, which landed a fix for the same stale rent figure. Resolved in favour of reading the value from the chain, since this file needs it at runtime anyway. #21593's SIMD-0437 rationale is kept, condensed — its schedule has four more steps between mid-Sep and Nov 2026, so a pinned figure needs revisiting at each one.

### ✅ Checks

coin-solana 545/545 unit, 27/27 integration. `tsc`, `oxlint`, `oxfmt`, `unimported` clean. live-common `tsc` matches the `develop` baseline exactly (2 pre-existing errors in `families/casper/bridge/mock.test.ts`, untouched here).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35692](https://ledgerhq.atlassian.net/browse/LIVE-35692)

[LIVE-35692]: https://ledgerhq.atlassian.net/browse/LIVE-35692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ