### PR TITLE
fix(contacts): fix intro sheet layout on all devices (LIVE-36992)

### DIFF
--- a/.changeset/calm-contacts-intro-footer.md
+++ b/.changeset/calm-contacts-intro-footer.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts-introduction": minor
+"live-mobile": minor
+---
+
+Pin the Contacts feature introduction CTA to the bottom of the mobile sheet

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
@@ -16,7 +16,8 @@ export function ContactsFeatureIntroductionSheet({
   onClose: onCloseCallback,
   ...contentProps
 }: ContactsFeatureIntroductionSheetProps): React.JSX.Element {
-  const { bottom: bottomInset } = useSafeAreaInsets();
+  const { bottom } = useSafeAreaInsets();
+  const bottomInset = Platform.OS === "ios" ? bottom : 0;
   const { complete, onClose } = useContactsFeatureIntroductionActions({
     isOpen,
     onComplete,
@@ -30,9 +31,7 @@ export function ContactsFeatureIntroductionSheet({
       onHeaderClosePressed={onClose}
       onBackdropPress={onClose}
       testID="contacts-feature-introduction-drawer"
-      enableDynamicSizing
-      // iOS: allow the sheet to grow with content; uncapped on Android to avoid excess empty space.
-      maxDynamicContentSize={Platform.OS === "ios" ? "fullWithOffset" : undefined}
+      snapPoints="fullWithOffset"
     >
       <ContactsFeatureIntroductionContent
         isOpen={isOpen}

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionContent.native.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionContent.native.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Image, type ImageSourcePropType } from "react-native";
 import {
+  BottomSheetFooter,
   BottomSheetHeader,
-  BottomSheetView,
+  BottomSheetScrollView,
   Box,
   Button,
   ListItem,
@@ -24,87 +25,82 @@ export function ContactsFeatureIntroductionContent({
   heroImageSrc,
   bottomInset,
   onComplete,
-}: ContactsFeatureIntroductionContentProps): React.JSX.Element {
+}: ContactsFeatureIntroductionContentProps): React.JSX.Element | null {
+  if (!isOpen) {
+    return null;
+  }
+
   const heroImage = heroImageSrc ?? CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE;
 
   return (
-    <BottomSheetView
-      style={{
-        paddingHorizontal: 0,
-        paddingBottom: bottomInset + 24,
-      }}
-    >
-      {isOpen ? (
-        <>
-          <BottomSheetHeader spacing />
+    <>
+      <BottomSheetHeader spacing />
+      <BottomSheetScrollView
+        testID="contacts-feature-introduction-content"
+        alwaysBounceVertical={false}
+        showsVerticalScrollIndicator={false}
+      >
+        <Box lx={{ gap: "s16", paddingBottom: "s16" }}>
           <Box
-            testID="contacts-feature-introduction-content"
-            style={{ flex: 1, minHeight: 679 }}
-            lx={{ justifyContent: "space-between", paddingHorizontal: "s16" }}
+            testID="contacts-feature-introduction-hero"
+            style={{
+              height: 192,
+              width: "100%",
+              borderRadius: 24,
+              overflow: "hidden",
+            }}
+            lx={{ backgroundColor: "muted" }}
           >
-            <Box lx={{ gap: "s16" }}>
-              <Box
-                testID="contacts-feature-introduction-hero"
-                style={{
-                  height: 192,
-                  width: "100%",
-                  borderRadius: 24,
-                  overflow: "hidden",
-                }}
-                lx={{ backgroundColor: "muted" }}
-              >
-                <Image
-                  testID="contacts-feature-introduction-hero-image"
-                  source={heroImage as ImageSourcePropType}
-                  accessibilityIgnoresInvertColors
-                  style={{ width: "100%", height: "100%" }}
-                  resizeMode="cover"
-                />
-              </Box>
-              <Box lx={{ gap: "s4" }}>
-                <Box lx={{ gap: "s8", paddingBottom: "s8" }}>
-                  <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-                    {title}
-                  </Text>
-                </Box>
-                <Box>
-                  {highlights.map(highlight => {
-                    const HighlightIcon = Icons[highlight.icon];
-
-                    return (
-                      <ListItem
-                        key={highlight.icon}
-                        density="expanded"
-                        testID={`contacts-feature-introduction-highlight-${highlight.icon}`}
-                        lx={{ marginHorizontal: "-s8" }}
-                      >
-                        <ListItemLeading>
-                          <HighlightIcon size={24} />
-                          <ListItemContent>
-                            <ListItemTitle>{highlight.title}</ListItemTitle>
-                            <ListItemDescription>{highlight.description}</ListItemDescription>
-                          </ListItemContent>
-                        </ListItemLeading>
-                      </ListItem>
-                    );
-                  })}
-                </Box>
-              </Box>
+            <Image
+              testID="contacts-feature-introduction-hero-image"
+              source={heroImage as ImageSourcePropType}
+              accessibilityIgnoresInvertColors
+              style={{ width: "100%", height: "100%" }}
+              resizeMode="cover"
+            />
+          </Box>
+          <Box lx={{ gap: "s4" }}>
+            <Box lx={{ gap: "s8", paddingBottom: "s8" }}>
+              <Text typography="heading3SemiBold" lx={{ color: "base" }}>
+                {title}
+              </Text>
             </Box>
-            <Box lx={{ gap: "s16", paddingTop: "s12" }}>
-              <Button
-                appearance="base"
-                size="lg"
-                isFull
-                onPress={onComplete}
-                testID="contacts-feature-introduction-primary"
-              >
-                {primaryActionLabel}
-              </Button>
+            <Box>
+              {highlights.map(highlight => {
+                const HighlightIcon = Icons[highlight.icon];
+
+                return (
+                  <ListItem
+                    key={highlight.icon}
+                    density="expanded"
+                    testID={`contacts-feature-introduction-highlight-${highlight.icon}`}
+                    lx={{ marginHorizontal: "-s8" }}
+                  >
+                    <ListItemLeading>
+                      <HighlightIcon size={24} />
+                      <ListItemContent>
+                        <ListItemTitle>{highlight.title}</ListItemTitle>
+                        <ListItemDescription>{highlight.description}</ListItemDescription>
+                      </ListItemContent>
+                    </ListItemLeading>
+                  </ListItem>
+                );
+              })}
             </Box>
           </Box>
-        </>
-      ) : null}
-    </BottomSheetView>
+        </Box>
+      </BottomSheetScrollView>
+      <BottomSheetFooter style={{ paddingBottom: bottomInset + 24 }}>
+        <Button
+          appearance="base"
+          size="lg"
+          isFull
+          onPress={onComplete}
+          testID="contacts-feature-introduction-primary"
+        >
+          {primaryActionLabel}
+        </Button>
+      </BottomSheetFooter>
+    </>
   );
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On large phones, the Contacts feature introduction CTA sat under the content instead of at the bottom of the sheet, so there was a large empty gap and missing bottom padding ([LIVE-36992](https://ledgerhq.atlassian.net/browse/LIVE-36992)).

The sheet now uses a full-height snap point with a Lumen `BottomSheetScrollView` and a sibling `BottomSheetFooter`, so **Explore now** stays pinned to the bottom on every device size. Scroll bounce is disabled when the content already fits. Footer padding is `bottomInset + 24`, matching the other Contacts bottom sheets.

**Before**            

https://github.com/user-attachments/assets/31e397b4-d901-4c23-9c35-54467ec499c3


**After**

https://github.com/user-attachments/assets/ac6eba8a-f0f5-4002-9b13-aded03631690







### 🔗 Context

- **JIRA issue**: [LIVE-36992](https://ledgerhq.atlassian.net/browse/LIVE-36992)
- **ADR** (if any): n/a

[LIVE-36992]: https://ledgerhq.atlassian.net/browse/LIVE-36992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36992]: https://ledgerhq.atlassian.net/browse/LIVE-36992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ