### PR TITLE
[LWDM] fix(send): stay on the same Send after MAD from New

### DIFF
--- a/.changeset/reuse-send-after-mad.md
+++ b/.changeset/reuse-send-after-mad.md
@@ -1,5 +1,6 @@
 ---
 "live-mobile": patch
+"@ledgerhq/live-common": patch
 ---
 
 Keep Pay New on the same Send after MAD instead of opening a second flow.

--- a/.changeset/reuse-send-after-mad.md
+++ b/.changeset/reuse-send-after-mad.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Keep Pay New on the same Send after MAD instead of opening a second flow.

--- a/.changeset/reuse-send-after-mad.md
+++ b/.changeset/reuse-send-after-mad.md
@@ -4,3 +4,4 @@
 ---
 
 Keep Pay New on the same Send after MAD instead of opening a second flow.
+With no one else to pay, open normal Send so the To bar can add a contact.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/context/SendFlowContext.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/context/SendFlowContext.tsx
@@ -45,7 +45,11 @@ type ActionsContextValue = Readonly<{
   operation: SendFlowOperationActions;
   status: FlowStatusActions;
   close: () => void;
-  setAccountAndNavigate: (account: AccountLike, parentAccount?: Account) => void;
+  setAccountAndNavigate: (
+    account: AccountLike,
+    parentAccount?: Account,
+    recipientAddress?: string,
+  ) => void | Promise<void>;
   setIsRecipientAddressComplete: (value: boolean) => void;
 }>;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -524,8 +524,10 @@ describe("PayTab integration", () => {
       await user.press(await screen.findByTestId("asset-item-ETH"));
       await user.press(await screen.findByTestId("account-item"));
 
-      expect(await screen.findByTestId("disabled-amount-continue-button")).toBeVisible();
-      expect(screen.getByText("Contact 0")).toBeVisible();
+      expect(await screen.findByTestId("enabled-amount-continue-button")).toBeVisible();
+      expect(
+        within(screen.getByTestId("recipient-contact-row")).getByText("Contact 0"),
+      ).toBeVisible();
     });
 
     it("should open send from New when some contacts have no address", async () => {
@@ -544,17 +546,29 @@ describe("PayTab integration", () => {
       expect(screen.queryByText("Me")).not.toBeOnTheScreen();
     });
 
-    it("should open send without Me from New when there is no one else to pay", async () => {
+    it("should open send recipient search from New when there is no one else to pay", async () => {
       const { user, store } = renderPayTab({
         contacts: [mockMeContact()],
         contactsEnabled: true,
+        cryptoOnly: true,
       });
 
       await user.press(await screen.findByRole("button", { name: "New" }));
 
-      expect(await screen.findByTestId("send-recipient-contacts-list")).toBeVisible();
+      await waitFor(() => {
+        expect(store.getState().modularDrawer).toMatchObject({
+          isOpen: true,
+          flow: "send",
+          source: "Pay",
+        });
+      });
+      expect(screen.queryByTestId("send-recipient-contacts-list")).not.toBeOnTheScreen();
       expect(screen.queryByText("Me")).not.toBeOnTheScreen();
-      expect(store.getState().modularDrawer.isOpen).toBe(false);
+
+      await user.press(await screen.findByTestId("asset-item-ETH"));
+      await user.press(await screen.findByTestId("account-item"));
+
+      expect(await screen.findByPlaceholderText("Enter address, ENS or contact")).toBeVisible();
     });
 
     it("should open send from New when no contact has an address", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -3,6 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { Contact, ContactAddress } from "@domain/entity-contact";
 import type { ContactAddressPickerProps } from "@features/flow-pay-contact";
+import { useContacts } from "@features/platform-contacts";
 import { useContactAddressPicker } from "LLM/features/Contacts/hooks/useContactAddressPicker";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
 import { NavigatorName } from "~/const";
@@ -15,6 +16,8 @@ export type UsePayTabNewPayment = Readonly<{
 
 export function usePayTabNewPayment(): UsePayTabNewPayment {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const contacts = useContacts();
+  const hasSomeoneToPay = contacts.some(contact => !contact.isMe);
   const { handleOpenSendFlow } = useOpenSendFlow({
     sourceScreenName: "Pay",
   });
@@ -36,15 +39,19 @@ export function usePayTabNewPayment(): UsePayTabNewPayment {
   const open = useCallback(
     (nextContact?: Contact) => {
       if (!nextContact) {
-        navigation.navigate(NavigatorName.SendFlow, {
-          params: { selectContactBeforeAccount: true },
-        });
+        if (hasSomeoneToPay) {
+          navigation.navigate(NavigatorName.SendFlow, {
+            params: { selectContactBeforeAccount: true },
+          });
+          return;
+        }
+        handleOpenSendFlow();
         return;
       }
 
       openPicker(nextContact);
     },
-    [openPicker, navigation],
+    [handleOpenSendFlow, hasSomeoneToPay, openPicker, navigation],
   );
 
   return { open, contactAddressPicker };

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendContactsFirst.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendContactsFirst.integration.test.tsx
@@ -231,6 +231,7 @@ describe("Send contacts-first", () => {
     await user.press(await screen.findByTestId("asset-item-ETH"));
     await user.press(await screen.findByTestId("account-item"));
 
-    expect(await screen.findByText(`send:${ethAccount.id}`)).toBeVisible();
+    expect(await screen.findByTestId("disabled-amount-continue-button")).toBeVisible();
+    expect(screen.queryByText(`send:${ethAccount.id}`)).not.toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendContactsFirst.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendContactsFirst.integration.test.tsx
@@ -11,9 +11,11 @@ import {
 } from "@domain/entity-contact/schema.mock";
 import { SEND_FLOW_STEP, type SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
 import type { StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
+import type { Account } from "@ledgerhq/types-live";
+import { BigNumber } from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { renderWithReactQuery, screen, withFlagOverrides } from "@tests/test-renderer";
+import { renderWithReactQuery, screen, withFlagOverrides, within } from "@tests/test-renderer";
 import { NavigatorName, ScreenName } from "~/const";
 import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
 import { SEND_FLOW_CONFIG } from "../constants";
@@ -25,9 +27,19 @@ import { CustomFeesScreen } from "../screens/CustomFees";
 import { RecipientScreen } from "../screens/Recipient";
 import { SignatureScreen } from "../screens/Signature";
 
-const ethAccount = genAccount("contacts-first-eth", {
-  currency: getCryptoCurrencyById("ethereum"),
-});
+const ethereum = getCryptoCurrencyById("ethereum");
+const ethAccount = {
+  ...genAccount("contacts-first-eth", { currency: ethereum }),
+  balance: new BigNumber(2),
+  spendableBalance: new BigNumber(2),
+  subAccounts: [],
+};
+const ethAccountB = {
+  ...genAccount("contacts-first-eth-b", { currency: ethereum }),
+  balance: new BigNumber(1),
+  spendableBalance: new BigNumber(1),
+  subAccounts: [],
+};
 
 type TestStackParamList = {
   PayHost: undefined;
@@ -108,7 +120,10 @@ function SendFlowScreen({
   );
 }
 
-function renderContactsFirstSend(contacts: readonly Contact[]) {
+function renderContactsFirstSend(
+  contacts: readonly Contact[],
+  accounts: readonly Account[] = [ethAccount],
+) {
   return renderWithReactQuery(
     <>
       <Stack.Navigator
@@ -133,11 +148,12 @@ function renderContactsFirstSend(contacts: readonly Contact[]) {
             enabled: true,
             params: { families: ["evm"], excludedCurrencyIds: [] },
           },
+          lwmContacts: { enabled: true, params: { newBadge: false } },
         },
         state => ({
           ...state,
           contacts: { contacts: [...contacts] },
-          accounts: { active: [{ ...ethAccount, subAccounts: [] }] },
+          accounts: { active: [...accounts] },
         }),
       ),
     },
@@ -231,7 +247,23 @@ describe("Send contacts-first", () => {
     await user.press(await screen.findByTestId("asset-item-ETH"));
     await user.press(await screen.findByTestId("account-item"));
 
-    expect(await screen.findByTestId("disabled-amount-continue-button")).toBeVisible();
+    expect(await screen.findByTestId("recipient-contact-row")).toBeVisible();
+    expect(within(screen.getByTestId("recipient-contact-row")).getByText("Yana")).toBeVisible();
     expect(screen.queryByText(`send:${ethAccount.id}`)).not.toBeOnTheScreen();
+  });
+
+  it("should keep the recipient when the second debit account is selected", async () => {
+    const yana = mockContactWithAddress({ id: "contact-yana", name: "Yana" });
+    const address = yana.addresses[0];
+    const { user } = renderContactsFirstSend([yana], [ethAccount, ethAccountB]);
+
+    await user.press(await screen.findByText("Yana"));
+    await user.press(await screen.findByLabelText(`${address.label}, ${address.address}`));
+    await user.press(await screen.findByTestId("asset-item-ETH"));
+    const accounts = await screen.findAllByTestId("account-item");
+    await user.press(accounts[1]);
+
+    expect(await screen.findByTestId("recipient-contact-row")).toBeVisible();
+    expect(within(screen.getByTestId("recipient-contact-row")).getByText("Yana")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendContactsFirst.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendContactsFirst.integration.test.tsx
@@ -233,7 +233,7 @@ describe("Send contacts-first", () => {
   it("should hide Me when only Me is saved", async () => {
     renderContactsFirstSend([mockMeContact({ name: "Me" })]);
 
-    expect(await screen.findByTestId("send-recipient-contacts-list")).toBeVisible();
+    expect(screen.queryByTestId("send-recipient-contacts-list")).not.toBeOnTheScreen();
     expect(screen.queryByText("Me")).not.toBeOnTheScreen();
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/context/SendFlowContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/context/SendFlowContext.tsx
@@ -28,7 +28,11 @@ type ActionsContextValue = Readonly<{
   operation: SendFlowOperationActions;
   status: FlowStatusActions;
   close: () => void;
-  setAccountAndNavigate: (account: AccountLike, parentAccount?: Account) => void;
+  setAccountAndNavigate: (
+    account: AccountLike,
+    parentAccount?: Account,
+    recipientAddress?: string,
+  ) => void | Promise<void>;
   setRecipientSearchValue: (value: string) => void;
   clearRecipientSearch: () => void;
 }>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
@@ -114,7 +114,7 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
     [openPicker],
   );
 
-  if (selectContactBeforeAccount) {
+  if (selectContactBeforeAccount && contacts.length > 0) {
     return {
       ready: true,
       mode: "selectContactBeforeAccount",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
@@ -6,7 +6,7 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useContacts } from "@features/platform-contacts";
 import { useNavigation } from "@react-navigation/native";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { ScreenName } from "~/const";
 import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
 import { useContactAddressPicker } from "LLM/features/Contacts/hooks/useContactAddressPicker";
@@ -51,7 +51,6 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
   const storedContacts = useContacts();
   const contacts = useMemo(() => storedContacts.filter(contact => !contact.isMe), [storedContacts]);
   const { openDrawer } = useModularDrawerController();
-  const [pendingRecipientAddress, setPendingRecipientAddress] = useState<string>();
 
   const account = state.account.account;
   const parentAccount = state.account.parentAccount ?? null;
@@ -93,22 +92,16 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
         enableAccountSelection: true,
         uiUseCase: PAY_ACCOUNT_UI_USE_CASE,
         onAccountSelected: (selectedAccount, selectedParentAccount) => {
-          setPendingRecipientAddress(address.address);
-          setAccountAndNavigate(selectedAccount, selectedParentAccount);
-          goToAmount();
+          void Promise.resolve(
+            setAccountAndNavigate(selectedAccount, selectedParentAccount, address.address),
+          ).then(() => {
+            goToAmount();
+          });
         },
       });
     },
     [goToAmount, openDrawer, setAccountAndNavigate],
   );
-
-  useEffect(() => {
-    if (!pendingRecipientAddress || !state.transaction.transaction) {
-      return;
-    }
-    transaction.setRecipient({ address: pendingRecipientAddress });
-    setPendingRecipientAddress(undefined);
-  }, [pendingRecipientAddress, state.transaction.transaction, transaction]);
 
   const { open: openPicker, contactAddressPicker } = useContactAddressPicker({
     onSelectAddress,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
@@ -6,11 +6,12 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useContacts } from "@features/platform-contacts";
 import { useNavigation } from "@react-navigation/native";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ScreenName } from "~/const";
 import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
 import { useContactAddressPicker } from "LLM/features/Contacts/hooks/useContactAddressPicker";
-import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
+import { useModularDrawerController } from "LLM/features/ModularDrawer";
+import { PAY_ACCOUNT_UI_USE_CASE } from "LLM/features/ModularDrawer/types";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import type { SendFlowNavigationProp } from "../../../types";
 
@@ -45,13 +46,12 @@ export type RecipientScreenViewModel =
 
 export function useRecipientScreenViewModel(): RecipientScreenViewModel {
   const { state, uiConfig, recipientSearch, selectContactBeforeAccount } = useSendFlowData();
-  const { transaction } = useSendFlowActions();
+  const { transaction, setAccountAndNavigate } = useSendFlowActions();
   const navigation = useNavigation<BaseNavigationComposite<SendFlowNavigationProp>>();
   const storedContacts = useContacts();
   const contacts = useMemo(() => storedContacts.filter(contact => !contact.isMe), [storedContacts]);
-  const { handleOpenSendFlow } = useOpenSendFlow({
-    sourceScreenName: "Pay",
-  });
+  const { openDrawer } = useModularDrawerController();
+  const [pendingRecipientAddress, setPendingRecipientAddress] = useState<string>();
 
   const account = state.account.account;
   const parentAccount = state.account.parentAccount ?? null;
@@ -85,14 +85,30 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
 
   const onSelectAddress = useCallback(
     (address: ContactAddress) => {
-      handleOpenSendFlow({
-        currencyIds: [address.currencyId],
-        recipient: address.address,
-        skipRecipientStep: true,
+      openDrawer({
+        currencies: [address.currencyId],
+        flow: "send",
+        source: "Pay",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: true,
+        uiUseCase: PAY_ACCOUNT_UI_USE_CASE,
+        onAccountSelected: (selectedAccount, selectedParentAccount) => {
+          setPendingRecipientAddress(address.address);
+          setAccountAndNavigate(selectedAccount, selectedParentAccount);
+          goToAmount();
+        },
       });
     },
-    [handleOpenSendFlow],
+    [goToAmount, openDrawer, setAccountAndNavigate],
   );
+
+  useEffect(() => {
+    if (!pendingRecipientAddress || !state.transaction.transaction) {
+      return;
+    }
+    transaction.setRecipient({ address: pendingRecipientAddress });
+    setPendingRecipientAddress(undefined);
+  }, [pendingRecipientAddress, state.transaction.transaction, transaction]);
 
   const { open: openPicker, contactAddressPicker } = useContactAddressPicker({
     onSelectAddress,
@@ -105,11 +121,7 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
     [openPicker],
   );
 
-  if (!account || !currency) {
-    if (!selectContactBeforeAccount) {
-      return { ready: false };
-    }
-
+  if (selectContactBeforeAccount) {
     return {
       ready: true,
       mode: "selectContactBeforeAccount",
@@ -117,6 +129,10 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
       onSelectContact,
       contactAddressPicker,
     };
+  }
+
+  if (!account || !currency) {
+    return { ready: false };
   }
 
   return {

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
@@ -28,7 +28,7 @@ export type Result<T extends Transaction = Transaction> = {
   updateTransaction: (updater: (arg0: T) => T) => void;
   account: AccountLike | null | undefined;
   parentAccount: Account | null | undefined;
-  setAccount: (arg0: AccountLike, arg1: Account | null | undefined) => Promise<void>;
+  setAccount: (arg0: AccountLike, arg1?: Account | null, recipient?: string) => Promise<void>;
   updateAccount: (account: AccountLike) => void;
   status: TransactionStatus;
   bridgeError: Error | null | undefined;
@@ -41,6 +41,7 @@ type Actions<T extends Transaction = Transaction> =
       account: AccountLike;
       parentAccount: Account | null | undefined;
       bridge: AccountBridge<any>;
+      recipient?: string;
     }
   | {
       type: "setTransaction";
@@ -169,6 +170,11 @@ const reducer = <T extends Transaction = Transaction>(
           t = { ...t, subAccountId };
         }
 
+        const recipient = action.recipient ?? state.transaction?.recipient;
+        if (recipient) {
+          t = bridge.updateTransaction(t, { recipient });
+        }
+
         return {
           ...initial,
           account,
@@ -256,13 +262,14 @@ const useBridgeTransaction = <T extends Transaction = Transaction>(
   ] = useReducer(reducer as Reducer<T>, undefined, makeInit(bridge, optionalInit));
 
   const setAccount = useCallback(
-    async (account, parentAccount) => {
+    async (account, parentAccount, recipient?: string) => {
       const bridge = await getAccountBridge(account, parentAccount);
       dispatch({
         type: "setAccount",
         account,
         parentAccount,
         bridge,
+        recipient,
       });
     },
     [dispatch],

--- a/libs/ledger-live-common/src/flows/send/hooks/useSendFlowBusinessLogic.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useSendFlowBusinessLogic.ts
@@ -55,7 +55,11 @@ type UseSendFlowBusinessLogicResult = Readonly<{
   recipient: RecipientData | null;
   isRecipientAddressComplete: boolean;
   setIsRecipientAddressComplete: (value: boolean) => void;
-  setAccountAndNavigate: (account: AccountLike, parentAccount?: Account) => void;
+  setAccountAndNavigate: (
+    account: AccountLike,
+    parentAccount?: Account,
+    recipientAddress?: string,
+  ) => void | Promise<void>;
   source?: string;
   selectContactBeforeAccount?: boolean;
 }>;
@@ -98,20 +102,23 @@ export function useSendFlowBusinessLogic({
     [accountHook.state.currency],
   );
 
-  const setAccountAndNavigate = useCallback(
-    (account: AccountLike, parentAccount?: Account) => {
-      accountHook.setAccount(account, parentAccount);
-      transactionHook.actions.setAccount(account, parentAccount);
-    },
-    [accountHook, transactionHook.actions],
-  );
-
   const handleRecipientSet = useCallback(
     (newRecipient: RecipientData) => {
       setRecipient(newRecipient);
       transactionHook.actions.setRecipient(newRecipient);
     },
     [transactionHook.actions],
+  );
+
+  const setAccountAndNavigate = useCallback(
+    async (account: AccountLike, parentAccount?: Account, recipientAddress?: string) => {
+      accountHook.setAccount(account, parentAccount);
+      await transactionHook.actions.setAccount(account, parentAccount, recipientAddress);
+      if (recipientAddress) {
+        setRecipient({ address: recipientAddress });
+      }
+    },
+    [accountHook, transactionHook.actions],
   );
 
   useEffect(() => {

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -95,7 +95,11 @@ export type SendFlowTransactionActions = Readonly<{
   setTransaction: (tx: Transaction) => void;
   updateTransaction: (updater: (tx: Transaction) => Transaction) => void;
   setRecipient: (recipient: RecipientData) => void;
-  setAccount: (account: AccountLike, parentAccount?: Account | null) => void;
+  setAccount: (
+    account: AccountLike,
+    parentAccount?: Account | null,
+    recipientAddress?: string,
+  ) => void | Promise<void>;
 }>;
 
 export type SendFlowOperationActions = Readonly<{
@@ -149,5 +153,9 @@ export type SendFlowBusinessContext = Readonly<{
   isRecipientAddressComplete: boolean;
   setIsRecipientAddressComplete: (value: boolean) => void;
   close: () => void;
-  setAccountAndNavigate: (account: AccountLike, parentAccount?: Account) => void;
+  setAccountAndNavigate: (
+    account: AccountLike,
+    parentAccount?: Account,
+    recipientAddress?: string,
+  ) => void | Promise<void>;
 }>;


### PR DESCRIPTION
## Summary
- After Pay New picks a contact address and an account in MAD, stay on the current Send and go to Amount.
- Stops a second SendFlow from mounting (the flicker).

## Test plan
- [ ] Pay → New → contact → address → MAD → account: Amount appears once, no stack flicker
- [ ] Back from Amount returns to the contacts list (same Send)
- [ ] Close Send returns to Pay

Stacked on #21528.