### PR TITLE
[LWDM] feat(aleo): bond flow part1 (LIVE-32807)

### DIFF
--- a/.changeset/bright-mice-work.md
+++ b/.changeset/bright-mice-work.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+part 1 for Aleo bond flow

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.test.tsx
@@ -10,12 +10,25 @@ import {
   ALEO_TOKEN_ACCOUNT,
   NEW_ALEO_ACCOUNT,
 } from "./__mocks__/account.mock";
+import { mockAleoCoinConfig } from "./__mocks__/config.mock";
+import { getAleoCurrencyConfig } from "./shared/utils";
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: () => ({
     isAccountEmpty: (a: { balance: { isZero: () => boolean } }) => a.balance.isZero(),
   }),
 }));
+
+jest.mock("./shared/utils", () => ({
+  ...jest.requireActual("./shared/utils"),
+  getAleoCurrencyConfig: jest.fn(),
+}));
+
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
+
+beforeEach(() => {
+  mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: false });
+});
 
 describe("AccountHeaderManageActions", () => {
   const hook = AccountHeaderActions;
@@ -110,6 +123,96 @@ describe("AccountHeaderManageActions", () => {
       expect(modalState).toEqual({
         isOpened: true,
         data: { account: ALEO_TOKEN_ACCOUNT, parentAccount: ALEO_MAIN_ACCOUNT },
+      });
+    });
+  });
+
+  // While enableStaking is off the entry point must be absent rather than merely disabled:
+  // a disabled button still advertises a feature that cannot work.
+  describe("the Earn action and the enableStaking flag", () => {
+    const findEarn = (account = ALEO_ACCOUNT_1, parentAccount: null = null) => {
+      const { result } = renderHook(() => hook({ account, parentAccount }));
+      return result.current?.find(action => action.key === "AleoBond");
+    };
+
+    it("is absent when staking is disabled", () => {
+      expect(findEarn()).toBeUndefined();
+    });
+
+    it("is absent when the currency config cannot be resolved", () => {
+      mockGetAleoCurrencyConfig.mockReturnValue(undefined);
+
+      expect(findEarn()).toBeUndefined();
+    });
+
+    it("is present when staking is enabled", () => {
+      mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
+
+      expect(findEarn()).toBeDefined();
+    });
+
+    it("routes an empty account to the no-funds modal instead of disabling the action", () => {
+      mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
+
+      const { result, store } = renderHook(() =>
+        hook({ account: NEW_ALEO_ACCOUNT, parentAccount: null }),
+      );
+      const action = result.current?.find(item => item.key === "AleoBond");
+
+      expect(action?.disabled).toBeFalsy();
+
+      act(() => {
+        action?.onClick();
+      });
+
+      expect(store.getState().modals.MODAL_NO_FUNDS_STAKE).toEqual({
+        isOpened: true,
+        data: { account: NEW_ALEO_ACCOUNT, parentAccount: undefined },
+      });
+      expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
+    });
+
+    it("opens the manage modal from an empty token account whose main account has funds", () => {
+      mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
+
+      const emptyTokenAccount = {
+        ...ALEO_TOKEN_ACCOUNT,
+        balance: new BigNumber(0),
+        operationsCount: 0,
+      };
+      const { result, store } = renderHook(() =>
+        hook({ account: emptyTokenAccount, parentAccount: ALEO_MAIN_ACCOUNT }),
+      );
+      const action = result.current?.find(item => item.key === "AleoBond");
+
+      expect(result.current?.find(item => item.key === "Self transfer")?.disabled).toBe(true);
+      expect(action?.disabled).toBeFalsy();
+
+      act(() => {
+        action?.onClick();
+      });
+
+      expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBe(true);
+      expect(store.getState().modals.MODAL_NO_FUNDS_STAKE?.isOpened).toBeFalsy();
+    });
+
+    // The manage modal drives the bond flow off the main account, so a token account must
+    // not reach it as the `account` — the bond spends native ALEO.
+    it("opens the manage modal on the main account, even from a token account", () => {
+      mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
+
+      const { result, store } = renderHook(() =>
+        hook({ account: ALEO_TOKEN_ACCOUNT, parentAccount: ALEO_MAIN_ACCOUNT }),
+      );
+      const action = result.current?.find(item => item.key === "AleoBond");
+
+      act(() => {
+        action?.onClick();
+      });
+
+      expect(store.getState().modals[AleoCustomModal.MANAGE]).toEqual({
+        isOpened: true,
+        data: { account: ALEO_MAIN_ACCOUNT, parentAccount: ALEO_MAIN_ACCOUNT },
       });
     });
   });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.test.tsx
@@ -167,7 +167,7 @@ describe("AccountHeaderManageActions", () => {
 
       expect(store.getState().modals.MODAL_NO_FUNDS_STAKE).toEqual({
         isOpened: true,
-        data: { account: NEW_ALEO_ACCOUNT, parentAccount: undefined },
+        data: { account: NEW_ALEO_ACCOUNT },
       });
       expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
     });
@@ -197,8 +197,10 @@ describe("AccountHeaderManageActions", () => {
     });
 
     // The manage modal drives the bond flow off the main account, so a token account must
-    // not reach it as the `account` — the bond spends native ALEO.
-    it("opens the manage modal on the main account, even from a token account", () => {
+    // not reach it as the `account` — the bond spends native ALEO. And once the account has
+    // been switched, no parent goes with it: forwarding the original would land the same
+    // account in both fields, which NoFundsStake passes on to its receive and buy flows.
+    it("opens the manage modal on the main account alone, even from a token account", () => {
       mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
 
       const { result, store } = renderHook(() =>
@@ -212,7 +214,7 @@ describe("AccountHeaderManageActions", () => {
 
       expect(store.getState().modals[AleoCustomModal.MANAGE]).toEqual({
         isOpened: true,
-        data: { account: ALEO_MAIN_ACCOUNT, parentAccount: ALEO_MAIN_ACCOUNT },
+        data: { account: ALEO_MAIN_ACCOUNT },
       });
     });
   });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
@@ -29,12 +29,7 @@ const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
       ? "MODAL_NO_FUNDS_STAKE"
       : AleoCustomModal.MANAGE;
 
-    dispatch(
-      openModal(modalKey, {
-        account: mainAccount,
-        parentAccount: parentAccount ?? undefined,
-      }),
-    );
+    dispatch(openModal(modalKey, { account: mainAccount }));
   };
 
   return [

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
@@ -1,10 +1,13 @@
 import { useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { openModal } from "~/renderer/actions/modals";
 import IconTransfer from "~/renderer/icons/Transfer";
+import IconCoins from "~/renderer/icons/Coins";
 import type { AleoFamily } from "./types";
 import { AleoCustomModal } from "./constants";
+import { getAleoCurrencyConfig } from "./shared/utils";
 
 const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
   account,
@@ -14,9 +17,24 @@ const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
   const { t } = useTranslation();
   const bridge = useAccountBridge(account, parentAccount);
   const isSelfTransferDisabled = bridge.isAccountEmpty(account);
+  const mainAccount = getMainAccount(account, parentAccount);
+  const isStakingEnabled = !!getAleoCurrencyConfig(mainAccount.currency)?.enableStaking;
 
   const onClick = () => {
     dispatch(openModal(AleoCustomModal.SELF_TRANSFER, { account, parentAccount }));
+  };
+
+  const onManage = () => {
+    const modalKey = bridge.isAccountEmpty(mainAccount)
+      ? "MODAL_NO_FUNDS_STAKE"
+      : AleoCustomModal.MANAGE;
+
+    dispatch(
+      openModal(modalKey, {
+        account: mainAccount,
+        parentAccount: parentAccount ?? undefined,
+      }),
+    );
   };
 
   return [
@@ -31,6 +49,19 @@ const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
       eventProperties: { button: "aleo-self-transfer" },
       accountActionsTestId: "self-transfer-button",
     },
+    ...(isStakingEnabled
+      ? [
+          {
+            key: "AleoBond",
+            onClick: onManage,
+            icon: IconCoins,
+            label: t("aleo.manage.headerAction"),
+            event: "button_clicked2",
+            eventProperties: { button: "aleo-manage" },
+            accountActionsTestId: "stake-button",
+          },
+        ]
+      : []),
   ];
 };
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.styles.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.styles.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+import Box from "~/renderer/components/Box";
+
+export const ManageButton = styled.button<{ disabled?: boolean }>`
+  display: flex;
+  align-items: center;
+  border: 1px solid ${p => p.theme.colors.neutral.c40};
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+  background: transparent;
+  cursor: ${p => (p.disabled ? "not-allowed" : "pointer")};
+  opacity: ${p => (p.disabled ? 0.5 : 1)};
+  &:hover {
+    background: ${p => (p.disabled ? "transparent" : p.theme.colors.neutral.c20)};
+  }
+`;
+
+export const IconWrapper = styled(Box)`
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 32px;
+  background-color: ${p => p.theme.colors.neutral.c20};
+  color: ${p => p.theme.colors.neutral.c100};
+  margin-right: 12px;
+`;
+
+export const InfoWrapper = styled(Box)`
+  align-items: flex-start;
+  justify-content: center;
+  flex-shrink: 1;
+  text-align: left;
+`;
+
+export const Title = styled(Box)`
+  font-size: 13px;
+  font-weight: 600;
+  color: ${p => p.theme.colors.neutral.c100};
+`;
+
+export const Description = styled(Box)`
+  font-size: 13px;
+  color: ${p => p.theme.colors.neutral.c70};
+`;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen, userEvent } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_MAIN_ACCOUNT } from "../__mocks__/account.mock";
+import { AleoCustomModal } from "../constants";
+import ManageModal from "./ManageModal";
+
+jest.mock("@ledgerhq/crypto-icons", () => ({ CryptoIcon: jest.fn() }));
+
+function setup() {
+  const modalsDiv = document.createElement("div");
+  modalsDiv.id = "modals";
+  document.body.appendChild(modalsDiv);
+
+  return render(<ManageModal account={ALEO_MAIN_ACCOUNT} />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        [AleoCustomModal.MANAGE]: {
+          isOpened: true,
+          data: { account: ALEO_MAIN_ACCOUNT, parentAccount: null },
+        },
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  document.getElementById("modals")?.remove();
+});
+
+describe("Aleo ManageModal", () => {
+  // The rows are shown so the modal describes the whole staking lifecycle, but none of the
+  // flows are built. A row that looked clickable would open nothing at all.
+  it.each(["aleo-bond-button", "aleo-unbond-button", "aleo-claim-button"])(
+    "leaves %s disabled",
+    async testId => {
+      setup();
+
+      expect(await screen.findByTestId(testId)).toBeDisabled();
+    },
+  );
+
+  it("does not open any flow from the rows", async () => {
+    const { store } = setup();
+
+    await userEvent.click(await screen.findByTestId("aleo-bond-button"));
+    await userEvent.click(await screen.findByTestId("aleo-unbond-button"));
+    await userEvent.click(await screen.findByTestId("aleo-claim-button"));
+
+    const openedModals = Object.entries(store.getState().modals)
+      .filter(([, state]) => state?.isOpened)
+      .map(([name]) => name);
+
+    expect(openedModals).toEqual([AleoCustomModal.MANAGE]);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import Box from "~/renderer/components/Box";
+import Modal, { ModalBody } from "~/renderer/components/Modal";
+import ToolTip from "~/renderer/components/Tooltip";
+import IconCoins from "~/renderer/icons/Coins";
+import UnbondIcon from "~/renderer/icons/Undelegate";
+import ClaimRewardIcon from "~/renderer/icons/ClaimReward";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { Account } from "@ledgerhq/types-live";
+import * as S from "./ManageModal.styles";
+
+export type Data = {
+  account: AleoAccount;
+  parentAccount?: Account;
+  source?: string;
+};
+
+const ManageModal = ({
+  account: _account,
+  parentAccount: _parentAccount,
+  source: _source,
+  ...rest
+}: Data) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      {...rest}
+      name="MODAL_ALEO_MANAGE"
+      centered
+      render={({ onClose }) => (
+        <ModalBody
+          onClose={onClose}
+          onBack={undefined}
+          title={<Trans i18nKey="aleo.manage.title" />}
+          render={() => (
+            <Box>
+              <ToolTip
+                content={t("aleo.manage.comingSoonTooltip")}
+                containerStyle={{ width: "100%" }}
+              >
+                <S.ManageButton data-testid="aleo-bond-button" disabled>
+                  <S.IconWrapper>
+                    <IconCoins size={16} />
+                  </S.IconWrapper>
+                  <S.InfoWrapper>
+                    <S.Title>
+                      <Trans i18nKey="aleo.manage.bond.title" />
+                    </S.Title>
+                    <S.Description>
+                      <Trans i18nKey="aleo.manage.bond.description" />
+                    </S.Description>
+                  </S.InfoWrapper>
+                </S.ManageButton>
+              </ToolTip>
+              <ToolTip
+                content={t("aleo.manage.comingSoonTooltip")}
+                containerStyle={{ width: "100%" }}
+              >
+                <S.ManageButton data-testid="aleo-unbond-button" disabled>
+                  <S.IconWrapper>
+                    <UnbondIcon size={16} />
+                  </S.IconWrapper>
+                  <S.InfoWrapper>
+                    <S.Title>
+                      <Trans i18nKey="aleo.manage.unbond.title" />
+                    </S.Title>
+                    <S.Description>
+                      <Trans i18nKey="aleo.manage.unbond.description" />
+                    </S.Description>
+                  </S.InfoWrapper>
+                </S.ManageButton>
+              </ToolTip>
+              <ToolTip
+                content={t("aleo.manage.comingSoonTooltip")}
+                containerStyle={{ width: "100%" }}
+              >
+                <S.ManageButton data-testid="aleo-claim-button" disabled>
+                  <S.IconWrapper>
+                    <ClaimRewardIcon size={16} />
+                  </S.IconWrapper>
+                  <S.InfoWrapper>
+                    <S.Title>
+                      <Trans i18nKey="aleo.manage.claim.title" />
+                    </S.Title>
+                    <S.Description>
+                      <Trans i18nKey="aleo.manage.claim.description" />
+                    </S.Description>
+                  </S.InfoWrapper>
+                </S.ManageButton>
+              </ToolTip>
+            </Box>
+          )}
+          renderFooter={undefined}
+        />
+      )}
+    />
+  );
+};
+
+export default ManageModal;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/sendFlow.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/sendFlow.integ.test.tsx
@@ -189,7 +189,7 @@ describe("Aleo send flow — full modal", () => {
     await waitFor(() => expect(screen.getByText("Transaction sent")).toBeInTheDocument(), {
       timeout: 5000,
     });
-  }, 12000);
+  }, 20000);
 
   it("blocks at the mandatory private sync step when the private balance is selected", async () => {
     setupModal();

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
@@ -1,3 +1,4 @@
 export enum AleoCustomModal {
   SELF_TRANSFER = "MODAL_ALEO_SELF_TRANSFER",
+  MANAGE = "MODAL_ALEO_MANAGE",
 }

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
@@ -19,7 +19,7 @@ const family: AleoFamily = {
   StepSummaryRecipientValue,
   StepSummaryPostAlert,
   StepSummaryAdditionalRows,
-  modalsToPreload: ["MODAL_ALEO_SELF_TRANSFER"],
+  modalsToPreload: ["MODAL_ALEO_SELF_TRANSFER", "MODAL_ALEO_MANAGE"],
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
@@ -1,6 +1,7 @@
 import React, { use } from "react";
 
 import type { Data as AleoSendData } from "./aleo/modals/send/types";
+import type { Data as AleoManageData } from "./aleo/ManageModal/ManageModal";
 import type { Data as AlgorandOptInData } from "./algorand/OptInFlowModal/Body";
 import type { Data as AlgorandClaimRewardsData } from "./algorand/Rewards/ClaimRewardsFlowModal/Body";
 import type { Props as AlgorandEarnRewardsInfoProps } from "./algorand/Rewards/EarnRewardsInfoModal";
@@ -81,6 +82,7 @@ import type { Data as TezosUnstakeRequiredData } from "./tezos/UnstakeRequiredMo
 
 export type CoinModalsData = {
   MODAL_ALEO_SELF_TRANSFER: AleoSendData;
+  MODAL_ALEO_MANAGE: AleoManageData;
   MODAL_ALGORAND_OPT_IN: AlgorandOptInData;
   MODAL_ALGORAND_CLAIM_REWARDS: AlgorandClaimRewardsData;
   MODAL_ALGORAND_EARN_REWARDS_INFO: AlgorandEarnRewardsInfoProps;
@@ -170,6 +172,7 @@ type CoinModalImport = () => Promise<{ default: React.ComponentType<any> }>;
 // preloadCoinModals() (the bundler dedupes, so React.lazy then resolves instantly).
 export const coinModalImports: Record<CoinModalKey, CoinModalImport> = {
   MODAL_ALEO_SELF_TRANSFER: () => import("./aleo/SelfTransferModal"),
+  MODAL_ALEO_MANAGE: () => import("./aleo/ManageModal/ManageModal"),
   MODAL_ALGORAND_OPT_IN: () => import("./algorand/OptInFlowModal"),
   MODAL_ALGORAND_CLAIM_REWARDS: () => import("./algorand/Rewards/ClaimRewardsFlowModal"),
   MODAL_ALGORAND_EARN_REWARDS_INFO: () => import("./algorand/Rewards/EarnRewardsInfoModal"),

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9441,6 +9441,23 @@
         "errorTitle": "Private sync failed",
         "errorDesc": "Something went wrong, please try again"
       }
+    },
+    "manage": {
+      "headerAction": "Earn",
+      "title": "Manage staking",
+      "comingSoonTooltip": "Coming soon.",
+      "bond": {
+        "title": "Bond",
+        "description": "Bond your ALEO to a validator to earn rewards."
+      },
+      "unbond": {
+        "title": "Unbond",
+        "description": "Unbond your bonded ALEO. Funds will be available after the unbonding period."
+      },
+      "claim": {
+        "title": "Claim",
+        "description": "Claim your unbonded ALEO back to your available balance."
+      }
     }
   },
   "updater": {

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
@@ -63,6 +63,16 @@ export const mockTxIntentTransferPublic: AleoTransactionIntent = {
   type: TRANSACTION_TYPE.TRANSFER_PUBLIC,
 };
 
+export const mockTxIntentBondPublic: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 1_000_000n,
+  type: TRANSACTION_TYPE.BOND_PUBLIC,
+  data: {
+    type: TRANSACTION_TYPE.BOND_PUBLIC,
+    withdrawal: "aleo1sender",
+  },
+};
+
 export const mockTxIntentTransferPrivate: AleoTransactionIntent = {
   ...baseTxIntentFields,
   amount: 200n,

--- a/libs/coin-modules/coin-aleo/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/transaction.test.ts
@@ -109,4 +109,44 @@ describe("transaction", () => {
       expect("properties" in result).toBe(false);
     },
   );
+
+  // `withdrawal` is the address unbonded funds are later released to. It is the one field a
+  // bond carries beyond the common shape, so dropping it here would silently unpin the
+  // withdrawal on any transaction that round-trips through storage.
+  describe("bond_public", () => {
+    const WITHDRAWAL = "aleo1a2ehlgqhvs3p7d4hqhs0tvgk954dr8gafu9kxse2mzu9a5sqxvpsrn98pr";
+
+    it("should preserve the withdrawal address when deserializing from raw", () => {
+      const raw = getMockedTransactionRaw({
+        mode: TRANSACTION_TYPE.BOND_PUBLIC,
+        withdrawal: WITHDRAWAL,
+      });
+
+      const result = fromTransactionRaw(raw);
+
+      expect(result.mode).toBe(TRANSACTION_TYPE.BOND_PUBLIC);
+      expect(result).toHaveProperty("withdrawal", WITHDRAWAL);
+    });
+
+    it("should preserve the withdrawal address when serializing to raw", () => {
+      const transaction = getMockedTransaction({
+        mode: TRANSACTION_TYPE.BOND_PUBLIC,
+        withdrawal: WITHDRAWAL,
+      });
+
+      const result = toTransactionRaw(transaction);
+
+      expect(result.mode).toBe(TRANSACTION_TYPE.BOND_PUBLIC);
+      expect(result).toHaveProperty("withdrawal", WITHDRAWAL);
+    });
+
+    it("should not include properties", () => {
+      const transaction = getMockedTransaction({
+        mode: TRANSACTION_TYPE.BOND_PUBLIC,
+        withdrawal: WITHDRAWAL,
+      });
+
+      expect("properties" in toTransactionRaw(transaction)).toBe(false);
+    });
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/transaction.ts
@@ -43,6 +43,15 @@ export function fromTransactionRaw(tr: TransactionRaw): Transaction {
     };
   }
 
+  if (tr.mode === TRANSACTION_TYPE.BOND_PUBLIC) {
+    return {
+      ...commonGeneric,
+      ...commonAleo,
+      mode: tr.mode,
+      withdrawal: tr.withdrawal,
+    };
+  }
+
   return {
     ...commonGeneric,
     ...commonAleo,
@@ -63,6 +72,15 @@ export function toTransactionRaw(t: Transaction): TransactionRaw {
       ...commonAleo,
       mode: t.mode,
       properties: t.properties,
+    };
+  }
+
+  if (t.mode === TRANSACTION_TYPE.BOND_PUBLIC) {
+    return {
+      ...commonGeneric,
+      ...commonAleo,
+      mode: t.mode,
+      withdrawal: t.withdrawal,
     };
   }
 

--- a/libs/coin-modules/coin-aleo/src/logic/getValidators.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getValidators.test.ts
@@ -2,6 +2,7 @@ import { apiClient } from "../network/api";
 import type { AleoCommitteeResponse } from "../types/api";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import coinConfig from "../config";
+import { MICROCREDITS_PER_CREDIT } from "../constants";
 import { getValidators } from "./getValidators";
 
 jest.mock("../network/api");
@@ -10,16 +11,19 @@ const OPEN_HIGH_STAKE = "aleo1open_high";
 const OPEN_LOW_STAKE = "aleo1open_low";
 const CLOSED_HIGH_STAKE = "aleo1closed_high";
 
-// Supply equal to the staked total makes the gross rate exactly the inflation rate
-// (0.05 * S / S), so each expectation below stays readable.
-const TOTAL_SUPPLY_CREDITS = 100;
+const UNBONDING_RAW = "{\n  microcredits: 10000000000u64,\n  height: 7862785u32\n}";
+
+const microcredits = (credits: number) => credits * MICROCREDITS_PER_CREDIT;
+
+const TOTAL_STAKE_CREDITS = 200_000_000;
+const TOTAL_SUPPLY_CREDITS = TOTAL_STAKE_CREDITS;
 const GROSS_RATE = 0.05;
 const committee: AleoCommitteeResponse = {
-  total_stake: 100 * 1_000_000,
+  total_stake: microcredits(TOTAL_STAKE_CREDITS),
   members: {
-    [CLOSED_HIGH_STAKE]: [50 * 1_000_000, false, 0],
-    [OPEN_LOW_STAKE]: [10 * 1_000_000, true, 50],
-    [OPEN_HIGH_STAKE]: [20 * 1_000_000, true, 0],
+    [CLOSED_HIGH_STAKE]: [microcredits(100_000_000), false, 0],
+    [OPEN_LOW_STAKE]: [microcredits(20_000_000), true, 50],
+    [OPEN_HIGH_STAKE]: [microcredits(40_000_000), true, 0],
   },
 };
 
@@ -36,6 +40,7 @@ describe("getValidators", () => {
       [OPEN_HIGH_STAKE]: "High Stake Validator",
     });
     jest.mocked(apiClient.getTotalSupply).mockResolvedValue(TOTAL_SUPPLY_CREDITS);
+    jest.mocked(apiClient.getUnbondingMapping).mockResolvedValue(null);
   });
 
   it("orders open validators first, then by descending stake", async () => {
@@ -82,7 +87,65 @@ describe("getValidators", () => {
     expect(apiClient.getTotalSupply).toHaveBeenCalledTimes(1);
   });
 
+  describe("unbonding validators", () => {
+    const unbondingOnly = (unbonding: string[]) =>
+      jest
+        .mocked(apiClient.getUnbondingMapping)
+        .mockImplementation(async (_config, address) =>
+          unbonding.includes(address) ? UNBONDING_RAW : null,
+        );
+
+    it("flags a validator that has an unbonding entry of its own", async () => {
+      unbondingOnly([OPEN_HIGH_STAKE]);
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators.find(v => v.address === OPEN_HIGH_STAKE)?.isUnbonding).toBe(true);
+      expect(validators.find(v => v.address === OPEN_LOW_STAKE)?.isUnbonding).toBe(false);
+    });
+
+    it("demotes an unbonding validator below the open ones, despite the higher stake", async () => {
+      unbondingOnly([OPEN_HIGH_STAKE]);
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      // Behind the one validator still taking stake, then among the rest by descending stake.
+      expect(validators.map(v => v.address)).toEqual([
+        OPEN_LOW_STAKE,
+        CLOSED_HIGH_STAKE,
+        OPEN_HIGH_STAKE,
+      ]);
+    });
+
+    it("reports no unbonding rather than failing the list when the lookup errors", async () => {
+      jest.mocked(apiClient.getUnbondingMapping).mockRejectedValue(new Error("boom"));
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators).toHaveLength(3);
+      expect(validators.every(v => v.isUnbonding === false)).toBe(true);
+    });
+  });
+
   describe("degraded responses", () => {
+    // Dividing by it would make every stake share infinite, so the whole list would come
+    // back flagged as earning nothing.
+    it.each([
+      ["zero", 0],
+      ["a non-numeric", "not-a-number"],
+    ])("reports no non-earning reason when the total stake is %s", async (_label, totalStake) => {
+      jest.mocked(apiClient.getCommittee).mockResolvedValue({
+        ...committee,
+        total_stake: totalStake as number,
+      });
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators).toHaveLength(3);
+      expect(validators.every(v => v.nonEarningReason === undefined)).toBe(true);
+      expect(validators.every(v => v.estimatedYearlyRewardsRate === undefined)).toBe(true);
+    });
+
     it("still returns a usable list when the names fetch fails", async () => {
       jest.mocked(apiClient.getValidatorMetadata).mockRejectedValue(new Error("boom"));
 

--- a/libs/coin-modules/coin-aleo/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getValidators.ts
@@ -2,7 +2,14 @@ import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
 import { apiClient } from "../network/api";
-import { estimateNetRate, isRecord, parseTotalSupply, resolveConfig } from "./utils";
+import { getUnbondingValidators } from "../network/utils";
+import {
+  estimateNetRate,
+  getValidatorNonEarningReason,
+  isRecord,
+  parseTotalSupply,
+  resolveConfig,
+} from "./utils";
 import type {
   AleoCommitteeMember,
   AleoCommitteeResponse,
@@ -44,11 +51,16 @@ function isValidValidatorMetadataResponse(value: unknown): value is AleoValidato
   return Object.values(value).every(entry => typeof entry === "string");
 }
 
+function isAcceptingNewStakes(validator: Pick<AleoValidator, "isOpen" | "isUnbonding">) {
+  return validator.isOpen && !validator.isUnbonding;
+}
+
 /**
  * The validator committee for `currencyId`'s configured network, ordered for a picker.
  *
- * Only the committee is required. Names and total supply are best-effort, so losing
- * either degrades a field rather than failing the list the bond flow depends on.
+ * Only the committee is required. Names, total supply and unbonding state are best-effort,
+ * so losing any of them degrades a field rather than failing the list the bond flow
+ * depends on.
  */
 export const getValidators = makeLRUCache(
   async (currencyId: string): Promise<AleoValidator[]> => {
@@ -65,10 +77,15 @@ export const getValidators = makeLRUCache(
     }
 
     const safeMetadata = metadata && isValidValidatorMetadataResponse(metadata) ? metadata : {};
+    const unbonding = await getUnbondingValidators(config, Object.keys(committee.members));
 
     const totalSupplyCredits = parseTotalSupply(totalSupply);
-    const totalStakeMicrocredits =
+    // A zero or unparseable total is treated as absent rather than divided by: it would make
+    // every validator's stake share infinite, flagging the whole list as non-earning.
+    const parsedTotalStake =
       committee.total_stake === undefined ? null : new BigNumber(committee.total_stake);
+    const totalStakeMicrocredits =
+      parsedTotalStake?.isFinite() && parsedTotalStake.isGreaterThan(0) ? parsedTotalStake : null;
 
     if (totalSupplyCredits === null || totalStakeMicrocredits === null) {
       log("aleo/getValidators", "no estimated rate: missing total supply or total stake", {
@@ -79,28 +96,37 @@ export const getValidators = makeLRUCache(
 
     return Object.entries(committee.members)
       .map(([address, [stakeMicrocredits, isOpen, commissionPercent]]) => {
+        const shared = {
+          totalStakeMicrocredits,
+          validatorStakeMicrocredits: new BigNumber(stakeMicrocredits),
+          commissionPercent: new BigNumber(commissionPercent),
+        };
+        // Total stake alone decides whether a validator earns; the rate additionally
+        // needs the supply, so a missing supply drops the rate but keeps the reason.
+        const nonEarningReason =
+          totalStakeMicrocredits === null
+            ? null
+            : getValidatorNonEarningReason({ ...shared, totalStakeMicrocredits });
         const rate =
           totalSupplyCredits === null || totalStakeMicrocredits === null
             ? null
-            : estimateNetRate({
-                totalSupplyCredits,
-                totalStakeMicrocredits,
-                validatorStakeMicrocredits: new BigNumber(stakeMicrocredits),
-                commissionPercent: new BigNumber(commissionPercent),
-              });
+            : estimateNetRate({ ...shared, totalStakeMicrocredits, totalSupplyCredits });
 
         return {
           address,
           name: safeMetadata[address],
           stakeMicrocredits,
           isOpen,
+          isUnbonding: unbonding.has(address),
           commissionPercent,
           ...(rate !== null && { estimatedYearlyRewardsRate: rate.toNumber() }),
+          ...(nonEarningReason !== null && { nonEarningReason }),
         };
       })
       .sort((left, right) => {
-        if (left.isOpen !== right.isOpen) {
-          return left.isOpen ? -1 : 1;
+        const leftBondable = isAcceptingNewStakes(left);
+        if (leftBondable !== isAcceptingNewStakes(right)) {
+          return leftBondable ? -1 : 1;
         }
 
         return right.stakeMicrocredits - left.stakeMicrocredits;

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -37,6 +37,7 @@ import {
   getMockedTransaction,
   mockTxIntentFeePrivate,
   mockTxIntentFeePublic,
+  mockTxIntentBondPublic,
   mockTxIntentSelfTransferToPrivate,
   mockTxIntentSelfTransferToPublic,
   mockTxIntentSelfTransferToPublic2,
@@ -53,6 +54,7 @@ import {
 import type {
   AleoContext,
   AleoOperationExtra,
+  AleoTransactionIntent,
   AleoPublicTransaction,
   AleoTokenType,
   ProvableApi,
@@ -99,6 +101,7 @@ import {
   getRecordByCommitment,
   getFunctionNameFromTransactionType,
   getNextSequenceNumber,
+  getValidatorNonEarningReason,
   extractViewKey,
   findBestRecordForFee,
   selectPrivateRecordsForAmount,
@@ -1177,6 +1180,32 @@ describe("mapTransactionIntentToSdkIntent", () => {
     });
   });
 
+  // The validator arrives as the intent's `recipient` but the program argument is named
+  // `validator`, and `withdrawal` is a third argument with no equivalent on a transfer.
+  it("should map bond_public intent to the validator/withdrawal SDK argument names", () => {
+    const intent = mockTxIntentBondPublic;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "bond_public",
+      amount: intent.amount.toString(),
+      validator: intent.recipient,
+      withdrawal: "aleo1sender",
+    });
+  });
+
+  it("should throw when a bond_public intent carries no withdrawal address", () => {
+    // The key has to be absent, not undefined: `hasSpecificIntentData` guards with `in`.
+    const { data: _data, ...withoutData } = mockTxIntentBondPublic as AleoTransactionIntent & {
+      data: unknown;
+    };
+
+    expect(() => mapTransactionIntentToSdkIntent(withoutData as AleoTransactionIntent)).toThrow(
+      "aleo: intent data is required for bond_public",
+    );
+  });
+
   it("should map convert_public_to_private intent to SDK intent with correct fields", () => {
     const intent = mockTxIntentSelfTransferToPrivate;
 
@@ -1571,6 +1600,8 @@ describe("getAvailableBalance", () => {
   it.each([
     [TRANSACTION_TYPE.TRANSFER_PUBLIC, mockTransparentBalance],
     [TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE, mockTransparentBalance],
+    // Only public ALEO can be bonded, so a bond spends the transparent balance.
+    [TRANSACTION_TYPE.BOND_PUBLIC, mockTransparentBalance],
     [TRANSACTION_TYPE.TRANSFER_PRIVATE, expectedPrivateSpendableBalance],
     [TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC, expectedPrivateSpendableBalance],
   ])("should return correct balance for %s", (mode, expected) => {
@@ -1745,6 +1776,32 @@ describe("createTransactionIntent", () => {
       });
     },
   );
+
+  // A bond carries the withdrawal address that unbonded funds are later released to, so
+  // unlike every other public mode its intent is not the bare base.
+  it("should carry the withdrawal address on a bond_public intent", () => {
+    const transaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.BOND_PUBLIC,
+      amount: new BigNumber(1_000_000),
+      recipient: "aleo1validator",
+      withdrawal: mockAccount.freshAddress,
+    });
+
+    const result = createTransactionIntent({ account: mockAccount, transaction });
+
+    expect(result).toEqual({
+      intentType: "transaction",
+      asset: { type: "native" },
+      type: TRANSACTION_TYPE.BOND_PUBLIC,
+      amount: 1_000_000n,
+      recipient: "aleo1validator",
+      sender: mockAccount.freshAddress,
+      data: {
+        type: TRANSACTION_TYPE.BOND_PUBLIC,
+        withdrawal: mockAccount.freshAddress,
+      },
+    });
+  });
 
   it.each(supportedPublicTransactionModes)(
     "should keep the native asset for %s even with a stale subAccountId from a previous token selection",
@@ -2297,6 +2354,7 @@ describe("getFunctionNameFromTransactionType", () => {
     ["transfer_token_private", TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE],
     ["transfer_token_public_to_private", TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE],
     ["transfer_token_private_to_public", TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC],
+    ["bond_public", TRANSACTION_TYPE.BOND_PUBLIC],
   ])("should return '%s' for transaction type '%s'", (expected, transactionType) => {
     expect(getFunctionNameFromTransactionType(transactionType)).toBe(expected);
   });
@@ -2884,6 +2942,77 @@ describe("staking rates", () => {
       ["a non-finite total stake", new BigNumber(100), new BigNumber(NaN)],
     ])("returns null for %s", (_label, supply, stake) => {
       expect(estimateGrossRate(supply, stake)).toBeNull();
+    });
+  });
+
+  describe("getValidatorNonEarningReason", () => {
+    const baseParams = {
+      totalStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS),
+      // Comfortably under the 25% concentration cap.
+      validatorStakeMicrocredits: toMicrocredits(10_000_000),
+      commissionPercent: new BigNumber(10),
+    };
+
+    it("returns null for a validator that pays its delegators", () => {
+      expect(getValidatorNonEarningReason(baseParams)).toBeNull();
+    });
+
+    it("reports overConcentrated above the 25% cap", () => {
+      expect(
+        getValidatorNonEarningReason({
+          ...baseParams,
+          validatorStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS * 0.26),
+        }),
+      ).toBe("overConcentrated");
+    });
+
+    it("still pays a validator sitting exactly at the cap", () => {
+      expect(
+        getValidatorNonEarningReason({
+          ...baseParams,
+          validatorStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS * 0.25),
+        }),
+      ).toBeNull();
+    });
+
+    it("reports fullCommission at exactly 100%", () => {
+      expect(
+        getValidatorNonEarningReason({ ...baseParams, commissionPercent: new BigNumber(100) }),
+      ).toBe("fullCommission");
+    });
+
+    it("still pays at 99% commission", () => {
+      expect(
+        getValidatorNonEarningReason({ ...baseParams, commissionPercent: new BigNumber(99) }),
+      ).toBeNull();
+    });
+
+    // Concentration is checked first: it is the reason the protocol pays nothing at all,
+    // so it outranks a commission split of something that was never earned.
+    it("prefers overConcentrated when both rules apply", () => {
+      expect(
+        getValidatorNonEarningReason({
+          ...baseParams,
+          validatorStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS * 0.26),
+          commissionPercent: new BigNumber(100),
+        }),
+      ).toBe("overConcentrated");
+    });
+
+    // estimateNetRate collapses every reason to exactly 0, so the two must not disagree.
+    it.each([
+      ["overConcentrated", { validatorStakeMicrocredits: toMicrocredits(1_000_000_000) }],
+      ["fullCommission", { commissionPercent: new BigNumber(100) }],
+    ])("agrees with a zero net rate for %s", (_label, override) => {
+      const params = { ...baseParams, ...override };
+
+      expect(getValidatorNonEarningReason(params)).not.toBeNull();
+      expect(
+        estimateNetRate({
+          ...params,
+          totalSupplyCredits: MAINNET_TOTAL_SUPPLY_CREDITS,
+        })?.toNumber(),
+      ).toBe(0);
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -65,6 +65,8 @@ import type {
   AleoTokenType,
   EnrichedPrivateRecord,
   AleoStakingPosition,
+  AleoStakingMode,
+  AleoValidatorNonEarningReason,
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
@@ -579,6 +581,7 @@ export function isPublicTransaction(transaction: Transaction): transaction is Tr
   return (
     transaction.mode === TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE ||
     transaction.mode === TRANSACTION_TYPE.TRANSFER_PUBLIC ||
+    transaction.mode === TRANSACTION_TYPE.BOND_PUBLIC ||
     isPublicTokenTransaction(transaction)
   );
 }
@@ -610,7 +613,7 @@ export function derivePublicTransactionMode({
 }: {
   isTokenTx: boolean;
   isSelfTransfer: boolean;
-}): TransactionPublic["mode"] {
+}): Exclude<TransactionPublic["mode"], AleoStakingMode> {
   if (isTokenTx) {
     return isSelfTransfer
       ? TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
@@ -857,6 +860,15 @@ export function mapTransactionIntentToSdkIntent(
         program_id: txIntent.data.programId,
       };
     }
+    case TRANSACTION_TYPE.BOND_PUBLIC: {
+      invariant(hasSpecificIntentData(txIntent, type), `aleo: intent data is required for ${type}`);
+      return {
+        type: "bond_public",
+        amount,
+        validator: to,
+        withdrawal: txIntent.data.withdrawal,
+      };
+    }
     default: {
       throw new Error(`aleo: unsupported intent type: ${type}`);
     }
@@ -891,6 +903,7 @@ export function getAvailableBalance(account: AleoAccount, transaction: Transacti
     // spending public native balance
     case TRANSACTION_TYPE.TRANSFER_PUBLIC:
     case TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE:
+    case TRANSACTION_TYPE.BOND_PUBLIC:
       return account.aleoResources?.transparentBalance ?? new BigNumber(0);
     // spending private native balance
     case TRANSACTION_TYPE.TRANSFER_PRIVATE:
@@ -1011,6 +1024,15 @@ export function createTransactionIntent({
     case TRANSACTION_TYPE.TRANSFER_PUBLIC:
     case TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE:
       return base;
+
+    case TRANSACTION_TYPE.BOND_PUBLIC:
+      return {
+        ...base,
+        data: {
+          type: TRANSACTION_TYPE.BOND_PUBLIC,
+          withdrawal: transaction.withdrawal,
+        },
+      };
 
     case TRANSACTION_TYPE.TRANSFER_PRIVATE:
     case TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC:
@@ -1199,6 +1221,8 @@ export function getFunctionNameFromTransactionType(transactionType: TransactionT
       return "transfer_token_public_to_private";
     case TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC:
       return "transfer_token_private_to_public";
+    case TRANSACTION_TYPE.BOND_PUBLIC:
+      return "bond_public";
     default:
       throw new Error(`aleo: unsupported transaction type: ${transactionType}`);
   }
@@ -1394,6 +1418,32 @@ export function estimateGrossRate(
 }
 
 /**
+ * Why a validator pays its delegators nothing, or null when it pays. The single source
+ * of truth for these rules: {@link estimateNetRate} collapses all of them to a rate of
+ * exactly 0, so anything wanting to say *which* must ask here rather than infer.
+ */
+export function getValidatorNonEarningReason({
+  totalStakeMicrocredits,
+  validatorStakeMicrocredits,
+  commissionPercent,
+}: {
+  totalStakeMicrocredits: BigNumber;
+  validatorStakeMicrocredits: BigNumber;
+  commissionPercent: BigNumber;
+}): AleoValidatorNonEarningReason | null {
+  if (
+    validatorStakeMicrocredits
+      .dividedBy(totalStakeMicrocredits)
+      .isGreaterThan(MAX_VALIDATOR_STAKE_SHARE)
+  ) {
+    return "overConcentrated";
+  }
+  if (commissionPercent.isGreaterThanOrEqualTo(100)) return "fullCommission";
+
+  return null;
+}
+
+/**
  * What a delegator can expect from one validator: the gross network rate less that
  * validator's commission, as a fraction (0.07 = 7%). A **lower bound** — every surface
  * showing it must label it an estimate.
@@ -1419,15 +1469,17 @@ export function estimateNetRate({
 
   if (!commissionPercent.isFinite() || commissionPercent.isLessThan(0)) return null;
 
-  const validatorOverConcentrated = validatorStakeMicrocredits
-    .dividedBy(totalStakeMicrocredits)
-    .isGreaterThan(MAX_VALIDATOR_STAKE_SHARE);
   const delegatorBelowMinimum =
     delegatorStakeMicrocredits !== undefined &&
     delegatorStakeMicrocredits.isLessThan(MIN_DELEGATOR_STAKE_MICROCREDITS);
-  if (validatorOverConcentrated || delegatorBelowMinimum) return new BigNumber(0);
+  const nonEarningReason = getValidatorNonEarningReason({
+    totalStakeMicrocredits,
+    validatorStakeMicrocredits,
+    commissionPercent,
+  });
+  if (delegatorBelowMinimum || nonEarningReason !== null) return new BigNumber(0);
 
-  const keptShare = BigNumber.maximum(new BigNumber(1).minus(commissionPercent.dividedBy(100)), 0);
+  const keptShare = new BigNumber(1).minus(commissionPercent.dividedBy(100));
 
   return grossRate.multipliedBy(keptShare);
 }

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -36,6 +36,7 @@ import {
   decryptRecordAmount,
   sumUnspentRecords,
   getStakingPosition,
+  getUnbondingValidators,
 } from "./utils";
 
 jest.mock("./api");
@@ -3395,5 +3396,59 @@ describe("getStakingPosition", () => {
       .mockRejectedValue(new LedgerAPI5xx("Internal Server Error"));
 
     await expect(getStakingPosition(config, ADDRESS)).rejects.toThrow("Internal Server Error");
+  });
+});
+
+describe("getUnbondingValidators", () => {
+  const config = getMockedConfig("mainnet");
+  const UNBONDING = "aleo1l7avejc23yv6e8nx4udjwz89dw6mg95dzsp936hf77yuhnjywv9syl0ywc";
+  const SETTLED = "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t";
+  const UNBONDING_RAW = "{\n  microcredits: 10000000000u64,\n  height: 7862785u32\n}";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(apiClient.getUnbondingMapping)
+      .mockImplementation(async (_config, address) =>
+        address === UNBONDING ? UNBONDING_RAW : null,
+      );
+  });
+
+  it("returns only the addresses that have an entry", async () => {
+    const unbonding = await getUnbondingValidators(config, [UNBONDING, SETTLED]);
+
+    expect([...unbonding]).toEqual([UNBONDING]);
+  });
+
+  it("reads the mapping once per address", async () => {
+    await getUnbondingValidators(config, [UNBONDING, SETTLED]);
+
+    expect(apiClient.getUnbondingMapping).toHaveBeenCalledTimes(2);
+    expect(apiClient.getUnbondingMapping).toHaveBeenCalledWith(config, UNBONDING);
+    expect(apiClient.getUnbondingMapping).toHaveBeenCalledWith(config, SETTLED);
+  });
+
+  // Any entry blocks the bond: the program asserts on `contains unbonding[validator]`, so a
+  // matured `height` still counts until `claim_unbond_public` removes the row.
+  it("counts a matured entry, not just one still within its unbonding period", async () => {
+    jest
+      .mocked(apiClient.getUnbondingMapping)
+      .mockResolvedValue("{\n  microcredits: 1u64,\n  height: 1u32\n}");
+
+    const unbonding = await getUnbondingValidators(config, [SETTLED]);
+
+    expect(unbonding.has(SETTLED)).toBe(true);
+  });
+
+  it("omits an address whose lookup fails rather than rejecting", async () => {
+    jest
+      .mocked(apiClient.getUnbondingMapping)
+      .mockImplementation(async (_config, address) =>
+        address === UNBONDING ? UNBONDING_RAW : Promise.reject(new LedgerAPI5xx("boom")),
+      );
+
+    const unbonding = await getUnbondingValidators(config, [UNBONDING, SETTLED]);
+
+    expect([...unbonding]).toEqual([UNBONDING]);
   });
 });

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -49,6 +49,18 @@ export async function getStakingPosition(
   return toStakingPosition({ bondedRaw, unbondingRaw, withdrawRaw });
 }
 
+export async function getUnbondingValidators(
+  config: AleoCoinConfig,
+  addresses: string[],
+): Promise<Set<string>> {
+  const flagged = await promiseAllBatched(4, addresses, async address => {
+    const raw = await apiClient.getUnbondingMapping(config, address).catch(() => null);
+    return raw ? address : null;
+  });
+
+  return new Set(flagged.filter((address): address is string => address !== null));
+}
+
 export async function decryptRecordAmount(
   config: AleoCoinConfig,
   viewKey: string,

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -62,6 +62,11 @@ export type Transaction = TransactionCommon & {
           feeRecordCommitment: string | null;
         };
       }
+    | {
+        mode: typeof TRANSACTION_TYPE.BOND_PUBLIC;
+        withdrawal: string;
+        properties?: never;
+      }
   );
 
 export type TransactionRaw = TransactionCommonRaw & {
@@ -111,6 +116,11 @@ export type TransactionRaw = TransactionCommonRaw & {
           amountRecordCommitments: string[];
           feeRecordCommitment: string | null;
         };
+      }
+    | {
+        mode: typeof TRANSACTION_TYPE.BOND_PUBLIC;
+        withdrawal: string;
+        properties?: never;
       }
   );
 
@@ -182,7 +192,8 @@ export type TransactionTransfer = Extract<
       | typeof TRANSACTION_TYPE.TRANSFER_PUBLIC
       | typeof TRANSACTION_TYPE.TRANSFER_PRIVATE
       | typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC
-      | typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE;
+      | typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE
+      | typeof TRANSACTION_TYPE.BOND_PUBLIC;
   }
 >;
 
@@ -204,7 +215,8 @@ export type TransactionPublic = Extract<
       | typeof TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE
       | typeof TRANSACTION_TYPE.TRANSFER_PUBLIC
       | typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC
-      | typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE;
+      | typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
+      | typeof TRANSACTION_TYPE.BOND_PUBLIC;
   }
 >;
 

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -49,17 +49,21 @@ export type AleoAccountInfo = {
   scannedHeight: number;
 };
 
+export type AleoValidatorNonEarningReason = "overConcentrated" | "fullCommission";
+
 export type AleoValidator = {
   address: string;
   name?: string;
   stakeMicrocredits: number;
   isOpen: boolean;
+  isUnbonding: boolean;
   commissionPercent: number;
   /**
    * Estimated net yearly rate as a fraction (0.07 = 7%). Absent when it could not be
    * derived; `0` is a real value meaning "earns nothing".
    */
   estimatedYearlyRewardsRate?: number;
+  nonEarningReason?: AleoValidatorNonEarningReason;
 };
 
 export type AleoStakingPosition = {
@@ -81,6 +85,11 @@ export type RecordPickingStrategy = "manual" | "auto";
 export type AleoTokenType = "arc20" | "arc21" | "arc22" | "unknown";
 
 export type TransactionType = (typeof TRANSACTION_TYPE)[keyof typeof TRANSACTION_TYPE];
+
+export type AleoStakingMode =
+  | typeof TRANSACTION_TYPE.BOND_PUBLIC
+  | typeof TRANSACTION_TYPE.UNBOND_PUBLIC
+  | typeof TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC;
 
 export type AleoTransactionIntentData =
   | TxDataNotSupported
@@ -124,6 +133,10 @@ export type AleoTransactionIntentData =
   | {
       type: typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE;
       programId: string;
+    }
+  | {
+      type: typeof TRANSACTION_TYPE.BOND_PUBLIC;
+      withdrawal: string;
     };
 
 export type AleoTransactionIntent = TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;

--- a/libs/coin-modules/coin-aleo/src/types/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/types/sdk.ts
@@ -122,6 +122,13 @@ type TransferTokenPrivateToPublicIntent =
       program_id: string;
     };
 
+interface BondPublicIntent {
+  type: "bond_public";
+  amount: string;
+  validator: string;
+  withdrawal: string;
+}
+
 export type Intent =
   | TransferPrivateIntent
   | TransferPublicIntent
@@ -132,7 +139,8 @@ export type Intent =
   | TransferTokenPrivateIntent
   | TransferTokenPrivateToPublicIntent
   | FeePrivateIntent
-  | FeePublicIntent;
+  | FeePublicIntent
+  | BondPublicIntent;
 
 export interface FeeConfiguration {
   function_name: "fee_private" | "fee_public";

--- a/libs/ledger-live-common/src/families/aleo/react.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.test.ts
@@ -1392,6 +1392,7 @@ describe("useAleoValidators", () => {
     name: "Validator One",
     stakeMicrocredits: 20_000_000,
     isOpen: true,
+    isUnbonding: false,
     commissionPercent: 10,
     estimatedYearlyRewardsRate: 0.07,
   };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description
**Part 1 of 2 of the Aleo bond flow.** This PR lands everything needed to *reach* a bond —
`bond_public` as a transaction mode through the coin module, and the Earn header action →
Manage modal entry point. Part 2 adds the bond flow UI itself and turns the feature on.

`ENABLE_STAKING` stays `false`, so **this PR changes nothing a user can see or reach**. It was
split out to keep the bridge/plumbing review separate from the ~1400 lines of flow UI.

#### Coin module — `bond_public` as a transaction mode

- `BOND_PUBLIC` variant on `Transaction` / `TransactionRaw`, with `withdrawal` as its only
  extra field, plus `BondPublicIntent` in the SDK `Intent` union and the matching
  `AleoTransactionIntentData` case.
- `AleoStakingMode` introduced and used to narrow `derivePublicTransactionMode`'s return, so
  the send-flow mode derivation can't accidentally produce a staking mode.
- `BOND_PUBLIC` handled in `fromTransactionRaw` / `toTransactionRaw`, `isPublicTransaction`,
  `getAvailableBalance` (spends the transparent balance), `createTransactionIntent`,
  `mapTransactionIntentToSdkIntent` and `getFunctionNameFromTransactionType`.

#### Coin module — validator list, for the picker Part 2 adds

- `getUnbondingValidators` flags validators currently withdrawing their own stake; the network
  rejects new stake to those, so they surface as `isUnbonding` and sort below bondable ones.
- `getValidatorNonEarningReason` extracted out of `estimateNetRate`, which collapsed every
  non-earning rule to a rate of exactly `0`. Callers can now say *which* rule applies
  (`overConcentrated` above the 25% stake cap, `fullCommission` at 100%) instead of inferring
  it from a zero. `estimateNetRate` now delegates to it, so the two can't drift.
- A zero or unparseable `total_stake` is treated as absent rather than divided by — it would
  have made every validator's stake share infinite and flagged the entire list as non-earning.
- Names, total supply and unbonding state stay best-effort: losing any of them degrades one
  field rather than failing the whole list.

#### Desktop — entry point

- Earn action in the account header, gated on the currency config's `enableStaking`, opening
  the new Manage modal on the **main** account (a bond spends native ALEO, so a token account
  must not reach the flow as its `account`).
- Manage modal listing the full staking lifecycle — bond, unbond, claim — with all three rows
  disabled behind a "coming soon" tooltip, since no flow exists yet.
- `MODAL_ALEO_MANAGE` registered in `modals-loaders.ts` and added to `modalsToPreload`.

<img width="1709" height="834" alt="image" src="https://github.com/user-attachments/assets/9ceb3627-2bf9-4fc7-9d73-328abf17d7ca" />

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-32807](https://ledgerhq.atlassian.net/browse/LIVE-32807)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
