### PR TITLE
fix(llm): keep Continuation naming so HID survives R8 (LIVE-37010)

### DIFF
--- a/.changeset/quiet-pandas-render.md
+++ b/.changeset/quiet-pandas-render.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix app crash on the first APDU exchange over USB HID in minified Android builds

--- a/apps/ledger-live-mobile/android/app/proguard-rules.pro
+++ b/apps/ledger-live-mobile/android/app/proguard-rules.pro
@@ -32,3 +32,11 @@
 -keep class com.google.android.exoplayer2.** { *; }
 
 -keep class com.ledger.live.BuildConfig { *; }
+
+# LIVE-37010: the HID transport passes a `cont::resume` callable reference inside a data
+# class that gets interpolated into a log string. FunctionReference.toString() asks
+# kotlin-reflect to render it, which resolves `resume` against ContinuationKt. The
+# reference's JVM signature is a compile-time constant R8 never rewrites, so both the
+# member and the Continuation type name must survive shrinking for the lookup to match.
+-keep class kotlin.coroutines.ContinuationKt { *; }
+-keepnames class kotlin.coroutines.Continuation


### PR DESCRIPTION
### 📝 Description

On minified Android builds the app died on the **first APDU exchange over USB HID** with a `KotlinReflectionNotSupportedError`. HID was unusable end to end, not just in an edge case.

`DeviceConnectionStateMachine.handleEvent` in `@ledgerhq/device-transport-kit-react-native-hid` builds a log string that is never logged — the `loggerService` call is commented out — but R8 keeps the interpolation because it cannot prove `toString()` is side-effect free. The event being rendered carries a `cont::resume` callable reference, so `FunctionReference.toString()` asks kotlin-reflect to render the lambda, which resolves `resume` against `kotlin.coroutines.ContinuationKt`.

That resolution needs two things R8 removed:

| | |
|---|---|
| `ContinuationKt.resume` | `@InlineOnly`, so compiled to `private static final` and shrunk away → `no members found` |
| `kotlin.coroutines.Continuation` | renamed, while the reference's JVM signature stays a compile-time constant R8 never rewrites → signature mismatch |

Both keeps are required; either one alone still crashes. Verified by installing a local `stagingRelease` build on device.

> [!NOTE]
> This works around an upstream issue. The root cause is the dead log string in the SDK, which is still present on `device-sdk-ts` default branch and makes any lambda-carrying data class it logs a latent R8 crash. Worth a follow-up upstream so we can drop these rules.

Only `rn-hid` is affected: it is the sole transport kit in `device-sdk-ts` shipping Kotlin Android sources — `rn-ble` has none.

**Verification** — Xiaomi 24030PN60G / Android 16, local `stagingRelease` (`minifyEnabled true`):

| | before | after |
|---|---|---|
| Crash markers in logcat | `FATAL EXCEPTION` on first APDU | 0 in 22.6k lines |
| App process | died | survived, same PID throughout |

No automated check guards this yet: it only reproduces in a **minified** build, which neither unit tests nor Detox exercise. Real USB hardware is not actually required — the crash is in the reflection path, not the transport — so #21608 follows up with a build-time guard on these keep rules.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37010](https://ledgerhq.atlassian.net/browse/LIVE-37010)
- **ADR** (if any): —


[LIVE-37010]: https://ledgerhq.atlassian.net/browse/LIVE-37010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
