### PR TITLE
fix(contacts): add 8px spacing between list items (LIVE-36996)

### DIFF
--- a/.changeset/calm-lists-space.md
+++ b/.changeset/calm-lists-space.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts-list": patch
+"live-mobile": patch
+---
+
+Fix missing 8px spacing between items in the mobile contacts list

--- a/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
@@ -80,6 +80,7 @@ export function ContactsListView({
           renderSectionHeader={({ section }) => (
             <ContactsSectionHeader title={section.title} surface={surface} />
           )}
+          ItemSeparatorComponent={() => <Box lx={{ height: "s8" }} />}
           ListHeaderComponent={listHeader}
           onViewableItemsChanged={onViewableItemsChanged}
           viewabilityConfig={viewabilityConfig}

--- a/features/flow/flow-contacts-list/src/components/ContactsList/Section/ContactsSectionHeader.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/Section/ContactsSectionHeader.native.tsx
@@ -14,7 +14,7 @@ export function ContactsSectionHeader({
   return (
     <Box
       testID={`contacts-section-${title}-background`}
-      lx={{ width: "full", marginTop: "s8", backgroundColor: surface }}
+      lx={{ width: "full", marginVertical: "s8", backgroundColor: surface }}
     >
       <SectionHeader appearance="plain" testID={`contacts-section-${title}`} lx={{ width: "full" }}>
         <SectionHeaderTitle>{title}</SectionHeaderTitle>


### PR DESCRIPTION
### 📝 Description

Contact list items on mobile were flush against each other, missing the 8px gap from the design.

This adds an 8px item separator in the contacts `SectionList` and applies vertical margin on section headers so spacing is consistent above and below each letter group.

| Before                        | After                         |
|-------------------------------|-------------------------------|
|<img height="881" alt="image" src="https://github.com/user-attachments/assets/53f14dd4-09b5-4135-bf58-e3be7ea3ef23" />|<img  height="881" alt="Screenshot 2026-09-07 at 3 19 44 PM" src="https://github.com/user-attachments/assets/989e2a07-23b7-4de7-89a1-6fcb86826656" />|

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36996](https://ledgerhq.atlassian.net/browse/LIVE-36996)
- **ADR** (if any): n/a

[LIVE-36996]: https://ledgerhq.atlassian.net/browse/LIVE-36996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ