### PR TITLE
fix(hw-app-exchange): make prebuild idempotent

### DIFF
--- a/.changeset/hw-app-exchange-prebuild-format.md
+++ b/.changeset/hw-app-exchange-prebuild-format.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-exchange": patch
+---
+
+Format the generated protobuf files in `prebuild`. `pbjs`/`pbts` emit their own style while the committed `generate-protocol.js`/`.d.ts` are oxfmt-formatted, so regenerating them always dirtied the tree and failed the CLI job's `git diff` check. Only visible on an nx cache miss, which is why it went unnoticed.

--- a/libs/ledgerjs/packages/hw-app-exchange/package.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "clean": "rimraf lib lib-es",
-    "prebuild": "pnpm pbjs -t static-module -w es6 -r ledger_trade -o src/generate-protocol.js ./protocol.proto && pnpm pbts -o src/generate-protocol.d.ts src/generate-protocol.js",
+    "prebuild": "pnpm pbjs -t static-module -w es6 -r ledger_trade -o src/generate-protocol.js ./protocol.proto && pnpm pbts -o src/generate-protocol.d.ts src/generate-protocol.js && pnpm exec oxfmt -c ../../../../.oxfmtrc.json src/generate-protocol.js src/generate-protocol.d.ts",
     "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
     "postbuild": "cp src/generate-protocol.d.ts lib/generate-protocol.d.ts && cp src/generate-protocol.d.ts lib-es/generate-protocol.d.ts && rm -f lib/generate-protocol.d.ts.map lib-es/generate-protocol.d.ts.map",
     "coverage": "jest --coverage --passWithNoTests",


### PR DESCRIPTION
### 📝 Description

`hw-app-exchange`'s `prebuild` regenerates `src/generate-protocol.js` / `.d.ts` from `protocol.proto` via `pbjs`/`pbts`, which emit their own formatting. The committed files are oxfmt-formatted, so every regeneration dirtied the tree and failed the CLI job's `git diff --exit-code` check.

This was invisible as long as nx served the build from cache — but any change to a widely-depended-on lib invalidates that cache, and the job then went red for reasons unrelated to the PR.

Fix: run oxfmt on the two generated files as the last step of `prebuild`, so the output matches what is committed.

```diff
- ... && pnpm pbts -o src/generate-protocol.d.ts src/generate-protocol.js
+ ... && pnpm pbts -o src/generate-protocol.d.ts src/generate-protocol.js && pnpm exec oxfmt -c ../../../../.oxfmtrc.json src/generate-protocol.js src/generate-protocol.d.ts
```

Verified locally: `pnpm run prebuild` in the package now leaves the tree clean.

### 🔗 Context

- **JIRA / GitHub issue**: n/a — CI flakiness spotted while working on another branch
- **ADR** (if any): n/a
