### PR TITLE
[LWM] test(llm): guard the R8 keeps that keep HID alive (LIVE-37010)

### DIFF
--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -243,3 +243,79 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1"
 }
+
+// LIVE-37010 regression guard.
+//
+// The HID transport hands a `cont::resume` callable reference to a data class that gets
+// interpolated into a log string, so FunctionReference.toString() asks kotlin-reflect to
+// render it. kotlin-reflect then resolves `resume` against kotlin.coroutines.ContinuationKt
+// using the reference's JVM signature, which is a compile-time constant R8 never rewrites.
+// The lookup therefore only matches while both the member and the Continuation type name
+// survive shrinking. When they don't, the app dies on the first APDU exchange -- and only
+// on a minified build, which no unit test or Detox run exercises.
+//
+// These assertions read the R8 mapping and fail the build if either invariant is lost,
+// whether because the keep rules were dropped or because an AGP/R8/Kotlin upgrade defeated
+// them. They verify the keeps are still effective; they cannot prove the SDK has not started
+// reflecting over some other lambda, which would need a new keep of its own.
+def kotlinReflectMappingAssertions = [
+    [
+        needle: "\nkotlin.coroutines.Continuation -> kotlin.coroutines.Continuation:\n",
+        failure: "kotlin.coroutines.Continuation was renamed by R8.",
+        remedy : "-keepnames class kotlin.coroutines.Continuation",
+    ],
+    [
+        needle: "\nkotlin.coroutines.ContinuationKt -> kotlin.coroutines.ContinuationKt:\n",
+        failure: "kotlin.coroutines.ContinuationKt was renamed by R8.",
+        remedy : "-keep class kotlin.coroutines.ContinuationKt { *; }",
+    ],
+    [
+        needle: "void resume(kotlin.coroutines.Continuation,java.lang.Object)",
+        // The mapping records original signatures on the left of "->", so this only proves
+        // the member survived shrinking. Renaming of the parameter type is covered above.
+        failure: "ContinuationKt.resume(Continuation, Object) did not survive shrinking.",
+        remedy : "-keep class kotlin.coroutines.ContinuationKt { *; }",
+    ],
+]
+
+afterEvaluate {
+    android.buildTypes.each { buildType ->
+        if (!buildType.minifyEnabled) {
+            return
+        }
+        // This module declares no product flavors, so variant name == build type name.
+        def variant = buildType.name
+        def suffix = variant.capitalize()
+        def mappingFile = layout.buildDirectory.file("outputs/mapping/${variant}/mapping.txt")
+
+        def guard = tasks.register("verify${suffix}KotlinReflectKeeps") {
+            group = "verification"
+            description = "Assert the LIVE-37010 ProGuard keeps still hold in the ${variant} R8 mapping"
+            outputs.upToDateWhen { false }
+            doLast {
+                def file = mappingFile.get().asFile
+                if (!file.exists()) {
+                    throw new GradleException(
+                        "LIVE-37010 guard: no R8 mapping at ${file}. Cannot verify the" +
+                        " kotlin-reflect keep rules for the ${variant} variant."
+                    )
+                }
+                def mapping = file.text
+                def failures = kotlinReflectMappingAssertions.findAll { !mapping.contains(it.needle) }
+                if (!failures.isEmpty()) {
+                    def detail = failures.collect { "  - ${it.failure}\n    Required rule: ${it.remedy}" }.join("\n")
+                    throw new GradleException(
+                        "LIVE-37010 guard failed for the ${variant} variant: USB HID will crash the app" +
+                        " on the first APDU exchange.\n${detail}\n" +
+                        "  See apps/ledger-live-mobile/android/app/proguard-rules.pro and" +
+                        " https://ledgerhq.atlassian.net/browse/LIVE-37010"
+                    )
+                }
+            }
+        }
+
+        tasks.matching { it.name == "minify${suffix}WithR8" }.configureEach {
+            finalizedBy(guard)
+        }
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #21605 — base is `fix/llm-LIVE-37010-hid-crash-r8`, so this diff shows only the guard. Re-target to `develop` once #21605 lands.

### 📝 Description

#21605 fixes the HID crash with two ProGuard keeps, but nothing protected them. LIVE-37010 only reproduces on a **minified** build, which no unit test or Detox run exercises, so dropping a rule — or an AGP/R8/Kotlin upgrade quietly defeating one — would have shipped the crash again undetected.

This adds a Gradle verification task, wired to every minifying variant through `finalizedBy`, that reads the R8 mapping and fails the build when an invariant the fix depends on is lost:

| Assertion | Guards |
|---|---|
| `Continuation` not renamed | the reference's baked JVM signature can still match |
| `ContinuationKt` not renamed | kotlin-reflect can locate the file class |
| `resume(Continuation, Object)` present | the `@InlineOnly` member survived shrinking |

Failures name the missing rule and link the ticket, so the next person gets a fix rather than a puzzle.

Because it hooks the build itself rather than a CI job, it protects local `stagingRelease` builds too, at no extra CI cost — the task adds well under a second on top of R8.

**Validated in both directions** on `stagingRelease`, so no assertion is unproven:

| Run | Result |
|---|---|
| unmodified | `BUILD SUCCESSFUL` |
| `-keepnames class kotlin.coroutines.Continuation` removed | fails assertion 1 |
| `-keep class kotlin.coroutines.ContinuationKt { *; }` removed | fails assertions 2 and 3 |

> [!WARNING]
> This guards the keep rules, not the app. If the SDK starts reflecting over a different lambda, the signature will name other types, and the guard will stay green while the app breaks. Closing the class of bug means removing the dead log string in `DeviceConnectionStateMachine.handleEvent` upstream — it is still present on `device-sdk-ts` default branch.

A stricter guard is possible: an instrumented test on a minified variant, executing a lambda's `toString()` for real. It needs no USB hardware, contrary to what #21605's description claims, but it does need an emulator running against a minified build in CI — a much larger change, deliberately left out of this PR.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37010](https://ledgerhq.atlassian.net/browse/LIVE-37010)
- **ADR** (if any): —


[LIVE-37010]: https://ledgerhq.atlassian.net/browse/LIVE-37010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ