### PR TITLE
[LWM] fix(contacts): use horizontal more icon (LIVE-37000)

### DIFF
--- a/.changeset/contacts-more-horizontal.md
+++ b/.changeset/contacts-more-horizontal.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Use the horizontal more icon on the mobile contact detail page

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailNavigationViewModel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailNavigationViewModel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { IconButton } from "@ledgerhq/lumen-ui-rnative";
-import { MoreVertical } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { MoreHorizontal } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { useTranslation } from "~/context/Locale";
@@ -16,7 +16,7 @@ export function useContactDetailNavigationViewModel(onOpenActionsMenu?: () => vo
       <IconButton
         appearance="no-background"
         size="md"
-        icon={MoreVertical}
+        icon={MoreHorizontal}
         accessibilityLabel={t("contacts.detailActions.menuAccessibilityLabel")}
         onPress={onOpenActionsMenu}
         testID="contacts-detail-actions-trigger"


### PR DESCRIPTION
### 📝 Description

The contact detail page on mobile used a vertical more icon for the top-right actions button, which does not match the expected “more” affordance.

This change swaps `MoreVertical` for `MoreHorizontal` on the contact detail header action so the control matches the intended design.

| Before                        | After                         |
|-------------------------------|-------------------------------|
|<img height="860"  alt="image" src="https://github.com/user-attachments/assets/2df80c97-4e01-4990-ab53-1b3d51a0ee02" />|<img  height="860" alt="Screenshot 2026-09-07 at 3 31 49 PM" src="https://github.com/user-attachments/assets/9fdc7aef-5880-49bd-a846-d7f6cd86592b" />|

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37000](https://ledgerhq.atlassian.net/browse/LIVE-37000)
- **ADR** (if any): N/A

[LIVE-37000]: https://ledgerhq.atlassian.net/browse/LIVE-37000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ