### PR TITLE
[LWM] fix(contacts): contact page scrolls as one unit (LIVE-37006)

### DIFF
--- a/.changeset/curly-foxes-sleep.md
+++ b/.changeset/curly-foxes-sleep.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Fix contact detail page scroll — full page now scrolls as one unit with safe area inset support

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactDetailViewProps } from "./types";
 import { ContactDetailAddressList } from "./components/ContactDetailAddressList/ContactDetailAddressList.native";
@@ -16,31 +18,41 @@ export function ContactDetailView({
   addressGroups,
   onAddressRowPress,
 }: ContactDetailViewProps): React.JSX.Element {
+  const { bottom } = useSafeAreaInsets();
   const hasPopulatedAddresses = addressGroups !== undefined && onAddressRowPress !== undefined;
 
   return (
     <Box testID="contacts-detail-screen" lx={{ flex: 1, backgroundColor: "base" }}>
-      <ContactDetailHeader
-        contact={contact}
-        labels={labels}
-        meAvatarSrc={meAvatarSrc}
-        onAddAddress={onAddAddress}
-      />
-      {ledgerWalletAccountsIntent && labels.ledgerWalletAddresses && onLedgerWalletAccountsPress ? (
-        <LedgerWalletAddressesCard
-          label={labels.ledgerWalletAddresses}
-          intent={ledgerWalletAccountsIntent}
-          onPress={onLedgerWalletAccountsPress}
+      <ScrollView
+        style={{ flex: 1 }}
+        alwaysBounceVertical={false}
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: bottom }}
+        showsVerticalScrollIndicator={false}
+      >
+        <ContactDetailHeader
+          contact={contact}
+          labels={labels}
+          meAvatarSrc={meAvatarSrc}
+          onAddAddress={onAddAddress}
         />
-      ) : null}
-      {hasPopulatedAddresses ? (
-        <ContactDetailAddressList
-          addressGroups={addressGroups}
-          onAddressRowPress={onAddressRowPress}
-        />
-      ) : (
-        <ContactDetailEmptyState contact={contact} labels={labels} />
-      )}
+        {ledgerWalletAccountsIntent &&
+        labels.ledgerWalletAddresses &&
+        onLedgerWalletAccountsPress ? (
+          <LedgerWalletAddressesCard
+            label={labels.ledgerWalletAddresses}
+            intent={ledgerWalletAccountsIntent}
+            onPress={onLedgerWalletAccountsPress}
+          />
+        ) : null}
+        {hasPopulatedAddresses ? (
+          <ContactDetailAddressList
+            addressGroups={addressGroups}
+            onAddressRowPress={onAddressRowPress}
+          />
+        ) : (
+          <ContactDetailEmptyState contact={contact} labels={labels} />
+        )}
+      </ScrollView>
     </Box>
   );
 }

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressList/ContactDetailAddressList.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressList/ContactDetailAddressList.native.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ScrollView } from "react-native";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactDetailAddressNetworkGroup, ContactDetailAddressRowIntent } from "../../types";
 import { ContactDetailAddressNetworkSection } from "../ContactDetailAddressNetworkSection/ContactDetailAddressNetworkSection.native";
@@ -14,21 +13,17 @@ export function ContactDetailAddressList({
   onAddressRowPress,
 }: ContactDetailAddressListProps): React.JSX.Element {
   return (
-    <ScrollView
+    <Box
       testID="contacts-detail-address-list"
-      alwaysBounceVertical={false}
-      contentContainerStyle={{ flexGrow: 1 }}
-      showsVerticalScrollIndicator={false}
+      lx={{ gap: "s24", paddingHorizontal: "s16", paddingTop: "s32", paddingBottom: "s32" }}
     >
-      <Box lx={{ gap: "s24", paddingHorizontal: "s16", paddingTop: "s32", paddingBottom: "s32" }}>
-        {addressGroups.map(group => (
-          <ContactDetailAddressNetworkSection
-            key={group.networkId}
-            group={group}
-            onAddressRowPress={onAddressRowPress}
-          />
-        ))}
-      </Box>
-    </ScrollView>
+      {addressGroups.map(group => (
+        <ContactDetailAddressNetworkSection
+          key={group.networkId}
+          group={group}
+          onAddressRowPress={onAddressRowPress}
+        />
+      ))}
+    </Box>
   );
 }

--- a/support/jest-features-flow/index.js
+++ b/support/jest-features-flow/index.js
@@ -21,6 +21,7 @@ const nativeMocks = {
   // from inside @testing-library/react-native.
   "^react-native$": path.join(__dirname, "mocks/react-native.js"),
   "^react-native-reanimated$": path.join(__dirname, "mocks/reanimated.js"),
+  "^react-native-safe-area-context$": path.join(__dirname, "mocks/safe-area-context.js"),
   "^@ledgerhq/lumen-ui-rnative(/.*)?$": path.join(__dirname, "mocks/passthrough-native.js"),
   "^@ledgerhq/crypto-icons$": path.join(__dirname, "mocks/passthrough-native.js"),
   "\\.(webp|png|jpg|jpeg|gif|svg)$": path.join(__dirname, "mocks/file-stub.js"),

--- a/support/jest-features-flow/mocks/safe-area-context.js
+++ b/support/jest-features-flow/mocks/safe-area-context.js
@@ -1,0 +1,4 @@
+module.exports = {
+  __esModule: true,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+};


### PR DESCRIPTION
### 📝 Description

On the contact detail page (LWM), only the address list section was scrollable — the header (avatar, name, "Add address" button) was fixed in place, blocking natural scroll behaviour. Additionally, the last address row was hidden behind the Android/iOS navigation bar.

**Fix**: moved the `ScrollView` from `ContactDetailAddressList` up to `ContactDetailView` so the entire page (header + address list) scrolls as one unit. Added `useSafeAreaInsets` bottom padding so the last item clears the system navigation bar.

https://github.com/user-attachments/assets/e336957b-52a0-4d8c-8b23-5aec18711a4f


### 🔗 Context

- **JIRA issue**: [LIVE-37006](https://ledgerhq.atlassian.net/browse/LIVE-37006)

[LIVE-37006]: https://ledgerhq.atlassian.net/browse/LIVE-37006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ