### PR TITLE
[LWDM] chore(env): migrate BIG_NUMBER_DECIMAL_PLACES off live-env (LIVE-37030)

### DIFF
--- a/.changeset/live-currency-format-drop-live-env.md
+++ b/.changeset/live-currency-format-drop-live-env.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/live-currency-format": patch
+"@ledgerhq/ledger-wallet-framework": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-cli": patch
+"@shared/env": patch
+---
+
+Migrate `BIG_NUMBER_DECIMAL_PLACES` off `@ledgerhq/live-env`: every call site now inlines the constant and the definition is removed. `@ledgerhq/live-currency-format` drops its `@ledgerhq/live-env` dependency altogether.

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -1,4 +1,4 @@
-import { EnvName, setEnv, setEnvUnsafe, getEnv } from "@shared/env";
+import { EnvName, setEnv, setEnvUnsafe } from "@shared/env";
 import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { listen } from "@ledgerhq/logs";
 import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-coins";
@@ -65,4 +65,6 @@ const value = "cli/0.0.0";
 setEnv("LEDGER_CLIENT_VERSION", value);
 bridgeEnvToNetworkState();
 
-BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });
+const BIG_NUMBER_DECIMAL_PLACES = 40;
+
+BigNumber.set({ DECIMAL_PLACES: BIG_NUMBER_DECIMAL_PLACES });

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -1,5 +1,5 @@
 import os from "os";
-import { setEnv, getEnv } from "@shared/env";
+import { setEnv } from "@shared/env";
 import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import {
@@ -39,4 +39,6 @@ liveBlindSigningReporter.setContext({
   platformVersion: os.release(),
 });
 
-BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });
+const BIG_NUMBER_DECIMAL_PLACES = 40;
+
+BigNumber.set({ DECIMAL_PLACES: BIG_NUMBER_DECIMAL_PLACES });

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -1,7 +1,7 @@
 import Config from "react-native-config";
 import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-coins";
 import { listen } from "@ledgerhq/logs";
-import { setEnv, getEnv } from "@shared/env";
+import { setEnv } from "@shared/env";
 import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
@@ -68,4 +68,6 @@ bridgeEnvToNetworkState();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 setSecp256k1Instance(require("./logic/secp256k1"));
 
-BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });
+const BIG_NUMBER_DECIMAL_PLACES = 40;
+
+BigNumber.set({ DECIMAL_PLACES: BIG_NUMBER_DECIMAL_PLACES });

--- a/libs/ledger-wallet-framework/src/setup.ts
+++ b/libs/ledger-wallet-framework/src/setup.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { getEnv } from "@ledgerhq/live-env";
 
-BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });
+const BIG_NUMBER_DECIMAL_PLACES = 40;
+
+BigNumber.set({ DECIMAL_PLACES: BIG_NUMBER_DECIMAL_PLACES });

--- a/libs/live-currency-format/jest-env-setup.js
+++ b/libs/live-currency-format/jest-env-setup.js
@@ -1,8 +1,0 @@
-const { injectDefinitions, intParser } = require("@ledgerhq/live-env");
-injectDefinitions({
-  BIG_NUMBER_DECIMAL_PLACES: {
-    def: 40,
-    parser: intParser,
-    desc: "bignumber.js decimal places configuration",
-  },
-});

--- a/libs/live-currency-format/jest.config.js
+++ b/libs/live-currency-format/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
     ],
   },
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFiles: ["<rootDir>/jest-env-setup.js"],
   setupFilesAfterEnv: ["<rootDir>/src/setup.ts", "@ledgerhq/test-quarantine/jest-retries"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [

--- a/libs/live-currency-format/package.json
+++ b/libs/live-currency-format/package.json
@@ -21,8 +21,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "bignumber.js": "^9.1.2",
-    "@ledgerhq/live-env": "workspace:^"
+    "bignumber.js": "^9.1.2"
   },
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:*",

--- a/libs/live-currency-format/src/setup.ts
+++ b/libs/live-currency-format/src/setup.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { getEnv } from "@ledgerhq/live-env";
 
-BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });
+const BIG_NUMBER_DECIMAL_PLACES = 40;
+
+BigNumber.set({ DECIMAL_PLACES: BIG_NUMBER_DECIMAL_PLACES });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15228,9 +15228,6 @@ importers:
 
   libs/live-currency-format:
     dependencies:
-      '@ledgerhq/live-env':
-        specifier: workspace:^
-        version: link:../env
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2

--- a/shared/env/src/definitions/team-wallet-xp/index.ts
+++ b/shared/env/src/definitions/team-wallet-xp/index.ts
@@ -56,11 +56,6 @@ const teamWalletXp = {
     parser: intParser,
     desc: "maximum size of account names",
   },
-  BIG_NUMBER_DECIMAL_PLACES: {
-    def: 40,
-    parser: intParser,
-    desc: "bignumber.js decimal places configuration",
-  },
   CRYPTO_ASSET_SEARCH_KEYS: {
     def: ["ticker", "name", "keywords"],
     parser: stringArrayParser,


### PR DESCRIPTION
Applies [`libs/env/MIGRATION.md`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/env/MIGRATION.md) to `BIG_NUMBER_DECIMAL_PLACES`. No product path sets it — the only writers are the generic escape hatches (the CLI's `process.env` loop and the debug UI) — so it takes exit 2, the inline constant, and the definition goes with it in the same PR.

Five call sites, all identical `BigNumber.set({ DECIMAL_PLACES: 40 })` bootstraps: two jest setups (`@ledgerhq/live-currency-format`, `@ledgerhq/ledger-wallet-framework`) and the three app composition roots (desktop, mobile, cli). Each now names the constant locally rather than importing a registry to read a number back out of it.

`@ledgerhq/live-currency-format` drops the `@ledgerhq/live-env` dependency entirely, along with the `injectDefinitions()` jest bootstrap it only needed to keep `getEnv` from throwing in its own tests. `@ledgerhq/ledger-wallet-framework` keeps the dependency — it still has twelve other call sites.

[LIVE-37030](https://ledgerhq.atlassian.net/browse/LIVE-37030)

[LIVE-37030]: https://ledgerhq.atlassian.net/browse/LIVE-37030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
