### PR TITLE
feat(pay-card): freeze/unfreeze VM and button (LIVE-35433)

### DIFF
--- a/.changeset/LIVE-35433-pay-card-freeze-vm.md
+++ b/.changeset/LIVE-35433-pay-card-freeze-vm.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-details": minor
+---
+
+Add Freeze component with useFreezeCardViewModel: freeze/unfreeze TileButton with optimistic state and error handling

--- a/features/flow/pay-card-details/package.json
+++ b/features/flow/pay-card-details/package.json
@@ -28,6 +28,7 @@
     "unimported": "pnpm knip --directory ../../.. -c features/flow/pay-card-details/knip.web.config.mjs -W features/flow/pay-card-details --tsConfig tsconfig.web.json && pnpm knip --directory ../../.. -c features/flow/pay-card-details/knip.native.config.mjs -W features/flow/pay-card-details --tsConfig tsconfig.native.json"
   },
   "dependencies": {
+    "@domain/api-card-management": "workspace:*",
     "@ledgerhq/lumen-utils-shared": "catalog:"
   },
   "devDependencies": {

--- a/features/flow/pay-card-details/src/components/Freeze/Freeze.native.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/Freeze.native.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { useFreezeCardViewModel } from "./useFreezeCardViewModel";
+import { FreezeView } from "./FreezeView";
+
+export function Freeze() {
+  return <FreezeView {...useFreezeCardViewModel()} />;
+}

--- a/features/flow/pay-card-details/src/components/Freeze/Freeze.web.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/Freeze.web.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { useFreezeCardViewModel } from "./useFreezeCardViewModel";
+import { FreezeView } from "./FreezeView";
+
+export function Freeze() {
+  return <FreezeView {...useFreezeCardViewModel()} />;
+}

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { TileButton } from "@ledgerhq/lumen-ui-rnative";
+import { Snow } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { FreezeViewProps } from "../../types";
+
+export function FreezeView({
+  isFrozen,
+  isBlocked,
+  isStatusLoading,
+  isFreezeLoading,
+  isUnfreezeLoading,
+  onFreeze,
+  onUnfreeze,
+}: FreezeViewProps) {
+  return (
+    <TileButton
+      icon={Snow}
+      onPress={isFrozen ? onUnfreeze : onFreeze}
+      disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
+      isFull
+    >
+      {isFrozen ? "Unfreeze" : "Freeze"}
+    </TileButton>
+  );
+}

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { TileButton } from "@ledgerhq/lumen-ui-react";
+import { Snow } from "@ledgerhq/lumen-ui-react/symbols";
+import type { FreezeViewProps } from "../../types";
+
+export function FreezeView({
+  isFrozen,
+  isBlocked,
+  isStatusLoading,
+  isFreezeLoading,
+  isUnfreezeLoading,
+  onFreeze,
+  onUnfreeze,
+}: FreezeViewProps) {
+  return (
+    <TileButton
+      icon={Snow}
+      onClick={isFrozen ? onUnfreeze : onFreeze}
+      disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
+      isFull
+    >
+      {isFrozen ? "Unfreeze" : "Freeze"}
+    </TileButton>
+  );
+}

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from "@testing-library/react";
+import { useFreezeCardViewModel } from "./useFreezeCardViewModel";
+
+jest.mock("@domain/api-card-management", () => ({
+  useFreezeCardMutation: jest.fn(),
+  useGetCardStatusQuery: jest.fn(),
+  useUnfreezeCardMutation: jest.fn(),
+}));
+
+import {
+  useFreezeCardMutation,
+  useGetCardStatusQuery,
+  useUnfreezeCardMutation,
+  type PayCardStatus,
+} from "@domain/api-card-management";
+
+function setupMocks({
+  status = "ACTIVE" as PayCardStatus["status"] | null,
+  isStatusLoading = false,
+  isFreezeLoading = false,
+  isFreezeError = false,
+  isUnfreezeLoading = false,
+  isUnfreezeError = false,
+} = {}) {
+  const freeze = jest.fn();
+  const unfreeze = jest.fn();
+
+  jest.mocked(useGetCardStatusQuery).mockReturnValue({
+    data: status
+      ? { id: "card-id", panLast4: "1234", status, type: "VIRTUAL" as const, orderedAt: "" }
+      : undefined,
+    isLoading: isStatusLoading,
+  } as unknown as ReturnType<typeof useGetCardStatusQuery>);
+
+  jest
+    .mocked(useFreezeCardMutation)
+    .mockReturnValue([
+      freeze,
+      { isLoading: isFreezeLoading, isError: isFreezeError },
+    ] as unknown as ReturnType<typeof useFreezeCardMutation>);
+
+  jest
+    .mocked(useUnfreezeCardMutation)
+    .mockReturnValue([
+      unfreeze,
+      { isLoading: isUnfreezeLoading, isError: isUnfreezeError },
+    ] as unknown as ReturnType<typeof useUnfreezeCardMutation>);
+
+  return { freeze, unfreeze };
+}
+
+describe("useFreezeCardViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns isFrozen: false when status is ACTIVE", () => {
+    setupMocks({ status: "ACTIVE" });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isFrozen).toBe(false);
+  });
+
+  it("returns isFrozen: true when status is FROZEN", () => {
+    setupMocks({ status: "FROZEN" });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isFrozen).toBe(true);
+  });
+
+  it("returns isFrozen: true (optimistic) while freeze mutation is loading", () => {
+    setupMocks({ status: "ACTIVE", isFreezeLoading: true });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isFrozen).toBe(true);
+  });
+
+  it("returns isFrozen: false (optimistic) while unfreeze mutation is loading", () => {
+    setupMocks({ status: "FROZEN", isUnfreezeLoading: true });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isFrozen).toBe(false);
+  });
+
+  it("returns isBlocked: true when status is BLOCKED", () => {
+    setupMocks({ status: "BLOCKED" });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isBlocked).toBe(true);
+  });
+
+  it("returns isBlocked: false for non-BLOCKED statuses", () => {
+    setupMocks({ status: "ACTIVE" });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isBlocked).toBe(false);
+  });
+
+  it("calls freeze mutation when onFreeze is invoked", () => {
+    const { freeze } = setupMocks({ status: "ACTIVE" });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    result.current.onFreeze();
+    expect(freeze).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls unfreeze mutation when onUnfreeze is invoked", () => {
+    const { unfreeze } = setupMocks({ status: "FROZEN" });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    result.current.onUnfreeze();
+    expect(unfreeze).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes isFreezeError: true when freeze mutation errored", () => {
+    setupMocks({ isFreezeError: true });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isFreezeError).toBe(true);
+  });
+
+  it("exposes isUnfreezeError: true when unfreeze mutation errored", () => {
+    setupMocks({ isUnfreezeError: true });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isUnfreezeError).toBe(true);
+  });
+
+  it("exposes isStatusLoading: true while card status query is loading", () => {
+    setupMocks({ isStatusLoading: true, status: null });
+    const { result } = renderHook(() => useFreezeCardViewModel());
+    expect(result.current.isStatusLoading).toBe(true);
+    expect(result.current.isFrozen).toBe(false);
+  });
+});

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
@@ -1,0 +1,51 @@
+import { useMemo } from "react";
+import {
+  useFreezeCardMutation,
+  useGetCardStatusQuery,
+  useUnfreezeCardMutation,
+  type PayCardStatus,
+} from "@domain/api-card-management";
+import type { FreezeCardViewProps } from "../../types";
+
+function resolveOptimisticFrozen(
+  statusFromApi: PayCardStatus["status"] | undefined,
+  isFreezeLoading: boolean,
+  isUnfreezeLoading: boolean,
+): boolean {
+  if (isFreezeLoading) return true;
+  if (isUnfreezeLoading) return false;
+  return statusFromApi === "FROZEN";
+}
+
+export function useFreezeCardViewModel(): FreezeCardViewProps {
+  const { data: cardStatus, isLoading: isStatusLoading } = useGetCardStatusQuery();
+  const [freeze, { isLoading: isFreezeLoading, isError: isFreezeError }] = useFreezeCardMutation();
+  const [unfreeze, { isLoading: isUnfreezeLoading, isError: isUnfreezeError }] =
+    useUnfreezeCardMutation();
+
+  return useMemo(() => {
+    const statusFromApi = cardStatus?.status;
+    const isFrozen = resolveOptimisticFrozen(statusFromApi, isFreezeLoading, isUnfreezeLoading);
+
+    return {
+      isFrozen,
+      isBlocked: statusFromApi === "BLOCKED",
+      isStatusLoading,
+      isFreezeLoading,
+      isUnfreezeLoading,
+      isFreezeError,
+      isUnfreezeError,
+      onFreeze: () => void freeze(),
+      onUnfreeze: () => void unfreeze(),
+    };
+  }, [
+    cardStatus,
+    isStatusLoading,
+    isFreezeLoading,
+    isUnfreezeLoading,
+    isFreezeError,
+    isUnfreezeError,
+    freeze,
+    unfreeze,
+  ]);
+}

--- a/features/flow/pay-card-details/src/exports.ts
+++ b/features/flow/pay-card-details/src/exports.ts
@@ -1,3 +1,5 @@
 export * from "./components/CardArtwork/CardArtwork";
+export * from "./components/Freeze/Freeze";
 export * from "./components/CardVisual/CardVisual";
+export * from "./components/Freeze/useFreezeCardViewModel";
 export * from "./types";

--- a/features/flow/pay-card-details/src/types.ts
+++ b/features/flow/pay-card-details/src/types.ts
@@ -15,3 +15,27 @@ export type CardVisualProps = Readonly<{
 }>;
 
 export type CardVisualViewProps = CardVisualProps;
+
+export type FreezeCardViewProps = Readonly<{
+  isFrozen: boolean;
+  /** `true` when card status is BLOCKED — disables all freeze/unfreeze actions. */
+  isBlocked: boolean;
+  isStatusLoading: boolean;
+  isFreezeLoading: boolean;
+  isUnfreezeLoading: boolean;
+  isFreezeError: boolean;
+  isUnfreezeError: boolean;
+  onFreeze: () => void;
+  onUnfreeze: () => void;
+}>;
+
+export type FreezeViewProps = Pick<
+  FreezeCardViewProps,
+  | "isFrozen"
+  | "isBlocked"
+  | "isStatusLoading"
+  | "isFreezeLoading"
+  | "isUnfreezeLoading"
+  | "onFreeze"
+  | "onUnfreeze"
+>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6874,6 +6874,9 @@ importers:
 
   features/flow/pay-card-details:
     dependencies:
+      '@domain/api-card-management':
+        specifier: workspace:*
+        version: link:../../../domain/api/card-management
       '@ledgerhq/lumen-utils-shared':
         specifier: 'catalog:'
         version: 0.1.11(react@19.1.4)
@@ -22272,11 +22275,6 @@ packages:
       '@ledgerhq/live-network': ^3.0.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/coin-module-framework@8.3.0':
-    resolution: {integrity: sha512-7AVtJjgDBTeoFWrzDDnOAmkiZEuMsg3fayVukRgWnID3m4sg/048XKqO9uKljw/i0OEi4pDc3hNJ8gQgYJR10w==}
-    peerDependencies:
-      '@ledgerhq/live-network': ^3.0.0
-
   '@ledgerhq/coin-module-framework@8.4.0':
     resolution: {integrity: sha512-dHt1kPdVyQPpMKCiY3Or0rcl1XvcIFrqN9/asZ5lKleNdDKw0ea1AiJwWe9rBH+QSfNQBNWO8H8Ai9ksfKFjFA==}
     peerDependencies:
@@ -23020,6 +23018,7 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -33643,11 +33642,6 @@ packages:
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
-  jayson@4.1.2:
-    resolution: {integrity: sha512-5nzMWDHy6f+koZOuYsArh2AXs73NfWYVlFyJJuCedr93GpY+Ku8qq10ropSXVfHK+H0T6paA88ww+/dV+1fBNA==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   jayson@4.3.0:
     resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
     engines: {node: '>=8'}
@@ -33938,9 +33932,6 @@ packages:
 
   js-base64@3.7.7:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
-
-  js-base64@3.7.8:
-    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-base64@3.9.3:
     resolution: {integrity: sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==}
@@ -37250,7 +37241,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -43736,7 +43726,7 @@ snapshots:
 
   '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
@@ -43787,7 +43777,7 @@ snapshots:
 
   '@babel/traverse@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.29.2
@@ -43982,7 +43972,7 @@ snapshots:
 
   '@callstack/repack-dev-server@5.2.5':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@fastify/middie': 9.3.2
       '@fastify/sensible': 6.0.4
       fastify: 5.8.5
@@ -45681,7 +45671,7 @@ snapshots:
 
   '@expo/metro-config@54.0.14(expo@54.0.33(01371b6b08adf68dcde9ab2ace4a34f9))':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
       '@expo/config': 12.0.13
@@ -47706,15 +47696,6 @@ snapshots:
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': 6.19.0
 
-  '@ledgerhq/coin-module-framework@8.3.0':
-    dependencies:
-      bignumber.js: 9.1.2
-
-  '@ledgerhq/coin-module-framework@8.3.0(@ledgerhq/live-network@libs+live-network)':
-    dependencies:
-      '@ledgerhq/live-network': link:libs/live-network
-      bignumber.js: 9.1.2
-
   '@ledgerhq/coin-module-framework@8.4.0':
     dependencies:
       bignumber.js: 9.1.2
@@ -47727,7 +47708,7 @@ snapshots:
   '@ledgerhq/coin-stellar@9.6.0(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
     dependencies:
       '@exodus/patch-broken-hermes-typed-arrays': 1.0.0-alpha.1(patch_hash=7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732)
-      '@ledgerhq/coin-module-framework': 8.3.0(@ledgerhq/live-network@libs+live-network)
+      '@ledgerhq/coin-module-framework': 8.4.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': 6.19.0
       '@stellar/stellar-sdk': 14.0.0
@@ -47737,7 +47718,7 @@ snapshots:
 
   '@ledgerhq/coin-tezos@10.2.1':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.3.0
+      '@ledgerhq/coin-module-framework': 8.4.0
       '@taquito/ledger-signer': 23.0.1
       '@taquito/rpc': 23.0.1
       '@taquito/taquito': 23.0.1
@@ -47747,7 +47728,7 @@ snapshots:
 
   '@ledgerhq/coin-tezos@10.2.1(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.3.0(@ledgerhq/live-network@libs+live-network)
+      '@ledgerhq/coin-module-framework': 8.4.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': 6.19.0
       '@taquito/ledger-signer': 23.0.1
@@ -47759,7 +47740,7 @@ snapshots:
 
   '@ledgerhq/coin-xrp@10.1.0(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.3.0(@ledgerhq/live-network@libs+live-network)
+      '@ledgerhq/coin-module-framework': 8.4.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': 6.19.0
       bignumber.js: 9.1.2
@@ -48033,7 +48014,7 @@ snapshots:
     dependencies:
       '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
-      js-base64: 3.7.8
+      js-base64: 3.9.3
       purify-ts: 2.1.0
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4)
       react-native-ble-plx: 3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(react@19.1.4)
@@ -49940,7 +49921,7 @@ snapshots:
       '@polkadot/x-textdecoder': 14.0.1
       '@polkadot/x-textencoder': 14.0.1
       '@types/bn.js': 5.2.0
-      bn.js: 5.2.2
+      bn.js: 5.2.5
       tslib: 2.6.2
 
   '@polkadot/wasm-bridge@7.5.4(@polkadot/util@14.0.1)(@polkadot/x-randomvalues@14.0.1(@polkadot/util@14.0.1)(@polkadot/wasm-util@7.5.4(@polkadot/util@14.0.1)))':
@@ -50712,7 +50693,7 @@ snapshots:
     dependencies:
       '@react-native-community/cli-tools': 18.0.1
       chalk: 4.1.2
-      cosmiconfig: 9.0.0(@typescript/typescript6@6.0.2)
+      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.2)
       deepmerge: 4.3.1
       fast-glob: 3.3.2
       joi: 17.12.2
@@ -50912,7 +50893,7 @@ snapshots:
 
   '@react-native/babel-plugin-codegen@0.81.6':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.8
       '@react-native/codegen': 0.81.6
     transitivePeerDependencies:
       - '@babel/core'
@@ -50920,7 +50901,7 @@ snapshots:
 
   '@react-native/babel-plugin-codegen@0.81.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.8
       '@react-native/codegen': 0.81.6(@babel/core@7.28.5)
     transitivePeerDependencies:
       - '@babel/core'
@@ -51068,7 +51049,7 @@ snapshots:
       '@babel/plugin-transform-sticky-regex': 7.27.1
       '@babel/plugin-transform-typescript': 7.28.5
       '@babel/plugin-transform-unicode-regex': 7.27.1
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@react-native/babel-plugin-codegen': 0.81.6
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2
@@ -51118,7 +51099,7 @@ snapshots:
       '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@react-native/babel-plugin-codegen': 0.81.6(@babel/core@7.28.5)
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.28.5)
@@ -51151,7 +51132,7 @@ snapshots:
 
   '@react-native/codegen@0.81.6':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       glob: 7.2.3
       hermes-parser: 0.29.1
       invariant: 2.2.4
@@ -51161,7 +51142,7 @@ snapshots:
   '@react-native/codegen@0.81.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       glob: 7.2.3
       hermes-parser: 0.29.1
       invariant: 2.2.4
@@ -53309,12 +53290,12 @@ snapshots:
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(@typescript/typescript6@6.0.2)
       agentkeepalive: 4.6.0
-      bn.js: 5.2.2
+      bn.js: 5.2.5
       borsh: 0.7.0
       bs58: 4.0.1
       buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
       fast-stable-stringify: 1.0.0
-      jayson: 4.1.2
+      jayson: 4.3.0
       node-fetch: 2.7.0
       rpc-websockets: 9.0.4
       superstruct: 2.0.2
@@ -54545,7 +54526,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -54724,8 +54705,8 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
@@ -59626,7 +59607,7 @@ snapshots:
       sanitize-filename: 1.6.3
       semver: 7.8.1
       serialize-error: 8.1.0
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       signal-exit: 3.0.7
       stream-json: 1.8.0
       strip-ansi: 6.0.1
@@ -59682,7 +59663,7 @@ snapshots:
       sanitize-filename: 1.6.3
       semver: 7.8.1
       serialize-error: 8.1.0
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       signal-exit: 3.0.7
       stream-json: 1.8.0
       strip-ansi: 6.0.1
@@ -62843,7 +62824,7 @@ snapshots:
 
   isomorphic-fetch@3.0.0:
     dependencies:
-      node-fetch: 2.6.13
+      node-fetch: 2.7.0
       whatwg-fetch: 3.6.20
     transitivePeerDependencies:
       - encoding
@@ -62902,7 +62883,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.8.1
@@ -62963,24 +62944,6 @@ snapshots:
       minimatch: 3.1.2
 
   javascript-stringify@2.1.0: {}
-
-  jayson@4.1.2:
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 12.20.55
-      '@types/ws': 7.4.7
-      JSONStream: 1.3.5
-      commander: 2.20.3
-      delay: 5.0.0
-      es6-promisify: 5.0.0
-      eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10)
-      json-stringify-safe: 5.0.1
-      uuid: 8.3.2
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   jayson@4.3.0:
     dependencies:
@@ -63825,8 +63788,6 @@ snapshots:
   js-base64@3.7.4: {}
 
   js-base64@3.7.7: {}
-
-  js-base64@3.7.8: {}
 
   js-base64@3.9.3: {}
 
@@ -65595,11 +65556,11 @@ snapshots:
 
   metro@0.81.5:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       accepts: 1.3.8


### PR DESCRIPTION
### Description

Adds `useFreezeCardViewModel` and the `Freeze` component to `@features/flow-pay-card-details`.

**Problem**: No ViewModel or UI existed to expose freeze/unfreeze actions from the card status API.

**Changes**:
- `useFreezeCardViewModel` — reads `getCardStatus`, calls `freezeCard`/`unfreezeCard` mutations, derives optimistic `isFrozen` state while a mutation is in-flight
- `Freeze` — platform-split TileButton (Snow icon, "Freeze"/"Unfreeze" label); native via `lumen-ui-rnative`, web via `lumen-ui-react`
- 11 unit tests, 100% coverage on the ViewModel
- `isFrozen` typed via `PayCardStatus["status"]` (Zod schema)

### Context

- JIRA: [LIVE-35433](https://ledgerhq.atlassian.net/browse/LIVE-35433)

[LIVE-35433]: https://ledgerhq.atlassian.net/browse/LIVE-35433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ