### PR TITLE
fix(mise): use full, pinned git URLs for plugins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -18,11 +18,6 @@ lockfile_platforms = [
 ]
 
 [plugins]
-# Full git URLs, pinned to a commit.
-# - mise 2026.7+ resolves a bare "owner/repo" as a relative filesystem path
-#   instead of a GitHub shorthand, which breaks `mise install`.
-# - The #<sha> suffix pins these third-party plugins, which otherwise track
-#   their default branch and can change under us.
 bundler = "https://github.com/jonathanmorley/asdf-bundler.git#a461ac46039620aed0a4f8478ff028ea890c5cda"
 cocoapods = "https://github.com/mise-plugins/mise-cocoapods.git#63cb1acce2c2581b374ce5e11724bd2081f494b3"
 

--- a/mise.toml
+++ b/mise.toml
@@ -18,8 +18,10 @@ lockfile_platforms = [
 ]
 
 [plugins]
-bundler = "jonathanmorley/asdf-bundler"
-cocoapods = "mise-plugins/mise-cocoapods"
+# Use full git URLs. mise 2026.7+ resolves a bare "owner/repo" as a relative
+# filesystem path instead of a GitHub shorthand, which breaks `mise install`.
+bundler = "https://github.com/jonathanmorley/asdf-bundler.git"
+cocoapods = "https://github.com/mise-plugins/mise-cocoapods.git"
 
 
 [tools]

--- a/mise.toml
+++ b/mise.toml
@@ -18,10 +18,13 @@ lockfile_platforms = [
 ]
 
 [plugins]
-# Use full git URLs. mise 2026.7+ resolves a bare "owner/repo" as a relative
-# filesystem path instead of a GitHub shorthand, which breaks `mise install`.
-bundler = "https://github.com/jonathanmorley/asdf-bundler.git"
-cocoapods = "https://github.com/mise-plugins/mise-cocoapods.git"
+# Full git URLs, pinned to a commit.
+# - mise 2026.7+ resolves a bare "owner/repo" as a relative filesystem path
+#   instead of a GitHub shorthand, which breaks `mise install`.
+# - The #<sha> suffix pins these third-party plugins, which otherwise track
+#   their default branch and can change under us.
+bundler = "https://github.com/jonathanmorley/asdf-bundler.git#a461ac46039620aed0a4f8478ff028ea890c5cda"
+cocoapods = "https://github.com/mise-plugins/mise-cocoapods.git#63cb1acce2c2581b374ce5e11724bd2081f494b3"
 
 
 [tools]


### PR DESCRIPTION
### 📝 Description

`[plugins]` declared its sources with the bare shorthand `owner/repo`. mise 2026.7+ resolves that as a *relative filesystem path* instead of a GitHub shorthand, so `mise install` fails locally for anyone on a newer mise than the version CI pins:

```
mise ERROR Could not verify that ".../ledger-live/jonathanmorley/asdf-bundler" url is a valid git directory
```

Both URLs also tracked their default branch, so these third-party plugins — whose shell scripts run locally — could change without any change here.

Fix: full git URLs, pinned to the commits already in use. No behaviour change on the pinned CI version (2026.6.14), which already expanded the shorthand to these same URLs and checked out these same commits.

Verified with `mise install` against a clean `MISE_DATA_DIR` on 2026.6.14 (CI's pin) and 2026.9.1: all tools install, plugins resolve to the pinned SHAs. There is no dedicated regression check for mise config; CI exercises it via the `setup-caches` step.

### 🔗 Context

- **JIRA / GitHub issue**: [NO-ISSUE] — same root cause as TSDINT-1644
- **ADR** (if any): n/a