### PR TITLE
fix(contacts): full-width address detail actions (LIVE-37009)

### DIFF
--- a/.changeset/contacts-address-detail-actions.md
+++ b/.changeset/contacts-address-detail-actions.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": patch
+"live-mobile": patch
+---
+
+Keep mobile contact address detail action buttons full width by applying horizontal padding only to the summary.

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.native.tsx
@@ -46,6 +46,7 @@ export function ContactAddressDetailActions({
           onPress={onSend}
           isFull
           lx={{ flex: 1 }}
+          numberOfLines={1}
         >
           {labels.send}
         </TileButton>
@@ -56,6 +57,7 @@ export function ContactAddressDetailActions({
           isFull
           lx={{ flex: 1 }}
           testID="contacts-address-detail-edit"
+          numberOfLines={1}
         >
           {labels.edit}
         </TileButton>
@@ -66,6 +68,7 @@ export function ContactAddressDetailActions({
           isFull
           lx={{ flex: 1 }}
           testID="contacts-address-detail-share"
+          numberOfLines={1}
         >
           {labels.share}
         </TileButton>
@@ -77,6 +80,7 @@ export function ContactAddressDetailActions({
           isFull
           lx={{ flex: 1 }}
           testID="contacts-address-detail-delete"
+          numberOfLines={1}
         >
           {labels.delete}
         </TileButton>

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.tsx
@@ -36,15 +36,14 @@ export function ContactAddressDetailDialog({
       {hasSelection && row !== undefined && network !== undefined ? (
         <>
           <BottomSheetHeader title={contactName} />
-          <Box
-            testID="contacts-address-detail-dialog"
-            lx={{ paddingHorizontal: "s24", alignItems: "center" }}
-          >
-            <ContactAddressDetailSummary
-              row={row}
-              network={network}
-              formatNetworkTag={labels.formatNetworkTag}
-            />
+          <Box testID="contacts-address-detail-dialog" lx={{ alignItems: "center" }}>
+            <Box lx={{ paddingHorizontal: "s24" }}>
+              <ContactAddressDetailSummary
+                row={row}
+                network={network}
+                formatNetworkTag={labels.formatNetworkTag}
+              />
+            </Box>
             <ContactAddressDetailActions
               labels={labels}
               hasCopied={hasCopied}


### PR DESCRIPTION
### 📝 Description

On mobile, the contact address detail sheet applied `s24` horizontal padding to both the QR/summary and the Send / Edit / Share / Delete action row. That extra inset squeezed the four tile buttons and made the bottom actions look cramped when opening an existing address (including the path used to rename it).

Apply the horizontal padding only around the summary so the action buttons can use the full sheet width.

<img width="1223" height="895" alt="image" src="https://github.com/user-attachments/assets/cb3ee0be-3540-4a14-ac27-a0ba9862fdd3" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37009](https://ledgerhq.atlassian.net/browse/LIVE-37009)
- **ADR** (if any): N/A


[LIVE-37009]: https://ledgerhq.atlassian.net/browse/LIVE-37009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ