### PR TITLE
chore(mise): drop redundant npm tool

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -240,14 +240,6 @@ url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-win-x64.zip"
 checksum = "sha256:313fa40c0d7b18575821de8cb17483031fe07d95de5994f6f435f3b345f85c66"
 url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-win-x64.zip"
 
-[[tools.npm]]
-version = "10.3.0"
-backend = "npm:npm"
-
-[tools.npm."platforms.linux-x64"]
-checksum = "blake3:1b6d9935349ad07cbdc69e3a3d1ba0ea32411a2583e5b7d4f23105b6e7e79d61"
-url = "https://registry.npmjs.org/npm/-/npm-10.3.0.tgz"
-
 [[tools.pkl]]
 version = "0.31.1"
 backend = "aqua:apple/pkl"

--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,6 @@ cocoapods = "https://github.com/mise-plugins/mise-cocoapods.git#63cb1acce2c2581b
 [tools]
 node = '24.14.0'
 pnpm = '10.24.0'
-npm = '10.3.0'
 bun = '1.3.14'
 gitleaks = '8.30.1'
 hk = '1.40.0'


### PR DESCRIPTION
### 📝 Description

> Stacked on #21618 — merge that first.

`npm = '10.3.0'` resolves to the `npm:npm` backend, so npm is installed from the registry *using node*, making node an install dependency. On mise 2026.7+ the parallel scheduler starts npm before node has finished:

```
Failed to install npm:npm@10.3.0: tool 'npm@10.3.0' requires configured
install dependency 'node@24.14.0', but its selected version is not installed
```

A second `mise install` succeeds, and `MISE_JOBS=1` passes first time — so it's a scheduling race, not a broken dependency declaration.

Fix: remove the tool. Nothing here invokes the npm CLI (`packageManager` is pnpm, release is `changeset publish`), it is the only `npm:` backend tool in the lockfile, and node 24.14.0 already bundles npm 11.9.0 — so the pin was in fact downgrading npm. Its orphaned `mise.lock` entry is removed too, since `mise lock` only refreshes existing entries.

Verified with `mise install` against a clean `MISE_DATA_DIR` on 2026.6.14 and 2026.9.1: single run, no missing tools, `npm -v` → 11.9.0.

### 🔗 Context

- **JIRA / GitHub issue**: [NO-ISSUE]
- **ADR** (if any): n/a