### PR TITLE
ci(mise): bump pinned version to 2026.9.1

### DIFF
--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -61,10 +61,7 @@ runs:
       if: inputs.use-mise == 'true'
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        # Pinned for reproducible CI: mise-action installs the latest release when
-        # unpinned, which is how the 2026.7.2 plugin regression reached us (TSDINT-1644).
-        # That regression is fixed in mise.toml by using full git plugin URLs.
-        version: "2026.9.1"
+        version: "2026.9.1" # pinned; bump deliberately (TSDINT-1644)
         install: true
         cache: true
         reshim: true

--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -61,7 +61,10 @@ runs:
       if: inputs.use-mise == 'true'
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        version: "2026.6.14" # pin to last known-good version until mise 2026.7.x regression is fixed
+        # Pinned for reproducible CI: mise-action installs the latest release when
+        # unpinned, which is how the 2026.7.2 plugin regression reached us (TSDINT-1644).
+        # That regression is fixed in mise.toml by using full git plugin URLs.
+        version: "2026.9.1"
         install: true
         cache: true
         reshim: true

--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -61,7 +61,8 @@ runs:
       if: inputs.use-mise == 'true'
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        version: "2026.9.1" # pinned; bump deliberately (TSDINT-1644)
+        # pinned: following latest mise once broke plugin installs (TSDINT-1644)
+        version: "2026.9.1"
         install: true
         cache: true
         reshim: true


### PR DESCRIPTION
### 📝 Description

> Stacked on #21621 → #21618 — merge bottom-up.

CI pinned mise to 2026.6.14 for one reason (TSDINT-1644): mise 2026.7.2 regressed asdf plugin resolution, treating the shorthand `jonathanmorley/asdf-bundler` as a relative path instead of a GitHub URL, breaking `mise install` on a cache miss.

#21618 fixes that cause (full git plugin URLs) and #21621 removes the redundant `npm` tool that fails separately on 2026.9.x, so the pin can move.

Bumped rather than removed: this repo pins external CI actions (`pinDigests` + `minimumReleaseAge: 15 days` in `renovate.json`) and `jdx/mise-action` itself is SHA-pinned, so an unpinned mise would be the only floating link. Note `mise.lock` already pins the tools, so this is about controlling *when* mise changes land, not reproducibility. **Gap:** Renovate doesn't cover this string (`enabledManagers` is npm + github-actions), so bumps stay manual — a custom manager would fix that if we want it.

**Reviewers:** the original failure only reproduced on a mise **cache miss**; a warm cache skips the plugin clone and hides it. Changing `version` changes mise-action's cache key, so this run should exercise that path — please confirm the "Install mise and tools" logs show plugins **cloned**, not restored.

### 🔗 Context

- **JIRA / GitHub issue**: [TSDINT-1644](https://ledgerhq.atlassian.net/browse/TSDINT-1644)
- **ADR** (if any): n/a

[TSDINT-1644]: https://ledgerhq.atlassian.net/browse/TSDINT-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ