### PR TITLE
[LWDM] chore(llc): wrap `getBalance` errors inside `UnexpectedGetBalanceError`

### DIFF
--- a/.changeset/rare-kiwis-film.md
+++ b/.changeset/rare-kiwis-film.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+chore(llc): wrap `getBalance` exceptions inside `UnexpectedGetBalanceError`

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -27,6 +27,7 @@ import type {
   StakingUnbonding,
   TokenAccount,
 } from "@ledgerhq/types-live";
+import { UnexpectedGetBalanceError } from "@ledgerhq/coin-module-framework/errors";
 
 function isNftCoreOp(operation: Operation): boolean {
   return (
@@ -420,9 +421,15 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         })
       : Promise.resolve(undefined);
 
+    const balancePromise = coinModuleApi
+      .getBalance(context, address, bridgeApi.balanceOptions)
+      .catch(err => {
+        throw new UnexpectedGetBalanceError("", err);
+      });
+
     const [blockInfo, balanceRes, validators, readiness, chainSpecificShape] = await Promise.all([
       coinModuleApi.lastBlock(context),
-      coinModuleApi.getBalance(context, address, bridgeApi.balanceOptions),
+      balancePromise,
       validatorsPromise,
       readinessPromise,
       chainSpecificShapePromise,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { UnexpectedGetBalanceError } from "@ledgerhq/coin-module-framework/errors";
 import { genericGetAccountShape } from "../getAccountShape";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 
@@ -150,6 +151,24 @@ describe("genericGetAccountShape", () => {
       );
 
       expect((result as any).readiness).toBeUndefined();
+    });
+  });
+
+  describe("getBalance error wrapping", () => {
+    test("rejects with UnexpectedGetBalanceError when getBalance throws, preserving the original error as cause", async () => {
+      const { currency, network } = chains[1];
+      const cause = new Error("network failure");
+      getBalanceMock.mockRejectedValue(cause);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const err = await getShape(
+        { address: "rTest", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} },
+      ).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(UnexpectedGetBalanceError);
+      expect(err).toMatchObject({ cause });
     });
   });
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wrap errors coming from `CoinModuleApi.getBalance` inside `UnexpectedGetBalanceError`. This gives consumers of the generic adapter, such as Ledger Wallet, the ability to discriminate errors coming from this particular method in the context of the generic `getAccountShape`.

QA scope is scan accounts on coins that use the generic adapter.

List of branded errors throws in the `getBalance` method of those coin modules:

| Error class | Thrown by | FIle |
| - | - | - |
| `UnknownNode` | `getNodeApi()` | `coin-evm/src/network/node/index.ts` |
| `UnknownExplorer` | `getExplorerApi()` | `coin-evm/src/network/explorer/index.ts` |

None of those branded errors are parsed by Ledger Wallet at the moment, so wrapping them inside `UnexpectedGetBalanceError` does not result in a regression.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36027
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
