### PR TITLE
feat(pay-card): work out the card onboarding status (LIVE-34770)

### DIFF
--- a/.changeset/pay-card-onboarding-status.md
+++ b/.changeset/pay-card-onboarding-status.md
@@ -1,0 +1,12 @@
+---
+"@features/flow-pay-card-widget": minor
+---
+
+Add `useCardOnboardingStatus`, which works out where a cardholder is in onboarding.
+
+- Five steps: account, card, funded wallet, card in the phone's wallet, first purchase.
+- Answered by `getUser`, `getCardStatus` and the linked-wallet join; the phone wallet step from the device; the purchase step reads `false` until the transactions endpoint lands.
+- Each step is an id and a flag. Copy and icons belong to whatever renders them.
+- Mobile lists all five, desktop the four it can answer.
+- `completedCount` comes with the steps.
+- Optional `skip`, so a signed-out host holds the reads.

--- a/features/flow/pay-card-widget/package.json
+++ b/features/flow/pay-card-widget/package.json
@@ -11,12 +11,14 @@
       "react-native": "./src/index.native.ts",
       "default": "./src/index.ts"
     },
+    "./onboarding-status": "./src/onboardingStatus/index.ts",
     "./state": "./src/state/index.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,
   "dependencies": {
     "@domain/api-card-management": "workspace:^",
+    "@features/flow-pay-card-wallets": "workspace:^",
     "@reduxjs/toolkit": "catalog:",
     "@shared/i18n": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*"

--- a/features/flow/pay-card-widget/src/onboardingStatus/deriveCardOnboardingStatus.test.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/deriveCardOnboardingStatus.test.ts
@@ -1,0 +1,100 @@
+import {
+  deriveCardOnboardingStatus,
+  hasPositiveBalance,
+  type CardOnboardingSignals,
+} from "./deriveCardOnboardingStatus";
+import {
+  CARD_ONBOARDING_STEPS,
+  CARD_ONBOARDING_STEPS_WITH_WALLET,
+  type CardOnboardingProviderStepId,
+} from "./steps";
+
+const NOTHING_DONE: CardOnboardingSignals<CardOnboardingProviderStepId> = {
+  "create-account": false,
+  "choose-card-type": false,
+  "top-up-card": false,
+  "first-purchase": false,
+};
+
+const NOTHING_DONE_WITH_WALLET: CardOnboardingSignals = {
+  ...NOTHING_DONE,
+  "apple-google-pay": false,
+};
+
+describe("deriveCardOnboardingStatus", () => {
+  it("lists the steps in the order the dialog walks them", () => {
+    const { steps } = deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS, NOTHING_DONE);
+
+    expect(steps.map(({ id }) => id)).toEqual([
+      "create-account",
+      "choose-card-type",
+      "top-up-card",
+      "first-purchase",
+    ]);
+  });
+
+  it("puts the phone wallet step before the purchase, for the platform that lists it", () => {
+    const { steps } = deriveCardOnboardingStatus(
+      CARD_ONBOARDING_STEPS_WITH_WALLET,
+      NOTHING_DONE_WITH_WALLET,
+    );
+
+    expect(steps.map(({ id }) => id)).toEqual([
+      "create-account",
+      "choose-card-type",
+      "top-up-card",
+      "apple-google-pay",
+      "first-purchase",
+    ]);
+  });
+
+  it("counts what is done, so no consumer has to", () => {
+    const { completedCount } = deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS, {
+      ...NOTHING_DONE,
+      "create-account": true,
+      "choose-card-type": true,
+    });
+
+    expect(completedCount).toBe(2);
+  });
+
+  it("counts the steps it was given, so a platform step counts like any other", () => {
+    const { completedCount } = deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS_WITH_WALLET, {
+      ...NOTHING_DONE_WITH_WALLET,
+      "apple-google-pay": true,
+    });
+
+    expect(completedCount).toBe(1);
+  });
+
+  it("counts nothing when nothing is answered yet", () => {
+    expect(deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS, NOTHING_DONE).completedCount).toBe(0);
+  });
+
+  it("marks each step from its own answer, not from the ones before it", () => {
+    // A holder can hold a funded wallet without having ordered a card.
+    const { steps } = deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS, {
+      ...NOTHING_DONE,
+      "top-up-card": true,
+    });
+
+    expect(steps.map(({ isDone }) => isDone)).toEqual([false, false, true, false]);
+  });
+});
+
+describe("hasPositiveBalance", () => {
+  it.each([
+    ["125.40", true],
+    ["0.01", true],
+    ["0", false],
+    ["0.00", false],
+    // Unread, which is not the same as empty.
+    [null, false],
+  ])("reads %s as %s", (balance, expected) => {
+    expect(hasPositiveBalance(balance)).toBe(expected);
+  });
+
+  it("does not read a balance it cannot parse as money", () => {
+    expect(hasPositiveBalance("not-a-number")).toBe(false);
+  });
+});

--- a/features/flow/pay-card-widget/src/onboardingStatus/deriveCardOnboardingStatus.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/deriveCardOnboardingStatus.ts
@@ -1,0 +1,43 @@
+import type { CardOnboardingStepId } from "./steps";
+
+export type CardOnboardingStep = {
+  readonly id: CardOnboardingStepId;
+  readonly isDone: boolean;
+};
+
+export type CardOnboardingStatus = {
+  readonly steps: readonly CardOnboardingStep[];
+  readonly completedCount: number;
+};
+
+/** One answer per listed step, so a step the platform lists can never be left unanswered. */
+export type CardOnboardingSignals<Id extends CardOnboardingStepId = CardOnboardingStepId> =
+  Readonly<Record<Id, boolean>>;
+
+/**
+ * Joins each answer onto the step it belongs to, and counts what is done.
+ *
+ * The steps are passed in rather than read from the catalog, because platforms list different ones:
+ * the count then belongs to whoever asked, and no consumer has to recount.
+ */
+export function deriveCardOnboardingStatus<Id extends CardOnboardingStepId>(
+  steps: readonly Id[],
+  signals: CardOnboardingSignals<Id>,
+): CardOnboardingStatus {
+  const derived = steps.map(id => ({ id, isDone: signals[id] }));
+
+  return { steps: derived, completedCount: derived.filter(({ isDone }) => isDone).length };
+}
+
+/**
+ * Whether a wallet holds anything at all.
+ *
+ * Balances arrive as strings the provider formatted, and an unread one is `null`. Neither `"0.00"`
+ * nor an absent balance counts as topped up.
+ */
+export function hasPositiveBalance(balance: string | null): boolean {
+  if (balance === null) return false;
+
+  const amount = Number(balance);
+  return Number.isFinite(amount) && amount > 0;
+}

--- a/features/flow/pay-card-widget/src/onboardingStatus/index.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/index.ts
@@ -1,0 +1,4 @@
+export * from "./deriveCardOnboardingStatus";
+export * from "./steps";
+export * from "./types";
+export * from "./useCardOnboardingStatus";

--- a/features/flow/pay-card-widget/src/onboardingStatus/steps.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/steps.ts
@@ -1,0 +1,23 @@
+/**
+ * The steps of card onboarding, in the order they are listed.
+ *
+ * Ids and order only. The copy belongs to whatever renders the steps, which translates it and
+ * picks each icon; the id is the contract between the two.
+ */
+const LEADING_STEPS = ["create-account", "choose-card-type", "top-up-card"] as const;
+
+/** The steps desktop lists. */
+export const CARD_ONBOARDING_STEPS = [...LEADING_STEPS, "first-purchase"] as const;
+
+/** The steps mobile lists: the phone can carry the card, so one more sits before the purchase. */
+export const CARD_ONBOARDING_STEPS_WITH_WALLET = [
+  ...LEADING_STEPS,
+  "apple-google-pay",
+  "first-purchase",
+] as const;
+
+/** Every onboarding step id, on any platform. */
+export type CardOnboardingStepId = (typeof CARD_ONBOARDING_STEPS_WITH_WALLET)[number];
+
+/** The steps the Card endpoints answer for: every step but the phone wallet one. */
+export type CardOnboardingProviderStepId = (typeof CARD_ONBOARDING_STEPS)[number];

--- a/features/flow/pay-card-widget/src/onboardingStatus/types.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/types.ts
@@ -1,0 +1,11 @@
+import type { CardOnboardingStatus } from "./deriveCardOnboardingStatus";
+
+export type UseCardOnboardingStatusResult = {
+  /**
+   * Always answered. Every signal has a value from the first render — a step nothing has answered
+   * yet reads as not done — so there is no "not known" state for a consumer to handle.
+   */
+  readonly data: CardOnboardingStatus;
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+};

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingSources.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingSources.ts
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+import { useGetCardStatusQuery, useGetUserQuery } from "@domain/api-card-management";
+import { useCardLinkedWallets } from "@features/flow-pay-card-wallets";
+import { hasPositiveBalance, type CardOnboardingSignals } from "./deriveCardOnboardingStatus";
+import type { CardOnboardingProviderStepId } from "./steps";
+
+export type CardOnboardingSourcesParams = {
+  /**
+   * Holds every read. The Card endpoints need a session, so a host that is signed out sets this
+   * rather than collecting 401s; while it is set, every step reads as not done.
+   */
+  readonly skip?: boolean;
+};
+
+export type CardOnboardingSources = {
+  readonly signals: CardOnboardingSignals<CardOnboardingProviderStepId>;
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+};
+
+const NO_COUNTER_VALUE = () => null;
+
+/**
+ * Asks the Card endpoints what they can answer about onboarding.
+ *
+ * The provider serves no onboarding endpoint: each step is a different question, so they are asked
+ * separately here and joined by the platform hook, which knows which steps its dialog lists. A step
+ * nothing can answer yet reads as not done.
+ */
+export function useCardOnboardingSources({
+  skip = false,
+}: CardOnboardingSourcesParams = {}): CardOnboardingSources {
+  const user = useGetUserQuery(undefined, { skip });
+  const cardStatus = useGetCardStatusQuery(undefined, { skip });
+  const linkedWallets = useCardLinkedWallets({ resolveCounterValue: NO_COUNTER_VALUE, skip });
+
+  const signals = useMemo(
+    () => ({
+      "create-account": user.data?.verificationState === "VERIFIED",
+      // Any card the provider answers with is a card: a frozen or blocked one was still ordered,
+      // and reading it as "no card" would send the holder back to choosing a type.
+      "choose-card-type": cardStatus.data !== undefined,
+      "top-up-card": linkedWallets.wallets.some(({ balance }) => hasPositiveBalance(balance)),
+      // Nothing reads the provider's transactions yet.
+      "first-purchase": false,
+    }),
+    [user.data, cardStatus.data, linkedWallets.wallets],
+  );
+
+  return {
+    signals,
+    // `isFetching` on all three, not `isLoading`: a query reports `isLoading` only while it has no
+    // data, so after the first read a refetch would have looked idle.
+    isLoading: user.isFetching || cardStatus.isFetching || linkedWallets.isFetching,
+    // A step that cannot be answered is reported as not done, so only a failure the holder can do
+    // nothing about is surfaced: the account read itself.
+    isError: user.isError,
+  };
+}

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.test.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from "@testing-library/react-native";
+
+jest.mock("@domain/api-card-management", () => ({
+  useGetCardStatusQuery: jest.fn(),
+  useGetUserQuery: jest.fn(),
+}));
+
+jest.mock("@features/flow-pay-card-wallets", () => ({
+  useCardLinkedWallets: jest.fn(),
+}));
+
+jest.mock("react-redux", () => ({ useSelector: jest.fn() }));
+
+import { useGetCardStatusQuery, useGetUserQuery } from "@domain/api-card-management";
+import { useCardLinkedWallets } from "@features/flow-pay-card-wallets";
+import { useSelector } from "react-redux";
+import { useCardOnboardingStatus } from "./useCardOnboardingStatus.native";
+
+function setupMocks({ hasAddedCardToWallet = false, verified = false } = {}) {
+  jest.mocked(useGetUserQuery).mockReturnValue({
+    data: { verificationState: verified ? "VERIFIED" : "PENDING" },
+    isFetching: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useGetUserQuery>);
+
+  jest.mocked(useGetCardStatusQuery).mockReturnValue({
+    data: undefined,
+    isFetching: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useGetCardStatusQuery>);
+
+  jest.mocked(useCardLinkedWallets).mockReturnValue({
+    wallets: [],
+    isFetching: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useCardLinkedWallets>);
+
+  // Run the real selector, so the state shape it reads stays covered.
+  jest.mocked(useSelector).mockImplementation(selector =>
+    (selector as (state: unknown) => unknown)({
+      payCardOnboardingWidget: { hasCompletedOnboarding: false, hasAddedCardToWallet },
+    }),
+  );
+}
+
+describe("useCardOnboardingStatus (native)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists the phone wallet step before the purchase", () => {
+    setupMocks();
+    const { result } = renderHook(() => useCardOnboardingStatus());
+
+    expect(result.current.data.steps.map(({ id }) => id)).toEqual([
+      "create-account",
+      "choose-card-type",
+      "top-up-card",
+      "apple-google-pay",
+      "first-purchase",
+    ]);
+  });
+
+  it.each([true, false])(
+    "reads the phone wallet step from what the device remembers: %s",
+    hasAddedCardToWallet => {
+      setupMocks({ hasAddedCardToWallet });
+      const { result } = renderHook(() => useCardOnboardingStatus());
+
+      const walletStep = result.current.data.steps.find(({ id }) => id === "apple-google-pay");
+      expect(walletStep?.isDone).toBe(hasAddedCardToWallet);
+    },
+  );
+
+  it("holds every read when the host asks it to", () => {
+    setupMocks();
+    renderHook(() => useCardOnboardingStatus({ skip: true }));
+
+    expect(jest.mocked(useGetUserQuery)).toHaveBeenCalledWith(undefined, { skip: true });
+    expect(jest.mocked(useGetCardStatusQuery)).toHaveBeenCalledWith(undefined, { skip: true });
+    expect(jest.mocked(useCardLinkedWallets)).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    );
+  });
+
+  it("counts the phone wallet step like any other", () => {
+    setupMocks({ hasAddedCardToWallet: true, verified: true });
+    const { result } = renderHook(() => useCardOnboardingStatus());
+
+    expect(result.current.data.completedCount).toBe(2);
+  });
+});

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import { deriveCardOnboardingStatus } from "./deriveCardOnboardingStatus";
+import { CARD_ONBOARDING_STEPS_WITH_WALLET } from "./steps";
+import { selectHasAddedCardToWallet } from "../state";
+import type { UseCardOnboardingStatusResult } from "./types";
+import {
+  useCardOnboardingSources,
+  type CardOnboardingSourcesParams,
+} from "./useCardOnboardingSources";
+
+/**
+ * Mobile lists one step more: the card can be carried in the phone's wallet.
+ *
+ * No endpoint answers whether it is, so the holder says so by pressing the step and the answer is
+ * kept on the device.
+ */
+export function useCardOnboardingStatus(
+  params: CardOnboardingSourcesParams = {},
+): UseCardOnboardingStatusResult {
+  const { signals, isLoading, isError } = useCardOnboardingSources(params);
+  const hasAddedCardToWallet = useSelector(selectHasAddedCardToWallet);
+
+  const data = useMemo(
+    () =>
+      deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS_WITH_WALLET, {
+        ...signals,
+        "apple-google-pay": hasAddedCardToWallet,
+      }),
+    [signals, hasAddedCardToWallet],
+  );
+
+  return { data, isLoading, isError };
+}

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.test.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.test.ts
@@ -1,0 +1,187 @@
+import { renderHook } from "@testing-library/react";
+
+jest.mock("@domain/api-card-management", () => ({
+  useGetCardStatusQuery: jest.fn(),
+  useGetUserQuery: jest.fn(),
+}));
+
+jest.mock("@features/flow-pay-card-wallets", () => ({
+  useCardLinkedWallets: jest.fn(),
+}));
+
+import { useGetCardStatusQuery, useGetUserQuery } from "@domain/api-card-management";
+import { useCardLinkedWallets } from "@features/flow-pay-card-wallets";
+import { useCardOnboardingStatus } from "./useCardOnboardingStatus";
+
+type Verification = "UNVERIFIED" | "PENDING" | "VERIFIED" | "REJECTED";
+
+function setupMocks({
+  // `null` is "not read yet": an explicit `undefined` would fall back to the default.
+  verificationState = "VERIFIED" as Verification | null,
+  hasCard = true,
+  cardStatus = "ACTIVE",
+  balances = [] as (string | null)[],
+  isUserFetching = false,
+  isCardStatusFetching = false,
+  areWalletsFetching = false,
+  isUserError = false,
+  areWalletsError = false,
+} = {}) {
+  jest.mocked(useGetUserQuery).mockReturnValue({
+    data: verificationState === null ? undefined : { verificationState },
+    isFetching: isUserFetching,
+    isError: isUserError,
+  } as unknown as ReturnType<typeof useGetUserQuery>);
+
+  jest.mocked(useGetCardStatusQuery).mockReturnValue({
+    data: hasCard ? { status: cardStatus } : undefined,
+    isFetching: isCardStatusFetching,
+    isError: false,
+  } as unknown as ReturnType<typeof useGetCardStatusQuery>);
+
+  jest.mocked(useCardLinkedWallets).mockReturnValue({
+    wallets: balances.map((balance, index) => ({ id: `w${index}`, balance })),
+    isFetching: areWalletsFetching,
+    isError: areWalletsError,
+  } as unknown as ReturnType<typeof useCardLinkedWallets>);
+}
+
+function stepsById() {
+  const { result } = renderHook(() => useCardOnboardingStatus());
+  const { data } = result.current;
+
+  return {
+    isDone: (id: string) => data.steps.find(step => step.id === id)?.isDone,
+    completedCount: data.completedCount,
+    status: result.current,
+  };
+}
+
+describe("useCardOnboardingStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("the account step", () => {
+    it("is done once the provider reports the account verified", () => {
+      setupMocks({ verificationState: "VERIFIED" });
+
+      expect(stepsById().isDone("create-account")).toBe(true);
+    });
+
+    it.each<Verification>(["UNVERIFIED", "PENDING", "REJECTED"])(
+      "is not done while the account reads %s",
+      verificationState => {
+        setupMocks({ verificationState });
+
+        expect(stepsById().isDone("create-account")).toBe(false);
+      },
+    );
+
+    it("is not done while the account has not been read", () => {
+      setupMocks({ verificationState: null });
+
+      expect(stepsById().isDone("create-account")).toBe(false);
+    });
+  });
+
+  describe("the card step", () => {
+    it.each(["ACTIVE", "INACTIVE", "FROZEN", "BLOCKED"])(
+      "counts a %s card as ordered",
+      cardStatus => {
+        setupMocks({ hasCard: true, cardStatus });
+
+        expect(stepsById().isDone("choose-card-type")).toBe(true);
+      },
+    );
+
+    it("is not done when the provider answers with no card", () => {
+      setupMocks({ hasCard: false });
+
+      expect(stepsById().isDone("choose-card-type")).toBe(false);
+    });
+  });
+
+  describe("the top-up step", () => {
+    it("is done as soon as one linked wallet holds anything", () => {
+      setupMocks({ balances: ["0.00", null, "0.00000001"] });
+
+      expect(stepsById().isDone("top-up-card")).toBe(true);
+    });
+
+    it.each([[[]], [["0"]], [["0.00", null]]])(
+      "is not done for balances %p",
+      (balances: (string | null)[]) => {
+        setupMocks({ balances });
+
+        expect(stepsById().isDone("top-up-card")).toBe(false);
+      },
+    );
+  });
+
+  it("leaves the purchase step not done, because nothing reads the transactions yet", () => {
+    setupMocks({ verificationState: "VERIFIED", hasCard: true, balances: ["12.50"] });
+
+    const steps = stepsById();
+    expect(steps.isDone("first-purchase")).toBe(false);
+    expect(steps.completedCount).toBe(3);
+  });
+
+  it("counts nothing done for a holder who has only signed up", () => {
+    setupMocks({ verificationState: "PENDING", hasCard: false, balances: [] });
+
+    expect(stepsById().completedCount).toBe(0);
+  });
+
+  describe("when the host holds the reads", () => {
+    it("asks nothing, so a signed-out host collects no 401s", () => {
+      setupMocks();
+      renderHook(() => useCardOnboardingStatus({ skip: true }));
+
+      expect(jest.mocked(useGetUserQuery)).toHaveBeenCalledWith(undefined, { skip: true });
+      expect(jest.mocked(useGetCardStatusQuery)).toHaveBeenCalledWith(undefined, { skip: true });
+      expect(jest.mocked(useCardLinkedWallets)).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: true }),
+      );
+    });
+
+    it("asks by default, so a host that says nothing gets the answer", () => {
+      setupMocks();
+      renderHook(() => useCardOnboardingStatus());
+
+      expect(jest.mocked(useGetUserQuery)).toHaveBeenCalledWith(undefined, { skip: false });
+    });
+  });
+
+  describe("what it reports while asking", () => {
+    it.each([
+      ["the account", { isUserFetching: true }],
+      ["the card", { isCardStatusFetching: true }],
+      ["the wallets", { areWalletsFetching: true }],
+    ])("is loading while %s is in flight, refetches included", (_source, fetching) => {
+      setupMocks(fetching);
+
+      expect(stepsById().status.isLoading).toBe(true);
+    });
+
+    it("is not loading once every source has answered", () => {
+      setupMocks();
+
+      expect(stepsById().status.isLoading).toBe(false);
+    });
+
+    it("surfaces a failed account read", () => {
+      setupMocks({ isUserError: true });
+
+      expect(stepsById().status.isError).toBe(true);
+    });
+
+    it("hides a failed wallet read, which only leaves the top-up step not done", () => {
+      setupMocks({ areWalletsError: true, balances: [] });
+
+      const steps = stepsById();
+      expect(steps.status.isError).toBe(false);
+      expect(steps.isDone("top-up-card")).toBe(false);
+    });
+  });
+});

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+import { deriveCardOnboardingStatus } from "./deriveCardOnboardingStatus";
+import { CARD_ONBOARDING_STEPS } from "./steps";
+import type { UseCardOnboardingStatusResult } from "./types";
+import {
+  useCardOnboardingSources,
+  type CardOnboardingSourcesParams,
+} from "./useCardOnboardingSources";
+
+/** Desktop lists four steps: there is no phone wallet to put the card in. */
+export function useCardOnboardingStatus(
+  params: CardOnboardingSourcesParams = {},
+): UseCardOnboardingStatusResult {
+  const { signals, isLoading, isError } = useCardOnboardingSources(params);
+
+  const data = useMemo(() => deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS, signals), [signals]);
+
+  return { data, isLoading, isError };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7116,6 +7116,9 @@ importers:
       '@domain/api-card-management':
         specifier: workspace:^
         version: link:../../../domain/api/card-management
+      '@features/flow-pay-card-wallets':
+        specifier: workspace:^
+        version: link:../pay-card-wallets
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21625 feat/LIVE-34770-pay-card-onboarding-status ← this PR**
- #21626 feat/LIVE-34770-pay-card-onboarding-devtool
<!-- stac-man:stack-end -->

Card onboarding has five steps, and each one is a different question. This adds a
hook that asks them and reports where the holder has got to.

### What it does

- A verified account from `getUser`, a card from `getCardStatus`, a funded wallet
  from the linked-wallet join, and the card in the phone's wallet from what the
  device remembers. The purchase step reads `false` until the transactions
  endpoint lands.
- Mobile lists all five steps; desktop lists the four it can answer, because a
  card cannot be added to a phone from there.
- The derivation walks the step list it is given rather than a fixed one, so
  `completedCount` is right on either platform and no consumer has to recount.
- Any card the provider answers with counts as a card: a frozen or blocked one
  was still ordered, and reading it as "no card" would send the holder back to
  choosing a type.
- A step nothing can answer reads as not done, so the only failure surfaced is
  the one the holder can do nothing about: the account read itself.

### Scope

One package, 12 files, all new bar a dependency line. Unit tests cover the
derivation and both platform hooks.
