### PR TITLE
feat(pay-card): drive the card onboarding status from the devtool

### DIFF
--- a/.changeset/pay-card-onboarding-devtool.md
+++ b/.changeset/pay-card-onboarding-devtool.md
@@ -1,0 +1,16 @@
+---
+"@domain/api-card-management": minor
+"@features/flow-pay-card-widget": minor
+"@devtools/pay-card": minor
+"@devtools/bindings": minor
+"live-mobile": patch
+---
+
+Show and drive the derived card onboarding status from the Card / Pay devtool.
+
+- A "Card onboarding" screen: a `Stepper` for the count, every step by the id the app keys it on, and the derived answer printed raw so a step can be traced to the response behind it.
+- Each step a request decides carries a toggle. It sets what that endpoint answers, so the step follows on the next read and holds until it is cleared. The phone wallet step is answered on the device; the purchase step is read-only while nothing answers it.
+- An endpoint answers from the provider until its toggle is used, so one step can be held while the rest stay real, and "Use the real answers" hands them all back.
+- `@domain/api-card-management/mock/card-onboarding-status` holds those answers and the responses that carry them; the mobile MSW handlers read it before falling back to what they answered before.
+- Mocking is started by an env var, so without it the screen says so instead of offering a toggle that would set an answer nothing reads.
+- The hook gains `refresh`, which re-asks all three sources: the screen asks on open and on demand.

--- a/apps/ledger-live-mobile/src/mocks/card/handler.ts
+++ b/apps/ledger-live-mobile/src/mocks/card/handler.ts
@@ -1,5 +1,12 @@
 import { http, HttpResponse, passthrough, delay } from "msw";
 import { getMockCardOnboardingStatus } from "@domain/api-card-management/mock";
+import {
+  mockPayCardInternalWallets,
+  mockPayCardLinkedWallets,
+  mockPayCardStatus,
+  mockPayCardUser,
+  readCardOnboardingStatusMock,
+} from "@domain/api-card-management/mock/card-onboarding-status";
 import { createCardMockState } from "./state";
 
 const state = createCardMockState();
@@ -101,6 +108,12 @@ const handlers = [
       return HttpResponse.json({ message: "unauthorized" }, { status: 401 });
     }
 
+    // Set by the card onboarding screen, and unset until a step is toggled there.
+    const { accountVerified } = readCardOnboardingStatusMock();
+    if (accountVerified !== undefined) {
+      return HttpResponse.json(mockPayCardUser(accountVerified));
+    }
+
     if (!usesMockToken(request)) {
       return passthrough();
     }
@@ -109,6 +122,15 @@ const handlers = [
   }),
 
   http.get("*/v1/card/status", ({ request }) => {
+    const { hasCard } = readCardOnboardingStatusMock();
+    if (hasCard !== undefined) {
+      // No card is an absent one, not an empty one: the step reads "has the provider answered with
+      // a card at all", and a 404 is how it answers that it has not.
+      return hasCard
+        ? HttpResponse.json(mockPayCardStatus())
+        : HttpResponse.json({ message: "No card ordered" }, { status: 404 });
+    }
+
     if (!usesMockToken(request)) {
       return passthrough();
     }
@@ -117,6 +139,26 @@ const handlers = [
 
   http.get("*/v1/card/onboarding-status", () => {
     return HttpResponse.json(getMockCardOnboardingStatus());
+  }),
+  http.get("*/v1/wallet/internal", ({ request }) => {
+    const { walletFunded } = readCardOnboardingStatusMock();
+    if (walletFunded !== undefined) {
+      return HttpResponse.json(mockPayCardInternalWallets(walletFunded));
+    }
+
+    // A mock session has no provider behind it, so answer as an empty wallet rather than send a
+    // mock bearer token to Baanx and collect a 401.
+    return usesMockToken(request)
+      ? HttpResponse.json(mockPayCardInternalWallets(false))
+      : passthrough();
+  }),
+
+  http.get("*/v1/wallet/internal/card_linked", ({ request }) => {
+    const { walletFunded } = readCardOnboardingStatusMock();
+
+    return walletFunded === undefined && !usesMockToken(request)
+      ? passthrough()
+      : HttpResponse.json(mockPayCardLinkedWallets());
   }),
 ];
 

--- a/devtools/bindings/jest.config.js
+++ b/devtools/bindings/jest.config.js
@@ -3,6 +3,10 @@ module.exports = {
   roots: ["<rootDir>/src"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   testMatch: ["**/*.test.ts?(x)"],
+  // These tests run the real feature hooks, and a feature package may ship a module with no
+  // suffix-less file at all. This project is jsdom, so it falls back to the `.web` variant; the
+  // plain extensions stay first, so every module that has one resolves exactly as before.
+  moduleFileExtensions: ["tsx", "ts", "js", "jsx", "json", "node", "web.tsx", "web.ts"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -17,6 +17,10 @@ import {
   markPayCardLoginIntroSeen,
 } from "@features/flow-pay-card-auth/state";
 import { payCardOnboardingWidgetSlice } from "@features/flow-pay-card-widget/state";
+import {
+  clearCardOnboardingStatusMock,
+  readCardOnboardingStatusMock,
+} from "@domain/api-card-management/mock/card-onboarding-status";
 import { usePayCardToolProps } from "./usePayCardToolProps";
 
 function buildStore() {
@@ -268,5 +272,95 @@ describe("usePayCardToolProps", () => {
 
     expect(store.getState().payCardLoginIntro.hasSeenLoginIntro).toBe(false);
     expect(store.getState().payCardFeatureTour.hasSeenFeatureTour).toBe(true);
+  });
+
+  describe("driving the onboarding steps", () => {
+    beforeEach(() => {
+      delete process.env.MSW_ENABLED;
+    });
+
+    afterEach(() => {
+      clearCardOnboardingStatusMock();
+      delete process.env.MSW_ENABLED;
+    });
+
+    it("sets the answer behind a step rather than the step itself", () => {
+      const store = buildStore();
+      const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+      act(() => {
+        result.current.cardOnboarding.setStepDone("top-up-card", true);
+        result.current.cardOnboarding.setStepDone("create-account", false);
+      });
+
+      expect(readCardOnboardingStatusMock()).toEqual({
+        walletFunded: true,
+        accountVerified: false,
+      });
+    });
+
+    it("keeps the phone wallet step on the device, because no endpoint answers it", () => {
+      const store = buildStore();
+      const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+      act(() => {
+        result.current.cardOnboarding.setStepDone("apple-google-pay", true);
+      });
+
+      expect(store.getState().payCardOnboardingWidget.hasAddedCardToWallet).toBe(true);
+      expect(readCardOnboardingStatusMock()).toEqual({});
+    });
+
+    it("ignores a step nothing answers, so the purchase step cannot be forced", () => {
+      const store = buildStore();
+      const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+      act(() => {
+        result.current.cardOnboarding.setStepDone("first-purchase", true);
+      });
+
+      expect(readCardOnboardingStatusMock()).toEqual({});
+    });
+
+    it("hands every endpoint back to the provider", () => {
+      const store = buildStore();
+      const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+      act(() => {
+        result.current.cardOnboarding.setStepDone("create-account", true);
+        result.current.cardOnboarding.setStepDone("choose-card-type", true);
+      });
+      act(() => {
+        result.current.cardOnboarding.clearMocks();
+      });
+
+      expect(readCardOnboardingStatusMock()).toEqual({});
+    });
+
+    it("offers no toggle at all while the host intercepts nothing", () => {
+      const store = buildStore();
+      const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+      expect(result.current.cardOnboarding.isMockingEnabled).toBe(false);
+      // Every step this project lists is answered by a request: the phone wallet step, which is
+      // answered on the device instead, is mobile-only and this project resolves the web hook.
+      expect(result.current.cardOnboarding.steps.every(({ canToggle }) => !canToggle)).toBe(true);
+    });
+
+    it("offers one per endpoint-answered step once the host intercepts requests", () => {
+      process.env.MSW_ENABLED = "true";
+      const store = buildStore();
+      const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+      expect(result.current.cardOnboarding.isMockingEnabled).toBe(true);
+      const togglable = result.current.cardOnboarding.steps
+        .filter(({ canToggle }) => canToggle)
+        .map(({ id }) => id);
+      expect(togglable).toContain("create-account");
+      expect(togglable).toContain("choose-card-type");
+      expect(togglable).toContain("top-up-card");
+      // Nothing answers the purchase step yet, so it stays read-only.
+      expect(togglable).not.toContain("first-purchase");
+    });
   });
 });

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -27,9 +27,17 @@ import {
   selectPayCardHasSeenLoginIntro,
 } from "@features/flow-pay-card-auth/state";
 import {
+  markCardAddedToWallet,
+  resetCardAddedToWallet,
   resetCardOnboardingCompleted,
   selectHasCompletedCardOnboarding,
 } from "@features/flow-pay-card-widget/state";
+import { useCardOnboardingStatus } from "@features/flow-pay-card-widget/onboarding-status";
+import {
+  clearCardOnboardingStatusMock,
+  setCardOnboardingStatusMock,
+  type CardOnboardingStatusMock,
+} from "@domain/api-card-management/mock/card-onboarding-status";
 import { setMockOnboardingStepDone } from "@domain/api-card-management/mock";
 import type { DevToolsConfig } from "@devtools/registry";
 import { usePayCardAuthProps } from "./usePayCardAuthProps";
@@ -76,6 +84,30 @@ function initialSteps(platform: "web" | "native"): readonly OnboardingStep[] {
  * balance and answers `null`, which the screen reports as unpriced.
  */
 const NO_COUNTER_VALUE: ResolveWalletCounterValue = () => null;
+
+/**
+ * The endpoint answer each derived step is decided by, for the steps a request decides.
+ *
+ * `apple-google-pay` is missing on purpose: nothing is asked for it, the holder says so and the
+ * answer is kept on the device. `first-purchase` is missing because nothing answers it yet.
+ */
+const STEP_ANSWERS: Readonly<Partial<Record<string, keyof CardOnboardingStatusMock>>> = {
+  "create-account": "accountVerified",
+  "choose-card-type": "hasCard",
+  "top-up-card": "walletFunded",
+};
+
+const WALLET_STEP_ID = "apple-google-pay";
+
+/**
+ * Whether the host intercepts the requests these answers are read from.
+ *
+ * Only the mobile handlers read the store, and mobile starts its worker from `MSW_ENABLED`. Desktop
+ * has its own flag, and answering to it here would report mocking a desktop request never sees.
+ */
+function isRequestMockingEnabled(): boolean {
+  return process.env.MSW_ENABLED === "true";
+}
 
 /** Reads what an endpoint answered, whatever shape the failure arrives in. */
 function describeError(error: unknown): string {
@@ -177,6 +209,59 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
   const onboarding = useMemo(() => ({ steps, setStepDone }), [steps, setStepDone]);
 
   const auth = usePayCardAuthProps({ openPayTab: options.openPayTab });
+  // Only the native tool renders this screen, so desktop asks the three endpoints for nothing.
+  const onboardingStatus = useCardOnboardingStatus({ skip: platform !== "native" });
+  const { data: derivedOnboarding, refresh: refreshCardOnboarding } = onboardingStatus;
+
+  const setDerivedStepDone = useCallback(
+    (id: string, done: boolean) => {
+      if (id === WALLET_STEP_ID) {
+        // Not an endpoint answer: the step is what the holder said, so the store is the source.
+        dispatch(done ? markCardAddedToWallet() : resetCardAddedToWallet());
+        return;
+      }
+
+      const answer = STEP_ANSWERS[id];
+      if (answer === undefined) return;
+
+      setCardOnboardingStatusMock(answer, done);
+      refreshCardOnboarding();
+    },
+    [dispatch, refreshCardOnboarding],
+  );
+
+  const clearCardOnboardingMocks = useCallback(() => {
+    clearCardOnboardingStatusMock();
+    refreshCardOnboarding();
+  }, [refreshCardOnboarding]);
+
+  const cardOnboarding = useMemo(() => {
+    const isMockingEnabled = isRequestMockingEnabled();
+
+    return {
+      steps: derivedOnboarding.steps.map(step => ({
+        id: step.id,
+        isDone: step.isDone,
+        canToggle: step.id === WALLET_STEP_ID || (isMockingEnabled && step.id in STEP_ANSWERS),
+      })),
+      completedCount: derivedOnboarding.completedCount,
+      isFetching: onboardingStatus.isLoading,
+      // Only the account read is surfaced as an error: a step nothing can answer reads as not done.
+      error: onboardingStatus.isError ? "the account could not be read" : undefined,
+      raw: JSON.stringify(derivedOnboarding, null, 2),
+      refresh: refreshCardOnboarding,
+      setStepDone: setDerivedStepDone,
+      clearMocks: clearCardOnboardingMocks,
+      isMockingEnabled,
+    };
+  }, [
+    derivedOnboarding,
+    onboardingStatus.isLoading,
+    onboardingStatus.isError,
+    refreshCardOnboarding,
+    setDerivedStepDone,
+    clearCardOnboardingMocks,
+  ]);
 
   const [runCardStatus, cardStatus] = useLazyGetCardStatusQuery();
 
@@ -289,6 +374,7 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
     () => ({
       flags,
       onboarding,
+      cardOnboarding,
       interaction,
       balance,
       hasSeenFeatureTour,
@@ -305,6 +391,7 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
     [
       flags,
       onboarding,
+      cardOnboarding,
       interaction,
       balance,
       hasSeenFeatureTour,

--- a/devtools/pay-card/src/components/CardOnboarding/CardOnboarding.native.tsx
+++ b/devtools/pay-card/src/components/CardOnboarding/CardOnboarding.native.tsx
@@ -1,0 +1,134 @@
+import { ScrollView } from "react-native";
+import {
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  Stepper,
+  Switch,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Refresh } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { PayCardOnboardingStatusProps, PayCardOnboardingStatusStep } from "../../types";
+import { Section } from "../Section/Section";
+
+export interface CardOnboardingScreenProps extends PayCardOnboardingStatusProps {
+  readonly onBack: () => void;
+}
+
+const HEADER_LX = {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "s16",
+} as const;
+const STEPPER_LX = { alignItems: "center", gap: "s8" } as const;
+const ROW_LX = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "s8",
+  paddingVertical: "s4",
+} as const;
+
+function Step({
+  step,
+  setStepDone,
+}: {
+  readonly step: PayCardOnboardingStatusStep;
+  readonly setStepDone: (id: string, done: boolean) => void;
+}) {
+  return (
+    <Box lx={ROW_LX}>
+      <Text typography="body3" lx={{ color: step.isDone ? "success" : "muted" }}>
+        {step.isDone ? "done" : "open"}
+      </Text>
+      <Box lx={{ flex: 1 }}>
+        {/* The id is the whole step: copy belongs to whatever renders it for a holder. */}
+        <Text typography="body3" lx={{ color: "base" }}>
+          {step.id}
+        </Text>
+      </Box>
+      {step.canToggle ? (
+        <Switch
+          checked={step.isDone}
+          onCheckedChange={done => setStepDone(step.id, done)}
+          accessibilityLabel={step.id}
+        />
+      ) : null}
+    </Box>
+  );
+}
+
+export function CardOnboardingScreen({
+  steps,
+  completedCount,
+  isFetching,
+  error,
+  raw,
+  refresh,
+  setStepDone,
+  clearMocks,
+  isMockingEnabled,
+  onBack,
+}: CardOnboardingScreenProps) {
+  return (
+    <ScrollView>
+      <Box lx={HEADER_LX}>
+        <Button appearance="gray" size="sm" onPress={onBack}>
+          Back
+        </Button>
+        <IconButton
+          icon={Refresh}
+          appearance="no-background"
+          size="sm"
+          loading={isFetching}
+          onPress={refresh}
+          accessibilityLabel="Refresh"
+        />
+      </Box>
+
+      <Section title="Card onboarding">
+        <Box lx={STEPPER_LX}>
+          <Stepper currentStep={completedCount} totalSteps={steps.length} />
+        </Box>
+
+        {error === undefined ? null : (
+          <Text typography="body3" lx={{ color: "error" }}>
+            {error}
+          </Text>
+        )}
+
+        <Divider />
+        {steps.map(step => (
+          <Step key={step.id} step={step} setStepDone={setStepDone} />
+        ))}
+      </Section>
+
+      <Section title="Mocked answers">
+        {isMockingEnabled ? (
+          <>
+            <Text typography="body3" lx={{ color: "muted" }}>
+              A step is set by mocking the endpoint it is read from, so the answer holds until it is
+              cleared. The purchase step has no toggle: nothing answers it yet.
+            </Text>
+            <Button appearance="gray" size="sm" onPress={clearMocks}>
+              Use the real answers
+            </Button>
+          </>
+        ) : (
+          <Text typography="body3" lx={{ color: "warning" }}>
+            Request mocking is off, so the endpoint steps cannot be set. Restart with
+            MSW_ENABLED=true to turn it on.
+          </Text>
+        )}
+      </Section>
+
+      {/* The steps are worked out, not fetched, so the answer itself is the thing to check. */}
+      <Section title="Derived response">
+        <Text typography="body3" lx={{ color: "base" }}>
+          {raw}
+        </Text>
+      </Section>
+    </ScrollView>
+  );
+}

--- a/devtools/pay-card/src/components/CardOnboarding/CardOnboarding.web.tsx
+++ b/devtools/pay-card/src/components/CardOnboarding/CardOnboarding.web.tsx
@@ -1,0 +1,10 @@
+import type { PayCardOnboardingStatusProps } from "../../types";
+
+export interface CardOnboardingScreenProps extends PayCardOnboardingStatusProps {
+  readonly onBack: () => void;
+}
+
+/** Native-only for now, like the screens it sits next to. */
+export function CardOnboardingScreen(_props: CardOnboardingScreenProps) {
+  return null;
+}

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -22,6 +22,17 @@ function buildProps(): PayCardToolProps {
       ],
       setStepDone: jest.fn(),
     },
+    cardOnboarding: {
+      steps: [],
+      completedCount: 0,
+      isFetching: false,
+      error: undefined,
+      raw: "{}",
+      refresh: jest.fn(),
+      setStepDone: jest.fn(),
+      clearMocks: jest.fn(),
+      isMockingEnabled: true,
+    },
     interaction: {
       probes: [],
       details: {
@@ -489,5 +500,107 @@ describe("PayCard (native)", () => {
     expect(screen.getByText("Send API requests")).toBeTruthy();
     expect(screen.getByText("MSW Auth Renewal Mock")).toBeTruthy();
     expect(screen.getByText("clear → cleared")).toBeTruthy();
+  });
+
+  const onboardingSteps = [
+    { id: "create-account", isDone: true, canToggle: true },
+    { id: "choose-card-type", isDone: true, canToggle: true },
+    { id: "top-up-card", isDone: false, canToggle: true },
+    { id: "first-purchase", isDone: false, canToggle: false },
+  ];
+
+  it("opens the card onboarding screen and asks for a fresh answer", async () => {
+    const user = userEvent.setup();
+    const refresh = jest.fn();
+    const props = buildProps();
+    render(<PayCard {...props} cardOnboarding={{ ...props.cardOnboarding, refresh }} />);
+
+    await user.press(screen.getByText("Card onboarding"));
+
+    expect(screen.getByText("Derived response")).toBeTruthy();
+    // Opening the screen re-asks, so a step is never read off a stale answer.
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows each step by the id the app keys it on", async () => {
+    const user = userEvent.setup();
+    const props = buildProps();
+    render(
+      <PayCard
+        {...props}
+        cardOnboarding={{ ...props.cardOnboarding, steps: onboardingSteps, completedCount: 2 }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card onboarding"));
+
+    expect(screen.getByText("top-up-card")).toBeTruthy();
+    // Two done, two not: the labels have to tell them apart.
+    expect(screen.getAllByText("done")).toHaveLength(2);
+    expect(screen.getAllByText("open")).toHaveLength(2);
+  });
+
+  it("sets a step by the answer behind it, and leaves the unanswerable one alone", async () => {
+    const user = userEvent.setup();
+    const setStepDone = jest.fn();
+    const props = buildProps();
+    render(
+      <PayCard
+        {...props}
+        cardOnboarding={{ ...props.cardOnboarding, steps: onboardingSteps, setStepDone }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card onboarding"));
+
+    // Three steps a request decides, so three toggles; the purchase step has none.
+    expect(screen.queryByLabelText("first-purchase")).toBeNull();
+
+    await user.press(screen.getByLabelText("top-up-card"));
+    expect(setStepDone).toHaveBeenCalledWith("top-up-card", true);
+
+    await user.press(screen.getByLabelText("create-account"));
+    expect(setStepDone).toHaveBeenCalledWith("create-account", false);
+  });
+
+  it("hands the endpoints back to the provider", async () => {
+    const user = userEvent.setup();
+    const clearMocks = jest.fn();
+    const props = buildProps();
+    render(<PayCard {...props} cardOnboarding={{ ...props.cardOnboarding, clearMocks }} />);
+
+    await user.press(screen.getByText("Card onboarding"));
+    await user.press(screen.getByText("Use the real answers"));
+
+    expect(clearMocks).toHaveBeenCalledTimes(1);
+  });
+
+  it("says so when the host is not intercepting requests, rather than offering a dead toggle", async () => {
+    const user = userEvent.setup();
+    const props = buildProps();
+    const steps = onboardingSteps.map(step => ({ ...step, canToggle: false }));
+    render(
+      <PayCard
+        {...props}
+        cardOnboarding={{ ...props.cardOnboarding, steps, isMockingEnabled: false }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card onboarding"));
+
+    expect(screen.getByText(/Request mocking is off/)).toBeTruthy();
+    expect(screen.queryByText("Use the real answers")).toBeNull();
+    expect(screen.queryByLabelText("top-up-card")).toBeNull();
+  });
+
+  it("shows the derived answer itself, because the steps are worked out and not fetched", async () => {
+    const user = userEvent.setup();
+    const props = buildProps();
+    const raw = JSON.stringify({ steps: onboardingSteps, completedCount: 2 }, null, 2);
+    render(<PayCard {...props} cardOnboarding={{ ...props.cardOnboarding, raw }} />);
+
+    await user.press(screen.getByText("Card onboarding"));
+
+    expect(screen.getByText(raw)).toBeTruthy();
   });
 });

--- a/devtools/pay-card/src/pay-card/PayCard.native.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.tsx
@@ -12,12 +12,18 @@ import {
   Spot,
   Tag,
 } from "@ledgerhq/lumen-ui-rnative";
-import { ChevronRight, CoinsCrypto, CreditCard } from "@ledgerhq/lumen-ui-rnative/symbols";
+import {
+  CheckmarkCircle,
+  ChevronRight,
+  CoinsCrypto,
+  CreditCard,
+} from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { PayCardToolProps } from "../types";
 import { Section } from "../components/Section/Section";
 import { ToggleRow } from "../components/ToggleRow/ToggleRow";
 import { Interaction } from "../components/Interaction/Interaction";
 import { BalanceScreen } from "../components/Balance/Balance";
+import { CardOnboardingScreen } from "../components/CardOnboarding/CardOnboarding";
 import { AuthSection } from "./AuthSection";
 import { ResultToast } from "./ResultToast";
 import { SecureBrowserSection } from "./SecureBrowserSection";
@@ -33,6 +39,7 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
   const {
     flags,
     onboarding,
+    cardOnboarding,
     interaction,
     balance,
     hasSeenFeatureTour,
@@ -56,7 +63,7 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
     onNavigateToPaySuccess ||
     onNavigateToSendSuccess,
   );
-  const [screen, setScreen] = useState<"tool" | "interaction" | "balance">("tool");
+  const [screen, setScreen] = useState<"tool" | "interaction" | "balance" | "onboarding">("tool");
 
   if (screen === "interaction") {
     return <Interaction {...interaction} onBack={() => setScreen("tool")} />;
@@ -64,6 +71,10 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
 
   if (screen === "balance") {
     return <BalanceScreen {...balance} onBack={() => setScreen("tool")} />;
+  }
+
+  if (screen === "onboarding") {
+    return <CardOnboardingScreen {...cardOnboarding} onBack={() => setScreen("tool")} />;
   }
 
   return (
@@ -99,6 +110,23 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
               <Spot appearance="icon" icon={CoinsCrypto} />
               <ListItemContent>
                 <ListItemTitle>Balance</ListItemTitle>
+              </ListItemContent>
+            </ListItemLeading>
+            <ListItemTrailing>
+              <ChevronRight />
+            </ListItemTrailing>
+          </ListItem>
+
+          <ListItem
+            onPress={() => {
+              cardOnboarding.refresh();
+              setScreen("onboarding");
+            }}
+          >
+            <ListItemLeading>
+              <Spot appearance="icon" icon={CheckmarkCircle} />
+              <ListItemContent>
+                <ListItemTitle>Card onboarding</ListItemTitle>
               </ListItemContent>
             </ListItemLeading>
             <ListItemTrailing>

--- a/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
@@ -22,6 +22,17 @@ function buildProps(): PayCardToolProps {
       ],
       setStepDone: jest.fn(),
     },
+    cardOnboarding: {
+      steps: [],
+      completedCount: 0,
+      isFetching: false,
+      error: undefined,
+      raw: "{}",
+      refresh: jest.fn(),
+      setStepDone: jest.fn(),
+      clearMocks: jest.fn(),
+      isMockingEnabled: true,
+    },
     interaction: {
       probes: [],
       details: {

--- a/devtools/pay-card/src/types.ts
+++ b/devtools/pay-card/src/types.ts
@@ -177,6 +177,44 @@ export interface PayCardBalanceProps {
 
 export type PayCardOpenSecureBrowser = (url: string) => Promise<string>;
 
+/** One step of the onboarding status the app works out from the Card endpoints. */
+export interface PayCardOnboardingStatusStep {
+  /** What the app keys the step on. There is no copy: the status carries ids, not labels. */
+  readonly id: string;
+  readonly isDone: boolean;
+  /**
+   * Whether something can drive this step. False while no source answers it, which is the purchase
+   * step until the transactions endpoint is read.
+   */
+  readonly canToggle: boolean;
+}
+
+/**
+ * The onboarding status the app works out from the Card endpoints, and how to drive it.
+ *
+ * The steps are worked out from several endpoints rather than fetched, so a step is set by mocking
+ * the answer behind it: the host intercepts that endpoint and the step follows on the next read.
+ * The raw answer is shown so a wrong step can be traced to the response behind it.
+ */
+export interface PayCardOnboardingStatusProps {
+  readonly steps: readonly PayCardOnboardingStatusStep[];
+  readonly completedCount: number;
+  readonly isFetching: boolean;
+  readonly error: string | undefined;
+  /** The derived answer, pretty-printed. Always present: every step has an answer to show. */
+  readonly raw: string;
+  readonly refresh: () => void;
+  /** Mocks the answer behind one step, then re-reads it. Ignored for a step nothing answers. */
+  readonly setStepDone: (id: string, done: boolean) => void;
+  /** Drops every mocked answer, so the endpoints reach the provider again. */
+  readonly clearMocks: () => void;
+  /**
+   * Whether the host is intercepting requests at all. Mocking is started by an env var, so without
+   * it a toggle would set an answer nothing ever reads.
+   */
+  readonly isMockingEnabled: boolean;
+}
+
 /**
  * Props contract for the Card / Pay DevTool.
  *
@@ -186,6 +224,7 @@ export type PayCardOpenSecureBrowser = (url: string) => Promise<string>;
 export interface PayCardToolProps {
   readonly flags: PayCardFlagsProps;
   readonly onboarding: PayCardOnboardingProps;
+  readonly cardOnboarding: PayCardOnboardingStatusProps;
   readonly interaction: PayCardInteractionProps;
   readonly balance: PayCardBalanceProps;
   /** Whether the user has already seen the Pay feature tour. */

--- a/devtools/pay-card/src/usePayCardViewModel.native.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.native.test.ts
@@ -27,6 +27,18 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
       setStepDone: jest.fn(),
       ...overrides.onboarding,
     },
+    cardOnboarding: {
+      steps: [],
+      completedCount: 0,
+      isFetching: false,
+      error: undefined,
+      raw: "{}",
+      refresh: jest.fn(),
+      setStepDone: jest.fn(),
+      clearMocks: jest.fn(),
+      isMockingEnabled: true,
+      ...overrides.cardOnboarding,
+    },
     interaction: {
       probes: [],
       details: {

--- a/devtools/pay-card/src/usePayCardViewModel.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.test.ts
@@ -26,6 +26,18 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
       setStepDone: jest.fn(),
       ...overrides.onboarding,
     },
+    cardOnboarding: {
+      steps: [],
+      completedCount: 0,
+      isFetching: false,
+      error: undefined,
+      raw: "{}",
+      refresh: jest.fn(),
+      setStepDone: jest.fn(),
+      clearMocks: jest.fn(),
+      isMockingEnabled: true,
+      ...overrides.cardOnboarding,
+    },
     interaction: {
       probes: [],
       details: {

--- a/domain/api/card-management/package.json
+++ b/domain/api/card-management/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./mock": "./src/onboardingStatus.mock.ts",
+    "./mock/card-onboarding-status": "./src/cardOnboardingStatus.mock.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/domain/api/card-management/src/cardOnboardingStatus.mock.test.ts
+++ b/domain/api/card-management/src/cardOnboardingStatus.mock.test.ts
@@ -1,0 +1,86 @@
+import {
+  PayCardInternalWalletsResponseSchema,
+  PayCardLinkedWalletsResponseSchema,
+  PayCardStatusResponseSchema,
+  PayCardUserResponseSchema,
+} from "./schema";
+import {
+  clearCardOnboardingStatusMock,
+  mockPayCardInternalWallets,
+  mockPayCardLinkedWallets,
+  mockPayCardStatus,
+  mockPayCardUser,
+  readCardOnboardingStatusMock,
+  setCardOnboardingStatusMock,
+} from "./cardOnboardingStatus.mock";
+
+describe("the onboarding answers", () => {
+  afterEach(() => {
+    clearCardOnboardingStatusMock();
+  });
+
+  it("mocks nothing until something is set, so requests reach the provider", () => {
+    expect(readCardOnboardingStatusMock()).toEqual({});
+  });
+
+  it("holds one endpoint without pinning the others", () => {
+    setCardOnboardingStatusMock("hasCard", true);
+
+    expect(readCardOnboardingStatusMock()).toEqual({ hasCard: true });
+  });
+
+  it("keeps a false answer, which is not the same as no answer", () => {
+    setCardOnboardingStatusMock("accountVerified", false);
+
+    const { accountVerified } = readCardOnboardingStatusMock();
+    expect(accountVerified).toBe(false);
+  });
+
+  it("hands an endpoint back by unsetting it", () => {
+    setCardOnboardingStatusMock("walletFunded", true);
+    setCardOnboardingStatusMock("walletFunded", undefined);
+
+    // Removed, not held as `undefined`: a present key means a mocked endpoint.
+    expect(readCardOnboardingStatusMock()).toEqual({});
+  });
+
+  it("drops every answer at once", () => {
+    setCardOnboardingStatusMock("accountVerified", true);
+    setCardOnboardingStatusMock("hasCard", true);
+
+    clearCardOnboardingStatusMock();
+
+    expect(readCardOnboardingStatusMock()).toEqual({});
+  });
+});
+
+describe("the mocked responses", () => {
+  it("answers as the provider is parsed, or the query would reject them", () => {
+    expect(PayCardUserResponseSchema.safeParse(mockPayCardUser(true)).success).toBe(true);
+    expect(PayCardUserResponseSchema.safeParse(mockPayCardUser(false)).success).toBe(true);
+    expect(PayCardStatusResponseSchema.safeParse(mockPayCardStatus()).success).toBe(true);
+    expect(
+      PayCardInternalWalletsResponseSchema.safeParse(mockPayCardInternalWallets(true)).success,
+    ).toBe(true);
+    expect(PayCardLinkedWalletsResponseSchema.safeParse(mockPayCardLinkedWallets()).success).toBe(
+      true,
+    );
+  });
+
+  it("verifies the account only when asked to", () => {
+    expect(mockPayCardUser(true).verificationState).toBe("VERIFIED");
+    expect(mockPayCardUser(false).verificationState).not.toBe("VERIFIED");
+  });
+
+  it("describes the same wallet in both answers, because the join keys them by id", () => {
+    const [internal] = mockPayCardInternalWallets(true);
+    const [linked] = mockPayCardLinkedWallets();
+
+    expect(internal?.id).toBe(linked?.id);
+  });
+
+  it("funds the wallet only when asked to, and empties it otherwise", () => {
+    expect(Number(mockPayCardInternalWallets(true)[0]?.balance)).toBeGreaterThan(0);
+    expect(Number(mockPayCardInternalWallets(false)[0]?.balance)).toBe(0);
+  });
+});

--- a/domain/api/card-management/src/cardOnboardingStatus.mock.ts
+++ b/domain/api/card-management/src/cardOnboardingStatus.mock.ts
@@ -1,0 +1,99 @@
+import type {
+  PayCardInternalWallet,
+  PayCardLinkedWallet,
+  PayCardStatus,
+  PayCardUser,
+} from "./types";
+
+/**
+ * What the Card endpoints should answer, so onboarding can be put into a given state.
+ *
+ * Onboarding is worked out from several endpoints rather than fetched, so a step is only reachable
+ * through the answer behind it. These are the answers, one per step a request can decide.
+ *
+ * An answer left unset is not mocked at all: the request reaches the provider. Setting one pins
+ * that endpoint until it is cleared, so a tester can hold one step and leave the rest real.
+ */
+export type CardOnboardingStatusMock = {
+  /** `GET /v1/user`: whether the account reads as verified. */
+  readonly accountVerified?: boolean;
+  /** `GET /v1/card/status`: whether a card is answered with at all. */
+  readonly hasCard?: boolean;
+  /** `GET /v1/wallet/internal(/card_linked)`: whether the linked wallet holds anything. */
+  readonly walletFunded?: boolean;
+};
+
+let answers: CardOnboardingStatusMock = {};
+
+/** Read by the host's MSW handlers, on every request they answer. */
+export function readCardOnboardingStatusMock(): CardOnboardingStatusMock {
+  return answers;
+}
+
+/** Written by the devtool. Pass `undefined` to hand the endpoint back to the provider. */
+export function setCardOnboardingStatusMock<Key extends keyof CardOnboardingStatusMock>(
+  key: Key,
+  value: CardOnboardingStatusMock[Key],
+): void {
+  const next = { ...answers };
+
+  if (value === undefined) {
+    // Removed rather than set to `undefined`, so a present key always means a mocked endpoint.
+    delete next[key];
+  } else {
+    next[key] = value;
+  }
+
+  answers = next;
+}
+
+/** Drops every answer, so all four endpoints answer from the provider again. */
+export function clearCardOnboardingStatusMock(): void {
+  answers = {};
+}
+
+const MOCK_WALLET_ID = "11111111-1111-4111-8111-111111111111";
+
+export function mockPayCardUser(verified: boolean): PayCardUser {
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    verificationState: verified ? "VERIFIED" : "PENDING",
+  };
+}
+
+export function mockPayCardStatus(): PayCardStatus {
+  return {
+    id: "card-mock",
+    holderName: "Mock Holder",
+    expiryDate: "2030/01",
+    panLast4: "4242",
+    status: "ACTIVE",
+    type: "VIRTUAL",
+    orderedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** The join keys balances to linked wallets by id, so both answers describe the same wallet. */
+export function mockPayCardInternalWallets(funded: boolean): readonly PayCardInternalWallet[] {
+  return [
+    {
+      id: MOCK_WALLET_ID,
+      balance: funded ? "125.40" : "0.00",
+      currency: "usdc",
+      address: "0x0000000000000000000000000000000000000000",
+      addressMemo: null,
+    },
+  ];
+}
+
+export function mockPayCardLinkedWallets(): readonly PayCardLinkedWallet[] {
+  return [
+    {
+      id: MOCK_WALLET_ID,
+      address: "0x0000000000000000000000000000000000000000",
+      currency: "usdc",
+      network: "ethereum",
+      priority: 1,
+    },
+  ];
+}

--- a/features/flow/pay-card-widget/src/onboardingStatus/types.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/types.ts
@@ -8,4 +8,6 @@ export type UseCardOnboardingStatusResult = {
   readonly data: CardOnboardingStatus;
   readonly isLoading: boolean;
   readonly isError: boolean;
+  /** Re-asks all three sources. The widget never needs it; the devtool does. */
+  readonly refresh: () => void;
 };

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingSources.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingSources.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useGetCardStatusQuery, useGetUserQuery } from "@domain/api-card-management";
 import { useCardLinkedWallets } from "@features/flow-pay-card-wallets";
 import { hasPositiveBalance, type CardOnboardingSignals } from "./deriveCardOnboardingStatus";
@@ -16,6 +16,7 @@ export type CardOnboardingSources = {
   readonly signals: CardOnboardingSignals<CardOnboardingProviderStepId>;
   readonly isLoading: boolean;
   readonly isError: boolean;
+  readonly refresh: () => void;
 };
 
 const NO_COUNTER_VALUE = () => null;
@@ -47,8 +48,24 @@ export function useCardOnboardingSources({
     [user.data, cardStatus.data, linkedWallets.wallets],
   );
 
+  const { refetch: refetchUser } = user;
+  const { refetch: refetchCardStatus } = cardStatus;
+  const { refetch: refetchWallets } = linkedWallets;
+
+  const refresh = useCallback(() => {
+    // Nothing was started while skipped, and RTK throws when asked to refetch that.
+    if (skip) {
+      return;
+    }
+
+    refetchUser();
+    refetchCardStatus();
+    refetchWallets();
+  }, [skip, refetchUser, refetchCardStatus, refetchWallets]);
+
   return {
     signals,
+    refresh,
     // `isFetching` on all three, not `isLoading`: a query reports `isLoading` only while it has no
     // data, so after the first read a refetch would have looked idle.
     isLoading: user.isFetching || cardStatus.isFetching || linkedWallets.isFetching,

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.test.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.test.ts
@@ -16,20 +16,27 @@ import { useCardLinkedWallets } from "@features/flow-pay-card-wallets";
 import { useSelector } from "react-redux";
 import { useCardOnboardingStatus } from "./useCardOnboardingStatus.native";
 
+const refetchUser = jest.fn();
+const refetchCardStatus = jest.fn();
+const refetchWallets = jest.fn();
+
 function setupMocks({ hasAddedCardToWallet = false, verified = false } = {}) {
   jest.mocked(useGetUserQuery).mockReturnValue({
+    refetch: refetchUser,
     data: { verificationState: verified ? "VERIFIED" : "PENDING" },
     isFetching: false,
     isError: false,
   } as unknown as ReturnType<typeof useGetUserQuery>);
 
   jest.mocked(useGetCardStatusQuery).mockReturnValue({
+    refetch: refetchCardStatus,
     data: undefined,
     isFetching: false,
     isError: false,
   } as unknown as ReturnType<typeof useGetCardStatusQuery>);
 
   jest.mocked(useCardLinkedWallets).mockReturnValue({
+    refetch: refetchWallets,
     wallets: [],
     isFetching: false,
     isError: false,
@@ -81,6 +88,28 @@ describe("useCardOnboardingStatus (native)", () => {
     expect(jest.mocked(useCardLinkedWallets)).toHaveBeenCalledWith(
       expect.objectContaining({ skip: true }),
     );
+  });
+
+  it("re-asks all three sources", () => {
+    setupMocks();
+    const { result } = renderHook(() => useCardOnboardingStatus());
+
+    result.current.refresh();
+
+    expect(refetchUser).toHaveBeenCalledTimes(1);
+    expect(refetchCardStatus).toHaveBeenCalledTimes(1);
+    expect(refetchWallets).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks nothing while skipped, because a query that never started cannot refetch", () => {
+    setupMocks();
+    const { result } = renderHook(() => useCardOnboardingStatus({ skip: true }));
+
+    result.current.refresh();
+
+    expect(refetchUser).not.toHaveBeenCalled();
+    expect(refetchCardStatus).not.toHaveBeenCalled();
+    expect(refetchWallets).not.toHaveBeenCalled();
   });
 
   it("counts the phone wallet step like any other", () => {

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.native.ts
@@ -18,7 +18,7 @@ import {
 export function useCardOnboardingStatus(
   params: CardOnboardingSourcesParams = {},
 ): UseCardOnboardingStatusResult {
-  const { signals, isLoading, isError } = useCardOnboardingSources(params);
+  const { signals, isLoading, isError, refresh } = useCardOnboardingSources(params);
   const hasAddedCardToWallet = useSelector(selectHasAddedCardToWallet);
 
   const data = useMemo(
@@ -30,5 +30,5 @@ export function useCardOnboardingStatus(
     [signals, hasAddedCardToWallet],
   );
 
-  return { data, isLoading, isError };
+  return { data, isLoading, isError, refresh };
 }

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.test.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.test.ts
@@ -15,6 +15,10 @@ import { useCardOnboardingStatus } from "./useCardOnboardingStatus";
 
 type Verification = "UNVERIFIED" | "PENDING" | "VERIFIED" | "REJECTED";
 
+const refetchUser = jest.fn();
+const refetchCardStatus = jest.fn();
+const refetchWallets = jest.fn();
+
 function setupMocks({
   // `null` is "not read yet": an explicit `undefined` would fall back to the default.
   verificationState = "VERIFIED" as Verification | null,
@@ -28,18 +32,21 @@ function setupMocks({
   areWalletsError = false,
 } = {}) {
   jest.mocked(useGetUserQuery).mockReturnValue({
+    refetch: refetchUser,
     data: verificationState === null ? undefined : { verificationState },
     isFetching: isUserFetching,
     isError: isUserError,
   } as unknown as ReturnType<typeof useGetUserQuery>);
 
   jest.mocked(useGetCardStatusQuery).mockReturnValue({
+    refetch: refetchCardStatus,
     data: hasCard ? { status: cardStatus } : undefined,
     isFetching: isCardStatusFetching,
     isError: false,
   } as unknown as ReturnType<typeof useGetCardStatusQuery>);
 
   jest.mocked(useCardLinkedWallets).mockReturnValue({
+    refetch: refetchWallets,
     wallets: balances.map((balance, index) => ({ id: `w${index}`, balance })),
     isFetching: areWalletsFetching,
     isError: areWalletsError,
@@ -131,6 +138,30 @@ describe("useCardOnboardingStatus", () => {
     setupMocks({ verificationState: "PENDING", hasCard: false, balances: [] });
 
     expect(stepsById().completedCount).toBe(0);
+  });
+
+  describe("re-asking", () => {
+    it("re-asks all three sources", () => {
+      setupMocks();
+      const { result } = renderHook(() => useCardOnboardingStatus());
+
+      result.current.refresh();
+
+      expect(refetchUser).toHaveBeenCalledTimes(1);
+      expect(refetchCardStatus).toHaveBeenCalledTimes(1);
+      expect(refetchWallets).toHaveBeenCalledTimes(1);
+    });
+
+    it("asks nothing while skipped, because a query that never started cannot refetch", () => {
+      setupMocks();
+      const { result } = renderHook(() => useCardOnboardingStatus({ skip: true }));
+
+      result.current.refresh();
+
+      expect(refetchUser).not.toHaveBeenCalled();
+      expect(refetchCardStatus).not.toHaveBeenCalled();
+      expect(refetchWallets).not.toHaveBeenCalled();
+    });
   });
 
   describe("when the host holds the reads", () => {

--- a/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.ts
+++ b/features/flow/pay-card-widget/src/onboardingStatus/useCardOnboardingStatus.web.ts
@@ -11,9 +11,9 @@ import {
 export function useCardOnboardingStatus(
   params: CardOnboardingSourcesParams = {},
 ): UseCardOnboardingStatusResult {
-  const { signals, isLoading, isError } = useCardOnboardingSources(params);
+  const { signals, isLoading, isError, refresh } = useCardOnboardingSources(params);
 
   const data = useMemo(() => deriveCardOnboardingStatus(CARD_ONBOARDING_STEPS, signals), [signals]);
 
-  return { data, isLoading, isError };
+  return { data, isLoading, isError, refresh };
 }


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #21625 feat/LIVE-34770-pay-card-onboarding-status
- **#21626 feat/LIVE-34770-pay-card-onboarding-devtool ← this PR**
<!-- stac-man:stack-end -->

The onboarding status is worked out from three endpoints, so a tester needs two
things: to see what it came out as, and to put it into a given state. This adds a
devtool screen for both.

### What it does

- A **Card onboarding** screen: a `Stepper` for the count, every step by the id
  the app keys it on as well as its title, and the derived answer printed raw
  underneath, so a step that reads wrong can be traced to the response behind it.
- **Each step a request decides carries a toggle.** It sets what that endpoint
  answers rather than the step, so the step follows on the next read and cannot
  be set to something the account does not support. The phone wallet step is
  answered on the device; the purchase step is read-only while nothing answers it.
- An endpoint answers from the provider until its toggle is used, so one step can
  be held while the rest stay real, and one button hands them all back.
- The answers and the responses that carry them live in
  `@domain/api-card-management/mock/onboarding-answers`, which the mobile MSW
  setup reads on every request it answers.
- Mocking is started by an env var (`MSW_ENABLED=true` on mobile). Without it the
  screen says so rather than offering a toggle that would set an answer nothing
  reads.
- `refresh` on the hook re-asks all three sources: the screen asks on open and on
  demand.

### Scope

Additive: a new `cardOnboarding` props group and screen, next to the existing
onboarding controls. The three fixtures that build `PayCardToolProps` gain the new
field, which is the only reason any existing test file is touched.

<img width="350" alt="Screenshot_20260910_123025_LL  DEV" src="https://github.com/user-attachments/assets/94bbc8bf-7954-45e0-b685-766d2d69b29e" />

