### PR TITLE
feat(card): read the card's transactions (LIVE-34780)

### DIFF
--- a/.changeset/pay-card-transactions.md
+++ b/.changeset/pay-card-transactions.md
@@ -1,0 +1,10 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add `getCardTransactions` for `GET /v1/card/transactions`.
+
+- Newest first, paged by number. The provider answers with a bare array, so a short page is how a caller learns it reached the end.
+- Narrowed to what a transaction list shows. The card and processor ids, the MCC number, the conversion rates and the funding sources are left undeclared, so Zod drops them before they reach the cache.
+- `declineReason` accepts the `""` the provider sends on a transaction that was not declined.
+- `dateFrom` and `dateTo` are validated as a pair before the request goes out, because the provider rejects one without the other.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -24,6 +24,7 @@ shape and the reasons.
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
 | `orderCard` | POST | `/v1/card/order` | Order a virtual card |
 | `getCardStatus` | GET | `/v1/card/status` | Read the ordered card's state and preview fields |
+| `getCardTransactions` | GET | `/v1/card/transactions` | Read the card's own transactions, newest first |
 | `createCardDetailsToken` | POST | `/v1/card/details/token` | Mint a single-use token and image URL showing PAN, CVV and expiry |
 | `freezeCard` | POST | `/v1/card/freeze` | Move an active card to `FROZEN` |
 | `unfreezeCard` | POST | `/v1/card/unfreeze` | Move a frozen card back to `ACTIVE` |

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -125,6 +125,7 @@ describe("cardManagementApi configuration", () => {
       "getCardLinkedWallets",
       "getCardOnboardingStatus",
       "getCardStatus",
+      "getCardTransactions",
       "getInternalWallets",
       "getUser",
       "logout",
@@ -432,6 +433,84 @@ describe("cardManagementApi requests", () => {
 
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("getCardTransactions", () => {
+    const TRANSACTIONS_PATH = "/v1/card/transactions";
+
+    const transaction = {
+      id: "100a99cf-f4d3-4fa1-9be9-2e9828b20ebb",
+      dateTime: "2024-10-14T10:44:36.276Z",
+      sign: "DEBIT",
+      merchantNameLocation: "WWW.ALIEXPRESS.COM, LONDON",
+      mccCategory: "MISC",
+      status: "CONFIRMED",
+      declineReason: "",
+      transactionCurrency: "EUR",
+      amountInTransactionCurrency: "0.79",
+      feesInTransactionCurrency: "0",
+      originalCurrency: "USD",
+      amountInOriginalCurrency: "0.85",
+    };
+
+    it("reads the transactions with the bearer token and the client key", async () => {
+      provider.get(TRANSACTIONS_PATH, () => jsonResponse([transaction]));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardTransactions.initiate(undefined),
+      );
+
+      expectSessionRequest("GET", TRANSACTIONS_PATH);
+      expect(result.data).toEqual([transaction]);
+    });
+
+    it("sends the filters as query parameters", async () => {
+      provider.get(TRANSACTIONS_PATH, () => jsonResponse([]));
+
+      const store = makeStore("session-token");
+      await store.dispatch(
+        cardManagementApi.endpoints.getCardTransactions.initiate({
+          page: 2,
+          dateFrom: "2026-01-01",
+          dateTo: "2026-01-31",
+          mccCategories: "FOOD,TRAVEL",
+        }),
+      );
+
+      const { searchParams } = new URL(provider.sent().url);
+      expect(searchParams.get("page")).toBe("2");
+      expect(searchParams.get("dateFrom")).toBe("2026-01-01");
+      expect(searchParams.get("dateTo")).toBe("2026-01-31");
+      expect(searchParams.get("mccCategories")).toBe("FOOD,TRAVEL");
+    });
+
+    it("rejects one date without the other before the request goes out", async () => {
+      provider.get(TRANSACTIONS_PATH, () => jsonResponse([]));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        // The pairing is part of the request type, so this line also asserts the type refuses it.
+        // @ts-expect-error one date without the other is not a filter
+        cardManagementApi.endpoints.getCardTransactions.initiate({ dateFrom: "2026-01-01" }),
+      );
+
+      expect(result.error).toBeDefined();
+      // The provider would answer 400; the filter never leaves the app.
+      expect(provider.requests()).toEqual([]);
+    });
+
+    it("reads an empty history as an empty list, not as a failure", async () => {
+      provider.get(TRANSACTIONS_PATH, () => jsonResponse([]));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardTransactions.initiate(undefined),
+      );
+
+      expect(result.data).toEqual([]);
+      expect(result.error).toBeUndefined();
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -12,6 +12,8 @@ import {
   PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
+  PayCardTransactionsRequestSchema,
+  PayCardTransactionsResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 import { transformPayCardSessionResponse } from "./transforms";
@@ -28,6 +30,8 @@ import type {
   PayCardDetailsCss,
   PayCardDetailsToken,
   PayCardStatus,
+  PayCardTransaction,
+  PayCardTransactionsRequest,
   PayCardUser,
 } from "./types";
 
@@ -118,6 +122,23 @@ export const cardManagementApi = cardApi
       }),
 
       /**
+       * The card's own transactions, newest first.
+       *
+       * Paged by number and nothing else: the provider answers with a bare array, so a short page
+       * is how a caller learns it has reached the end.
+       */
+      getCardTransactions: build.query<PayCardTransaction[], PayCardTransactionsRequest>({
+        query: filters => ({
+          url: "/v1/card/transactions",
+          method: "GET",
+          params: filters,
+        }),
+        argSchema: PayCardTransactionsRequestSchema,
+        responseSchema: PayCardTransactionsResponseSchema,
+        providesTags: ["CardTransactions"],
+      }),
+
+      /**
        * A mutation, though it reads: the provider spends the token on first use, so the answer must
        * never be served from a cache, and a mutation is never cached.
        *
@@ -200,6 +221,8 @@ export const {
   useGetUserQuery,
   useOrderCardMutation,
   useGetCardStatusQuery,
+  useGetCardTransactionsQuery,
+  useLazyGetCardTransactionsQuery,
   useCreateCardDetailsTokenMutation,
   useLazyGetCardStatusQuery,
   useFreezeCardMutation,

--- a/domain/api/card-management/src/constants.ts
+++ b/domain/api/card-management/src/constants.ts
@@ -2,6 +2,10 @@
  * RTK Query cache tags owned by the Card Management use case. Registered on the shared `cardApi` via
  * `enhanceEndpoints({ addTagTypes })`, so the shared service never has to know they exist.
  */
-export const CARD_MANAGEMENT_TAGS = ["CardStatus", "CardOnboardingStatus"] as const;
+export const CARD_MANAGEMENT_TAGS = [
+  "CardStatus",
+  "CardOnboardingStatus",
+  "CardTransactions",
+] as const;
 
 export const OAUTH2_TOKEN_PATH = "/v1/auth/oauth2/token";

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -10,6 +10,8 @@ import {
   PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
+  PayCardTransactionSchema,
+  PayCardTransactionsRequestSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 
@@ -347,5 +349,113 @@ describe("PayCardOnboardingStatusResponseSchema", () => {
         steps: [{ ...response.steps[0], title: "" }],
       }),
     ).toThrow();
+  });
+});
+
+describe("PayCardTransactionSchema", () => {
+  // The provider's own documented example, kept whole so the extra keys are exercised too.
+  const documented = {
+    id: "100a99cf-f4d3-4fa1-9be9-2e9828b20ebb",
+    cardId: "1234537292209260487",
+    panLast4: "9189",
+    transactionId: "1122334477422",
+    dateTime: "2024-10-14T10:44:36.276Z",
+    sign: "DEBIT",
+    merchantNameLocation: "WWW.ALIEXPRESS.COM, LONDON",
+    merchantType: "OutOfWalletOnline",
+    mcc: 5964,
+    mccCategory: "MISC",
+    transactionCurrency: "EUR",
+    amountInTransactionCurrency: "0.79",
+    feesInTransactionCurrency: "0",
+    originalCurrency: "USD",
+    amountInOriginalCurrency: "0.85",
+    feesInOriginalCurrency: "0",
+    billingConversionRate: "0.9294117647058824",
+    ecbRate: "0.9161704076958315",
+    status: "CONFIRMED",
+    declineReason: "",
+    fundingSources: [
+      {
+        id: "3181a37a-07fa-41dc-b423-6c2db07a7ba1",
+        address: "0x3a11a86cf218c448be519728cd3ac5c741fb3424",
+        network: "linea",
+        txHash: "0xb92de09d893e8162b0861c0f7321f68df02212efbc58f208839ae3f176d89638",
+        currency: "usdc",
+        amount: "0.104201",
+        fees: "0",
+        swapFee: "0.00208",
+        sign: "DEBIT",
+        status: "CONFIRMED",
+        dateTime: "2024-10-14T10:44:36.288Z",
+      },
+    ],
+  };
+
+  it("reads the transaction the provider documents", () => {
+    expect(PayCardTransactionSchema.parse(documented).id).toBe(documented.id);
+  });
+
+  it("accepts the empty decline reason a confirmed transaction carries", () => {
+    // The provider sends `""`, not an absent key. A non-empty rule here would reject every
+    // transaction that was not declined.
+    expect(PayCardTransactionSchema.parse(documented).declineReason).toBe("");
+  });
+
+  it("reads a declined transaction with its reason", () => {
+    const declined = { ...documented, status: "DECLINED", declineReason: "Insufficient funds" };
+
+    expect(PayCardTransactionSchema.parse(declined)).toMatchObject({
+      status: "DECLINED",
+      declineReason: "Insufficient funds",
+    });
+  });
+
+  it.each(["CONFIRMED", "PENDING", "DECLINED", "REVERTED"])("reads a %s transaction", status => {
+    expect(PayCardTransactionSchema.parse({ ...documented, status }).status).toBe(status);
+  });
+
+  it("keeps the card and processor ids out of what callers receive", () => {
+    const parsed = PayCardTransactionSchema.parse(documented);
+
+    // Zod drops what is not declared, which is what keeps the unneeded fields out of the cache.
+    expect(parsed).not.toHaveProperty("cardId");
+    expect(parsed).not.toHaveProperty("panLast4");
+    expect(parsed).not.toHaveProperty("fundingSources");
+  });
+
+  it("keeps the amount as the string the provider sent, not a number", () => {
+    expect(PayCardTransactionSchema.parse(documented).amountInTransactionCurrency).toBe("0.79");
+  });
+
+  it("rejects a direction the wire contract does not name", () => {
+    expect(() => PayCardTransactionSchema.parse({ ...documented, sign: "REFUND" })).toThrow();
+  });
+});
+
+describe("PayCardTransactionsRequestSchema", () => {
+  it("takes no filters at all", () => {
+    expect(PayCardTransactionsRequestSchema.parse(undefined)).toBeUndefined();
+  });
+
+  it("takes a page on its own", () => {
+    expect(PayCardTransactionsRequestSchema.parse({ page: 2 })).toEqual({ page: 2 });
+  });
+
+  it("takes both dates together", () => {
+    const range = { dateFrom: "2026-01-01", dateTo: "2026-01-31" };
+
+    expect(PayCardTransactionsRequestSchema.parse(range)).toEqual(range);
+  });
+
+  it.each([{ dateFrom: "2026-01-01" }, { dateTo: "2026-01-31" }])(
+    "rejects %s, because the provider requires the pair",
+    range => {
+      expect(() => PayCardTransactionsRequestSchema.parse(range)).toThrow();
+    },
+  );
+
+  it("rejects a negative page", () => {
+    expect(() => PayCardTransactionsRequestSchema.parse({ page: -1 })).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -77,6 +77,64 @@ export const PayCardDetailsTokenResponseSchema = z.object({
     .refine(value => value.startsWith("https://"), { message: "must be an https URL" }),
 });
 
+/**
+ * One card transaction, narrowed to what a transaction list shows.
+ *
+ * The response carries more: the card and processor ids, the MCC number, the conversion and ECB
+ * rates, and the funding sources behind each charge. None of it is displayed, and one field here is
+ * already sensitive — `merchantNameLocation` says where the cardholder shopped — so the rest is
+ * left undeclared and Zod drops it before it reaches the cache.
+ */
+export const PayCardTransactionSchema = z.object({
+  id: z.string().min(1),
+  /** ISO 8601, as the provider formats it. */
+  dateTime: z.string().min(1),
+  sign: z.enum(["DEBIT", "CREDIT"]),
+  merchantNameLocation: z.string().min(1),
+  /** The provider's own grouping, not an id we map: `SUBSCRIPTIONS`, `FOOD`, `MISC` and so on. */
+  mccCategory: z.string().min(1),
+  status: z.enum(["CONFIRMED", "PENDING", "DECLINED", "REVERTED"]),
+  /** The provider sends `""` on a transaction that was not declined, so an empty one is expected. */
+  declineReason: z.string().optional(),
+  transactionCurrency: z.string().min(1),
+  amountInTransactionCurrency: z.string().min(1),
+  feesInTransactionCurrency: z.string().min(1),
+  /** What the merchant charged, when that differs from the card's own currency. */
+  originalCurrency: z.string().min(1),
+  amountInOriginalCurrency: z.string().min(1),
+});
+
+export const PayCardTransactionsResponseSchema = z.array(PayCardTransactionSchema);
+
+const PayCardTransactionFiltersSchema = z.object({
+  page: z.number().int().nonnegative().optional(),
+  searchKey: z.string().min(1).optional(),
+  mccCategories: z.string().min(1).optional(),
+});
+
+/**
+ * The provider requires `dateFrom` and `dateTo` together, so neither is useful alone: one without
+ * the other is a filter the backend rejects.
+ *
+ * A union rather than a refinement, so the rule is in the inferred type as well: a caller cannot
+ * write a filter that only fails once it is sent.
+ */
+export const PayCardTransactionsRequestSchema = z
+  .union(
+    [
+      PayCardTransactionFiltersSchema.extend({
+        dateFrom: z.string().min(1),
+        dateTo: z.string().min(1),
+      }),
+      PayCardTransactionFiltersSchema.extend({
+        dateFrom: z.undefined().optional(),
+        dateTo: z.undefined().optional(),
+      }),
+    ],
+    { error: "dateFrom and dateTo go together" },
+  )
+  .optional();
+
 export const PayCardInternalWalletSchema = z.object({
   id: z.string().min(1),
   balance: z.string().min(1),

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -13,6 +13,8 @@ import {
   PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
+  PayCardTransactionSchema,
+  PayCardTransactionsRequestSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 
@@ -34,6 +36,11 @@ export type PayCardErrorResponse = z.infer<typeof PayCardErrorResponseSchema>;
 export type PayCardStatus = z.infer<typeof PayCardStatusResponseSchema>;
 
 export type PayCardDetailsCss = z.infer<typeof PayCardDetailsCssSchema>;
+
+export type PayCardTransaction = z.infer<typeof PayCardTransactionSchema>;
+
+/** Every filter the provider takes. The dates go together; the rest stand alone. */
+export type PayCardTransactionsRequest = z.infer<typeof PayCardTransactionsRequestSchema>;
 
 /**
  * Single use, and short-lived: the provider invalidates the token once the image has been read.


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21627 feat/LIVE-34780-card-transactions ← this PR**
- #21635 feat/LIVE-34780-wallet-history
<!-- stac-man:stack-end -->

The first of the two lists the ticket asks for. Newest first, paged by number:
the provider answers with a bare array, so a short page is how a caller learns
it has reached the end.

- Narrowed to what a transaction list shows. The card and processor ids, the
  MCC number, the conversion and ECB rates and the funding sources are left
  undeclared, so Zod drops them. One declared field already says where the
  cardholder shopped; the rest do not need to be in the cache too.
- `declineReason` takes the `""` the provider sends on a transaction that was
  not declined. A non-empty rule would have rejected every confirmed one.
- `dateFrom` and `dateTo` are checked as a pair before the request goes out,
  because the provider rejects one without the other.