### PR TITLE
feat(tron): add gasSponsorship feature flag

### DIFF
--- a/.changeset/nice-feet-begin.md
+++ b/.changeset/nice-feet-begin.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+feat(tron): add gasSponsorship feature flag

--- a/shared/feature-flags/src/flags/team-coin-integration/gasSponsorship.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/gasSponsorship.ts
@@ -1,0 +1,10 @@
+import { flag } from "../../define";
+
+/**
+ * Gates gas sponsorship — paying network fees through a third-party energy provider instead of
+ * burning the native asset.
+ *
+ * On/off only. Which coin families offer it, which provider serves them, and whether one is
+ * configured at all lives in each family's remote coin-config.
+ */
+export const gasSponsorship = flag();

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -100,6 +100,7 @@ export * from "./editBitcoinTx";
 export * from "./editEvmTx";
 export * from "./evmNativeStaking";
 export * from "./fetchAdditionalCoins";
+export * from "./gasSponsorship";
 export * from "./lldHideSmallValueTokenOperations";
 export * from "./lldMemoTag";
 export * from "./lldTezosStaking";


### PR DESCRIPTION
### 📝 Description

Adds the `gasSponsorship` feature flag — the remote kill-switch for paying network fees through a third-party energy provider (TRON/Tronify first) instead of burning the native asset. Firebase parameter: `feature_gas_sponsorship`. Default off, so nothing changes until it is provisioned; nothing consumes it yet.

On/off only, no params: which families offer sponsorship and which provider serves them already lives in each family's remote coin-config (`config_currency_tron.energyRent`, absent by default and carrying the provider plus its settings), so a second whitelist here would be a duplicate source of truth. LIVE-33403's fee selector consumes this via `useFeature("gasSponsorship")` and owns the third-party disclosure and the per-transaction opt-in — so the ticket's "global user setting" ACs are delivered there, not here.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32778](https://ledgerhq.atlassian.net/browse/LIVE-32778)
- **ADR** (if any): n/a

[LIVE-32778]: https://ledgerhq.atlassian.net/browse/LIVE-32778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ