### PR TITLE
test(e2e): add filter tests by team

### DIFF
--- a/.github/workflows/notify-e2e-required-reusable.yml
+++ b/.github/workflows/notify-e2e-required-reusable.yml
@@ -108,6 +108,7 @@ jobs:
               section += `- Select "Run workflow"\n`;
               section += `- Branch: \`${branch}\`\n`;
               section += `- Device: ${device}\n`;
+              section += `- **Filter by team:** pick your team in the \`team\` dropdown to run only its specs\n`;
               if (isTargeted) {
                 section += `- **Filter by coin:** Use the coin filter to test only \`${coins}\`\n`;
               }

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1,6 +1,6 @@
 name: "[Mobile] - E2E Only - Scheduled/Manual"
 run-name: >
-  @Mobile E2E • ${{ github.event_name == 'workflow_dispatch' && 'Manual' || github.event_name == 'schedule' && 'Scheduled' || github.event_name }} • ${{ inputs.tests_type || 'All' }} • ${{ inputs.ref || github.ref_name }} • ${{ github.actor }}
+  @Mobile E2E • ${{ github.event_name == 'workflow_dispatch' && 'Manual' || github.event_name == 'schedule' && 'Scheduled' || github.event_name }} • ${{ inputs.tests_type || 'All' }} •${{ inputs.team && inputs.team != 'all' && format(' team {0} •', inputs.team) || '' }} ${{ inputs.ref || github.ref_name }} • ${{ github.actor }}
 
 # One concurrent run per: workflow definition ref (Use workflow from), code ref/sha under test,
 # test surface (tests_type or schedule cron). Matches checkout ref: inputs.ref || github.sha.
@@ -12,7 +12,7 @@ concurrency:
   # overlapping — they would otherwise race on the same on-chain accounts across machines, which no
   # per-run mechanism can prevent. Non-broadcast runs keep the original per-ref/tests_type group.
   group: >-
-    ${{ (inputs.enable_broadcast || github.event.schedule == '0 0 * * 3' || github.event.schedule == '0 0 * * 5') && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, inputs.test_filter && 'filtered' || 'all') }}
+    ${{ (inputs.enable_broadcast || github.event.schedule == '0 0 * * 3' || github.event.schedule == '0 0 * * 5') && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, (inputs.test_filter || (inputs.team && inputs.team != 'all')) && 'filtered' || 'all') }}
   cancel-in-progress: false
 
 on:
@@ -30,9 +30,15 @@ on:
         description: "Specify branch to checkout and test or leave blank to use the workflow branch"
         required: false
       test_filter:
-        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks")
+        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks". A @team-<slug> token selects that team's specs as one more alternative)
         required: false
         type: string
+      team:
+        description: "Run only one team's tests. ANDed with test_filter, Smoke and the device."
+        required: false
+        type: choice
+        options: [all, bst, buy-and-sell, coin-integration, earn, engagement, swap, wallet-xp]
+        default: all
       tests_type:
         description: "Which tests to run"
         required: true
@@ -105,9 +111,14 @@ on:
         required: false
         type: string
       test_filter:
-        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks")
+        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks". A @team-<slug> token selects that team's specs as one more alternative)
         required: false
         type: string
+      team:
+        description: "Team slug whose specs to run. One of: all, bst, buy-and-sell, coin-integration, earn, engagement, swap, wallet-xp."
+        required: false
+        type: string
+        default: all
       tests_type:
         description: "Which tests to run"
         required: false
@@ -421,33 +432,40 @@ jobs:
 
       - name: Prepare test filter
         id: test-filter
-        run: |
-          RESOLVED_FILTER="$(node e2e/tooling/filter/resolve.mjs \
-            --input "$TEST_FILTER_INPUT" \
-            --smoke-tests "$SMOKE_TESTS_INPUT" \
-            --check-dir "e2e/mobile/specs" \
-            --runner detox)"
-          echo "filter=$RESOLVED_FILTER" >> $GITHUB_OUTPUT
         shell: bash
         env:
           TEST_FILTER_INPUT: ${{ inputs.test_filter }}
           SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
+          TEAM_INPUT: ${{ inputs.team || 'all' }}
+        run: |
+          # Heredoc-delimited output: a team selection is a "|"-joined spec list (~1 KB), which the
+          # previous `echo key=$VALUE` form could not carry safely.
+          node e2e/tooling/filter/resolve.mjs \
+            --input "$TEST_FILTER_INPUT" \
+            --smoke-tests "$SMOKE_TESTS_INPUT" \
+            --team "$TEAM_INPUT" \
+            --check-dir "e2e/mobile/specs" \
+            --runner detox \
+            --github-output >> "$GITHUB_OUTPUT"
 
       - name: Write resolved filter to GitHub Summary
-        run: |
-          FILTER_PATTERN="${{ steps.test-filter.outputs.filter }}"
-          if [ -z "$FILTER_PATTERN" ]; then
-            FILTER_PATTERN="(none)"
-          fi
-          echo "- **Resolved filtered pattern:** $FILTER_PATTERN" >> $GITHUB_STEP_SUMMARY
         shell: bash
+        env:
+          FILTER_PATTERN: ${{ steps.test-filter.outputs.filter }}
+          TEAM_INPUT: ${{ inputs.team || 'all' }}
+        run: |
+          # Passed via env, not interpolated into the script: test_filter is free-text user input.
+          {
+            echo "- **Team:** ${TEAM_INPUT}"
+            node e2e/tooling/filter/format-summary.mjs "${FILTER_PATTERN:-}" "- **Resolved filtered pattern:**"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate shards matrix and test files
         id: generate-shards
         uses: LedgerHQ/ledger-live/tools/actions/composites/generate-shards-matrix@develop
         with:
           test_directory: e2e/mobile
-          test_filter: ${{ steps.test-filter.outputs.filter }}
+          test_filter: ${{ steps.test-filter.outputs.runner_filter }}
           event_name: ${{ github.event_name }}
           ref: ${{ inputs.ref || github.ref_name }}
           ios_timing_cache_key: ${{ steps.cache-keys.outputs.ios_timing_cache_key }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1,6 +1,6 @@
 name: "[Mobile] - E2E Only - Scheduled/Manual"
 run-name: >
-  @Mobile E2E • ${{ github.event_name == 'workflow_dispatch' && 'Manual' || github.event_name == 'schedule' && 'Scheduled' || github.event_name }} • ${{ inputs.tests_type || 'All' }} •${{ inputs.team && inputs.team != 'all' && format(' team {0} •', inputs.team) || '' }} ${{ inputs.ref || github.ref_name }} • ${{ github.actor }}
+  @Mobile E2E • ${{ github.event_name == 'workflow_dispatch' && 'Manual' || github.event_name == 'schedule' && 'Scheduled' || github.event_name }} • ${{ inputs.tests_type || 'All' }} • ${{ inputs.ref || github.ref_name }} • ${{ github.actor }}
 
 # One concurrent run per: workflow definition ref (Use workflow from), code ref/sha under test,
 # test surface (tests_type or schedule cron). Matches checkout ref: inputs.ref || github.sha.
@@ -30,7 +30,7 @@ on:
         description: "Specify branch to checkout and test or leave blank to use the workflow branch"
         required: false
       test_filter:
-        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks". A @team-<slug> token selects that team's specs as one more alternative)
+        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks")
         required: false
         type: string
       team:
@@ -111,7 +111,7 @@ on:
         required: false
         type: string
       test_filter:
-        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks". A @team-<slug> token selects that team's specs as one more alternative)
+        description: Filter pattern(s) to select spec files by file path or declared @-tag (mobile matches whole spec files, not test names), separated by ',' or '|' (e.g. "@smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks")
         required: false
         type: string
       team:
@@ -432,14 +432,7 @@ jobs:
 
       - name: Prepare test filter
         id: test-filter
-        shell: bash
-        env:
-          TEST_FILTER_INPUT: ${{ inputs.test_filter }}
-          SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
-          TEAM_INPUT: ${{ inputs.team || 'all' }}
         run: |
-          # Heredoc-delimited output: a team selection is a "|"-joined spec list (~1 KB), which the
-          # previous `echo key=$VALUE` form could not carry safely.
           node e2e/tooling/filter/resolve.mjs \
             --input "$TEST_FILTER_INPUT" \
             --smoke-tests "$SMOKE_TESTS_INPUT" \
@@ -447,18 +440,22 @@ jobs:
             --check-dir "e2e/mobile/specs" \
             --runner detox \
             --github-output >> "$GITHUB_OUTPUT"
-
-      - name: Write resolved filter to GitHub Summary
         shell: bash
         env:
-          FILTER_PATTERN: ${{ steps.test-filter.outputs.filter }}
+          TEST_FILTER_INPUT: ${{ inputs.test_filter }}
+          SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
           TEAM_INPUT: ${{ inputs.team || 'all' }}
+
+      - name: Write resolved filter to GitHub Summary
         run: |
-          # Passed via env, not interpolated into the script: test_filter is free-text user input.
           {
             echo "- **Team:** ${TEAM_INPUT}"
             node e2e/tooling/filter/format-summary.mjs "${FILTER_PATTERN:-}" "- **Resolved filtered pattern:**"
           } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+        env:
+          FILTER_PATTERN: ${{ steps.test-filter.outputs.filter }}
+          TEAM_INPUT: ${{ inputs.team || 'all' }}
 
       - name: Generate shards matrix and test files
         id: generate-shards

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -1,6 +1,7 @@
 name: "[Desktop] - E2E Only - Scheduled/Manual"
 run-name: >
-  @Desktop E2E • triggered on ${{ inputs.ref || github.ref_name }} by ${{ github.actor }}
+  @Desktop E2E •${{ inputs.team && inputs.team != 'all' && format(' team {0} •', inputs.team) || '' }}
+  triggered on ${{ inputs.ref || github.ref_name }} by ${{ github.actor }}
 
 on:
   schedule:
@@ -16,8 +17,14 @@ on:
         description: "Specify branch to checkout and test or leave blank to use the workflow branch"
         required: false
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings")
+        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings". A @team-<slug> token selects that team's specs as one more alternative)
         required: false
+      team:
+        description: "Run only one team's tests. ANDed with test_filter, Smoke and the device."
+        required: false
+        type: choice
+        options: [all, bst, buy-and-sell, coin-integration, earn, engagement, swap, wallet-xp]
+        default: all
       invert_filter:
         description: Ignore test having name pattern (entered in the previous field)
         type: boolean
@@ -84,9 +91,14 @@ on:
         required: false
         type: string
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings")
+        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings". A @team-<slug> token selects that team's specs as one more alternative)
         required: false
         type: string
+      team:
+        description: "Team slug whose specs to run. One of: all, bst, buy-and-sell, coin-integration, earn, engagement, swap, wallet-xp."
+        required: false
+        type: string
+        default: all
       invert_filter:
         description: Ignore test having name pattern (entered in the previous field)
         type: boolean
@@ -262,6 +274,26 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: Build Playwright grep filter from inputs
+        id: test-filter
+        shell: bash
+        env:
+          TEST_FILTER_INPUT: ${{ inputs.test_filter }}
+          SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
+          TEAM_INPUT: ${{ inputs.team || 'all' }}
+          INVERT_FILTER_INPUT: ${{ inputs.invert_filter || false }}
+        run: |
+          # `shell: bash` runs with -eo pipefail, so a non-zero exit from resolve.mjs (unknown team,
+          # empty selection) fails the job HERE — before pnpm install and the LLD build.
+          node e2e/tooling/filter/resolve.mjs \
+            --input "$TEST_FILTER_INPUT" \
+            --smoke-tests "$SMOKE_TESTS_INPUT" \
+            --team "$TEAM_INPUT" \
+            --invert-filter "$INVERT_FILTER_INPUT" \
+            --check-dir "e2e/desktop/tests" \
+            --runner playwright \
+            --github-output >> "$GITHUB_OUTPUT"
+
       - name: Pull Speculos docker image
         run: docker pull ${{ env.SPECULOS_IMAGE_TAG }}
         shell: bash
@@ -293,20 +325,6 @@ jobs:
           enable_broadcast: ${{ env.E2E_BROADCAST_ENABLED }}
           build_type: ${{ inputs.build_type }}
 
-      - name: Build Playwright grep filter from inputs
-        id: test-filter
-        run: |
-          RESOLVED_FILTER="$(node e2e/tooling/filter/resolve.mjs \
-            --input "$TEST_FILTER_INPUT" \
-            --smoke-tests "$SMOKE_TESTS_INPUT" \
-            --check-dir "e2e/desktop/tests" \
-            --runner playwright)"
-          echo "filter=$RESOLVED_FILTER" >> "$GITHUB_OUTPUT"
-        shell: bash
-        env:
-          TEST_FILTER_INPUT: ${{ inputs.test_filter }}
-          SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
-
       - name: Write workflow context to GitHub Summary
         env:
           FILTER_PATTERN: ${{ steps.test-filter.outputs.filter }}
@@ -317,6 +335,7 @@ jobs:
           TRIGGERED_BRANCH: ${{ inputs.ref || github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
           FEATURE_FLAGS: ${{ env.E2E_DESKTOP_FEATURE_FLAGS }}
+          TEAM_INPUT: ${{ inputs.team || 'all' }}
         run: |
           DEVICE="$SPECULOS_DEVICE"
           EXTRA_FEATURE_FLAGS="$E2E_FEATURE_FLAGS_JSON"
@@ -336,6 +355,7 @@ jobs:
             echo "- **Triggered branch:** $TRIGGERED_BRANCH"
             echo "- **Commit SHA:** $COMMIT_SHA"
             echo "- **Device selected:** $DEVICE"
+            echo "- **Team:** $TEAM_INPUT"
             echo "$FILTER_SUMMARY"
             echo "- **Firebase env to target:** $BUILD_TYPE"
             echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
@@ -389,7 +409,7 @@ jobs:
         uses: LedgerHQ/ledger-live/tools/actions/composites/run-e2e-playwright-tests@develop
         with:
           speculos_device: ${{ env.SPECULOS_DEVICE }}
-          test_filter: ${{ steps.test-filter.outputs.filter }}
+          test_filter: ${{ steps.test-filter.outputs.runner_filter }}
           invert_filter: ${{ inputs.invert_filter || false }}
           repeat_each: ${{ inputs.repeat_each }}
           feature_flags: ${{ env.E2E_DESKTOP_FEATURE_FLAGS }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -1,7 +1,6 @@
 name: "[Desktop] - E2E Only - Scheduled/Manual"
 run-name: >
-  @Desktop E2E •${{ inputs.team && inputs.team != 'all' && format(' team {0} •', inputs.team) || '' }}
-  triggered on ${{ inputs.ref || github.ref_name }} by ${{ github.actor }}
+  @Desktop E2E • triggered on ${{ inputs.ref || github.ref_name }} by ${{ github.actor }}
 
 on:
   schedule:
@@ -17,7 +16,7 @@ on:
         description: "Specify branch to checkout and test or leave blank to use the workflow branch"
         required: false
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings". A @team-<slug> token selects that team's specs as one more alternative)
+        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings")
         required: false
       team:
         description: "Run only one team's tests. ANDed with test_filter, Smoke and the device."
@@ -91,7 +90,7 @@ on:
         required: false
         type: string
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings". A @team-<slug> token selects that team's specs as one more alternative)
+        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings")
         required: false
         type: string
       team:
@@ -283,8 +282,6 @@ jobs:
           TEAM_INPUT: ${{ inputs.team || 'all' }}
           INVERT_FILTER_INPUT: ${{ inputs.invert_filter || false }}
         run: |
-          # `shell: bash` runs with -eo pipefail, so a non-zero exit from resolve.mjs (unknown team,
-          # empty selection) fails the job HERE — before pnpm install and the LLD build.
           node e2e/tooling/filter/resolve.mjs \
             --input "$TEST_FILTER_INPUT" \
             --smoke-tests "$SMOKE_TESTS_INPUT" \

--- a/e2e/tooling/filter/README.md
+++ b/e2e/tooling/filter/README.md
@@ -12,6 +12,7 @@ the test runtime (specs, page objects, fixtures) — they run inside GitHub Acti
 | `escaping.mjs`       | Single source of truth for the filter grammar: splits patterns on separators (`\|` / `,`) that are not backslash-escaped and is odd-backslash aware, defines the Playwright leaf anchor `(?! [^@])`, and unescapes regex-literal characters (`unescapeLiteral`) for display.                                                                               |
 | `resolve.mjs`        | Resolves the workflow `test_filter` input into a Playwright/Detox grep string (expands `@generic-coin-framework`, applies `@smoke`, warns on zero matches). The zero-match check mirrors the target runner (`--runner detox\|playwright`): detox reuses `selectSpecs.filterTestFiles` (path + `@`-tag), playwright matches a regex over spec path/content. |
 | `generatedTags.mjs`  | Vocabulary of tags the specs attach at **runtime** (`buildTags`): currency ids + families (from `domain/entity/currency-crypto/src/currencies/*.ts`) and the device tags (from `e2e/desktop/tests/utils/tagsUtils.ts`). Lets the playwright zero-match check downgrade "matched 0 specs" to a notice for a valid-but-unobservable tag, while a real typo still warns. |
+| `teamSpecs.mjs`      | Maps every spec to the team(s) that own it by reading the `Team.<MEMBER>` references the specs already carry (`teamOwner` on desktop, `setTeamOwner()` on mobile). **Additive**: ownership is per-*test*, so a spec's own references are unioned with those of the runner/registrar it imports — `newSendFlow.tx.spec.ts` declares `Team.BST` on some entries while the registrar gives the rest `?? Team.COIN_INTEGRATION`, so it genuinely has both owners. Over-selecting a shared spec is safe; dropping one loses coverage silently. Expands a team into anchored spec basenames (playwright) or repo-relative path needles (detox). Owns `TEAM_SLUGS`, duplicated from `libs/live-e2e-shared/src/enum/Team.ts` because the mobile job sparse-checks-out `e2e/tooling/filter` but not `libs/`; `teamSpecs.test.mjs` asserts they stay in sync. |
 | `selectSpecs.mjs`    | Selects which Detox spec files a mobile E2E run executes for a filter — matches a spec by its path or a declared `@` tag (never raw file text). Consumed by `e2e/mobile/scripts/shard-tests.mjs`.                                                                                                                                                          |
 | `format-summary.mjs` | Renders a resolved filter as a readable Markdown bullet list for the "Workflow Context" job summary.                                                                                                                                                                                                                                                       |
 
@@ -28,6 +29,24 @@ knowable ahead of the run:
   statically verifiable") instead of a misleading `::warning`. A tag that is *not* in the
   vocabulary (a typo such as `@cardanoo`) still warns.
 
+## Two outputs
+
+`resolve.mjs --github-output` emits **two** keys, and the distinction matters:
+
+- **`filter`** — the resolved *pattern* string. Unchanged in meaning, and on mobile it is also
+  the `INPUTS_TEST_FILTER` contract that several specs read as `.includes("@smoke")`.
+- **`runner_filter`** — what the runner actually selects with: the zero-width conjunct grep
+  string on desktop, the intersected spec list on detox.
+
+With no team selected the two are **byte-identical**, which is what keeps every existing
+dispatch, scheduled run and external caller behaving exactly as before. `teamSpecs.test.mjs`
+asserts it.
+
+The desktop conjunct relies on the composite's own wrapper
+(`"$device.*(RESOLVED)|(RESOLVED).*$device"`): a zero-width `RESOLVED` matches at position 0,
+so the second alternative evaluates every lookahead against the whole grep title and then
+requires the device tag — a true AND, with no change to the composite.
+
 ## Usage
 
 ```bash
@@ -35,8 +54,17 @@ knowable ahead of the run:
 node e2e/tooling/filter/resolve.mjs --input "@bitcoin,@family-evm" --smoke-tests false --check-dir e2e/desktop/tests --runner playwright
 node e2e/tooling/filter/resolve.mjs --input "@bitcoin,@family-evm" --smoke-tests false --check-dir e2e/mobile/specs --runner detox
 
+# Resolve with a team (AND), emitting both keys for $GITHUB_OUTPUT
+node e2e/tooling/filter/resolve.mjs --input "@bitcoin" --team bst --check-dir e2e/mobile/specs --runner detox --github-output
+
+# List the teams and how many specs each owns
+node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/desktop/tests --runner playwright
+
 # Format a resolved filter for the job summary
 node e2e/tooling/filter/format-summary.mjs "$RESOLVED_FILTER"
+
+# Run the tooling's own tests (no pnpm install needed)
+node --test "e2e/tooling/filter/*.test.mjs"
 ```
 
 ## Keep in sync

--- a/e2e/tooling/filter/README.md
+++ b/e2e/tooling/filter/README.md
@@ -12,7 +12,7 @@ the test runtime (specs, page objects, fixtures) — they run inside GitHub Acti
 | `escaping.mjs`       | Single source of truth for the filter grammar: splits patterns on separators (`\|` / `,`) that are not backslash-escaped and is odd-backslash aware, defines the Playwright leaf anchor `(?! [^@])`, and unescapes regex-literal characters (`unescapeLiteral`) for display.                                                                               |
 | `resolve.mjs`        | Resolves the workflow `test_filter` input into a Playwright/Detox grep string (expands `@generic-coin-framework`, applies `@smoke`, warns on zero matches). The zero-match check mirrors the target runner (`--runner detox\|playwright`): detox reuses `selectSpecs.filterTestFiles` (path + `@`-tag), playwright matches a regex over spec path/content. |
 | `generatedTags.mjs`  | Vocabulary of tags the specs attach at **runtime** (`buildTags`): currency ids + families (from `domain/entity/currency-crypto/src/currencies/*.ts`) and the device tags (from `e2e/desktop/tests/utils/tagsUtils.ts`). Lets the playwright zero-match check downgrade "matched 0 specs" to a notice for a valid-but-unobservable tag, while a real typo still warns. |
-| `teamSpecs.mjs`      | Maps every spec to the team(s) that own it by reading the `Team.<MEMBER>` references the specs already carry (`teamOwner` on desktop, `setTeamOwner()` on mobile). **Additive**: ownership is per-*test*, so a spec's own references are unioned with those of the runner/registrar it imports — `newSendFlow.tx.spec.ts` declares `Team.BST` on some entries while the registrar gives the rest `?? Team.COIN_INTEGRATION`, so it genuinely has both owners. Over-selecting a shared spec is safe; dropping one loses coverage silently. Expands a team into anchored spec basenames (playwright) or repo-relative path needles (detox). Owns `TEAM_SLUGS`, duplicated from `libs/live-e2e-shared/src/enum/Team.ts` because the mobile job sparse-checks-out `e2e/tooling/filter` but not `libs/`; `teamSpecs.test.mjs` asserts they stay in sync. |
+| `teamSpecs.mjs`      | Maps every spec to the team(s) that own it by reading the `Team.<MEMBER>` references the specs already carry (`teamOwner` on desktop, `setTeamOwner()` on mobile). **Additive**: ownership is per-*test*, so a spec's own references are unioned with those of the runner/registrar it imports — `newSendFlow.tx.spec.ts` declares `Team.BST` on some entries while the registrar gives the rest `?? Team.COIN_INTEGRATION`, so it genuinely has both owners. Over-selecting a shared spec is safe; dropping one loses coverage silently. Expands a team into anchored spec basenames (playwright) or repo-relative path needles (detox). Owns `TEAM_SLUGS`, duplicated from `libs/live-e2e-shared/src/enum/Team.ts` because the mobile job sparse-checks-out `e2e/tooling/filter` but not `libs/`. |
 | `selectSpecs.mjs`    | Selects which Detox spec files a mobile E2E run executes for a filter — matches a spec by its path or a declared `@` tag (never raw file text). Consumed by `e2e/mobile/scripts/shard-tests.mjs`.                                                                                                                                                          |
 | `format-summary.mjs` | Renders a resolved filter as a readable Markdown bullet list for the "Workflow Context" job summary.                                                                                                                                                                                                                                                       |
 
@@ -39,8 +39,7 @@ knowable ahead of the run:
   string on desktop, the intersected spec list on detox.
 
 With no team selected the two are **byte-identical**, which is what keeps every existing
-dispatch, scheduled run and external caller behaving exactly as before. `teamSpecs.test.mjs`
-asserts it.
+dispatch, scheduled run and external caller behaving exactly as before.
 
 The desktop conjunct relies on the composite's own wrapper
 (`"$device.*(RESOLVED)|(RESOLVED).*$device"`): a zero-width `RESOLVED` matches at position 0,
@@ -62,9 +61,6 @@ node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/desktop/tests -
 
 # Format a resolved filter for the job summary
 node e2e/tooling/filter/format-summary.mjs "$RESOLVED_FILTER"
-
-# Run the tooling's own tests (no pnpm install needed)
-node --test "e2e/tooling/filter/*.test.mjs"
 ```
 
 ## Keep in sync

--- a/e2e/tooling/filter/escaping.mjs
+++ b/e2e/tooling/filter/escaping.mjs
@@ -31,7 +31,3 @@ export function unescapeLiteral(pattern) {
 export function escapeLiteral(text) {
   return String(text).replace(REGEX_LITERAL, "\\$&");
 }
-
-export function stripSpecAnchor(pattern) {
-  return pattern.replaceAll(SPEC_ANCHOR, "");
-}

--- a/e2e/tooling/filter/escaping.mjs
+++ b/e2e/tooling/filter/escaping.mjs
@@ -1,6 +1,16 @@
 export const LEAF_ANCHOR = "(?! [^@])";
 
+// Anchors a spec-file pattern to a segment boundary so `delegate.spec.ts` cannot match inside
+// `undelegate.spec.ts`. Playwright compiles --grep with `new RegExp(pattern, "gi")` in Node,
+// which supports lookbehind.
+export const SPEC_ANCHOR = "(?<![\\w.-])";
+
 const REGEX_LITERAL_ESCAPE = /\\([\^$.*+?()[\]{}|,/\\-])/g;
+// Exact forward mirror of REGEX_LITERAL_ESCAPE — the two must stay inverses so an escaped pattern
+// renders unescaped in the job summary, and so the `esc` in
+// tools/actions/composites/get-failed-tests-summary/action.yml keeps ONE counterpart to mirror
+// (see "Keep in sync" in ./README.md).
+const REGEX_LITERAL = /[\^$.*+?()[\]{}|,/\\-]/g;
 
 export function splitFilter(input) {
   return (String(input).match(/(?:\\.|[^|,])+/g) ?? []).map(part => part.trim()).filter(Boolean);
@@ -16,4 +26,12 @@ export function stripLeafAnchor(pattern) {
 
 export function unescapeLiteral(pattern) {
   return pattern.replace(REGEX_LITERAL_ESCAPE, "$1");
+}
+
+export function escapeLiteral(text) {
+  return String(text).replace(REGEX_LITERAL, "\\$&");
+}
+
+export function stripSpecAnchor(pattern) {
+  return pattern.replaceAll(SPEC_ANCHOR, "");
 }

--- a/e2e/tooling/filter/format-summary.mjs
+++ b/e2e/tooling/filter/format-summary.mjs
@@ -3,15 +3,19 @@
 
 import { fileURLToPath } from "node:url";
 
-import { splitFilter, stripLeafAnchor, unescapeLiteral } from "./escaping.mjs";
+import { splitFilter, stripLeafAnchor, stripSpecAnchor, unescapeLiteral } from "./escaping.mjs";
 
-const LABEL = "- **Filtered pattern:**";
+const DEFAULT_LABEL = "- **Filtered pattern:**";
+// A team expansion is up to 21 mobile needles or 13 desktop basenames. Listing them all buries
+// the rest of the "Workflow Context" block QA are told to read.
+const MAX_BULLETS = 10;
 
 function humanizePattern(pattern) {
-  return unescapeLiteral(stripLeafAnchor(pattern)).trim();
+  return unescapeLiteral(stripSpecAnchor(stripLeafAnchor(pattern))).trim();
 }
 
-export function formatFilterSummary(rawInput = "") {
+export function formatFilterSummary(rawInput = "", label = DEFAULT_LABEL) {
+  const LABEL = label || DEFAULT_LABEL;
   const input = String(rawInput).trim();
   if (!input || input === "(none)") {
     return `${LABEL} (none)`;
@@ -27,13 +31,16 @@ export function formatFilterSummary(rawInput = "") {
   }
 
   const lines = [`${LABEL} (${patterns.length} patterns)`];
-  for (const pattern of patterns) {
+  for (const pattern of patterns.slice(0, MAX_BULLETS)) {
     lines.push(`  - ${pattern}`);
+  }
+  if (patterns.length > MAX_BULLETS) {
+    lines.push(`  - …and ${patterns.length - MAX_BULLETS} more`);
   }
   return lines.join("\n");
 }
 
 const currentFile = fileURLToPath(import.meta.url);
 if (process.argv[1] === currentFile) {
-  console.log(formatFilterSummary(process.argv[2] ?? ""));
+  console.log(formatFilterSummary(process.argv[2] ?? "", process.argv[3]));
 }

--- a/e2e/tooling/filter/format-summary.mjs
+++ b/e2e/tooling/filter/format-summary.mjs
@@ -3,15 +3,13 @@
 
 import { fileURLToPath } from "node:url";
 
-import { splitFilter, stripLeafAnchor, stripSpecAnchor, unescapeLiteral } from "./escaping.mjs";
+import { splitFilter, stripLeafAnchor, unescapeLiteral } from "./escaping.mjs";
 
+// The two E2E workflows render different things with this, so the caller names the bullet.
 const DEFAULT_LABEL = "- **Filtered pattern:**";
-// A team expansion is up to 21 mobile needles or 13 desktop basenames. Listing them all buries
-// the rest of the "Workflow Context" block QA are told to read.
-const MAX_BULLETS = 10;
 
 function humanizePattern(pattern) {
-  return unescapeLiteral(stripSpecAnchor(stripLeafAnchor(pattern))).trim();
+  return unescapeLiteral(stripLeafAnchor(pattern)).trim();
 }
 
 export function formatFilterSummary(rawInput = "", label = DEFAULT_LABEL) {
@@ -31,11 +29,8 @@ export function formatFilterSummary(rawInput = "", label = DEFAULT_LABEL) {
   }
 
   const lines = [`${LABEL} (${patterns.length} patterns)`];
-  for (const pattern of patterns.slice(0, MAX_BULLETS)) {
+  for (const pattern of patterns) {
     lines.push(`  - ${pattern}`);
-  }
-  if (patterns.length > MAX_BULLETS) {
-    lines.push(`  - …and ${patterns.length - MAX_BULLETS} more`);
   }
   return lines.join("\n");
 }

--- a/e2e/tooling/filter/resolve.mjs
+++ b/e2e/tooling/filter/resolve.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 import { joinFilter, splitFilter } from "./escaping.mjs";
 import { isRuntimeGeneratedTag } from "./generatedTags.mjs";
 import { findTestFiles as findSpecFiles, filterTestFiles } from "./selectSpecs.mjs";
-import { TEAM_SLUGS, createTeamExpander, parseTeamAlias } from "./teamSpecs.mjs";
+import { TEAM_SLUGS, createTeamExpander } from "./teamSpecs.mjs";
 
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
@@ -46,10 +46,8 @@ function conjunction(groups) {
 }
 
 export function resolveBaseFilter(input, options = {}) {
-  const {
-    enabledGenericCoinFrameworkFamilies = readEnabledGenericCoinFrameworkFamilies(),
-    teamExpander = null,
-  } = options;
+  const { enabledGenericCoinFrameworkFamilies = readEnabledGenericCoinFrameworkFamilies() } =
+    options;
 
   const parts = splitFilter(input);
   const genericCoinFrameworkTags = enabledGenericCoinFrameworkFamilies.map(
@@ -57,31 +55,11 @@ export function resolveBaseFilter(input, options = {}) {
   );
   let expandedGenericCoinFramework = false;
   const resolvedParts = [];
-  const teams = []; // { slug, specCount } — expanded OK
-  const emptyTeams = []; // valid slug, owns nothing on this runner
-  const unknownTeams = []; // typo
 
   for (const part of parts) {
     if (GENERIC_COIN_FRAMEWORK_ALIASES.has(part)) {
       expandedGenericCoinFramework = true;
       resolvedParts.push(...genericCoinFrameworkTags);
-      continue;
-    }
-
-    const slug = parseTeamAlias(part);
-    if (slug) {
-      if (!TEAM_SLUGS.includes(slug)) {
-        unknownTeams.push(part);
-        continue;
-      }
-      const patterns = teamExpander?.expand(slug) ?? [];
-      if (patterns.length === 0) {
-        emptyTeams.push(slug);
-        continue;
-      }
-      teams.push({ slug, specCount: teamExpander.specCount(slug) });
-      // OR: an alias inside test_filter is one more alternative, like every other token.
-      resolvedParts.push(...patterns);
       continue;
     }
 
@@ -91,16 +69,18 @@ export function resolveBaseFilter(input, options = {}) {
   return {
     filter: joinFilter(resolvedParts),
     expandedTags: expandedGenericCoinFramework ? genericCoinFrameworkTags : [],
-    teams,
-    emptyTeams,
-    unknownTeams,
   };
 }
 
-// Space-as-OR is the composite's documented behaviour; normalising here keeps it true once we
-// introduce a "|" of our own. Detox is unaffected either way (filterTestFiles splits on /[\s,|]+/).
+// Mirrors run-e2e-playwright-tests/action.yml exactly: it rewrites spaces to "|" ONLY when the
+// filter has a space and carries no "|" of its own. We pre-apply that here so the meaning survives
+// once WE add a "|" (the "@smoke|" prefix, or a team conjunct) — which would otherwise suppress the
+// composite's rewrite and silently turn a space-separated filter into a literal phrase.
+// Detox is unaffected either way (filterTestFiles splits on /[\s,|]+/).
 export function normalizeAlternatives(filter) {
-  return String(filter).split(/\s+/).filter(Boolean).join("|");
+  const text = String(filter);
+  if (!/ /.test(text) || text.includes("|")) return text;
+  return text.split(/\s+/).filter(Boolean).join("|");
 }
 
 export function applySmokeFilter(filter, smokeTests) {
@@ -192,8 +172,7 @@ function warnZeroMatches(checkDir, files, baseFilter, expandedTags, runner) {
 //                   INPUTS_TEST_FILTER contract that several specs read as `.includes("@smoke")`.
 //   runner_filter — what the runner actually selects with: the conjunct grep string on desktop,
 //                   the intersected spec list on mobile.
-// With no team selected the two are byte-identical, which is the acceptance criterion that keeps
-// every existing dispatch, scheduled run and external caller behaving exactly as before.
+// With no team selected the two are byte-identical.
 export function resolveE2eSelection({
   input = "",
   smokeTests = false,
@@ -205,26 +184,31 @@ export function resolveE2eSelection({
   const isDetox = runner === "detox";
   const specRoot = checkDir ? path.resolve(repoRoot, checkDir) : "";
   const specFiles = specRoot ? findSpecFiles(specRoot) : []; // scanned ONCE, reused below
-  const expander = specFiles.length
-    ? createTeamExpander({ files: specFiles, specRoot, runner })
-    : null;
 
   const selectedTeam = String(team ?? "")
     .trim()
     .toLowerCase();
   const hasTeam = Boolean(selectedTeam) && selectedTeam !== "all";
 
-  const {
-    filter: rawBaseFilter,
-    expandedTags,
-    teams,
-    emptyTeams,
-    unknownTeams,
-  } = resolveBaseFilter(input, { teamExpander: expander });
+  const { filter: rawBaseFilter, expandedTags } = resolveBaseFilter(input);
   const baseFilter = isDetox ? rawBaseFilter : normalizeAlternatives(rawBaseFilter);
 
   let ok = true;
   const notes = [];
+
+  // Filtering by team is the dropdown's job, and only the dropdown ANDs. A `@team-…` pattern would
+  // otherwise be treated as an ordinary literal, match nothing, and (on mobile) skip every test job
+  // while the run stayed green.
+  const teamTokens = splitFilter(input)
+    .flatMap(part => part.split(/\s+/))
+    .filter(Boolean)
+    .filter(token => /^@?team-/i.test(token));
+  if (teamTokens.length > 0) {
+    console.warn(
+      `::error title=Use the team dropdown::${teamTokens.join(", ")} is not a test_filter pattern; pick the team in the "team" dropdown instead (one of: ${TEAM_SLUGS.join(", ")})`,
+    );
+    ok = false;
+  }
 
   if (hasTeam && invertFilter) {
     // The composite applies --grep-invert to the whole pattern, team conjunct included, so this
@@ -237,22 +221,6 @@ export function resolveE2eSelection({
   if (hasTeam && !TEAM_SLUGS.includes(selectedTeam)) {
     console.warn(
       `::error title=Unknown E2E team::"${team}" is not a team. Pick one of: all, ${TEAM_SLUGS.join(", ")}`,
-    );
-    ok = false;
-  }
-  for (const entry of teams) {
-    console.warn(
-      `::notice title=E2E team filter::@team-${entry.slug} -> ${entry.specCount} spec(s) in ${checkDir}`,
-    );
-  }
-  for (const slug of emptyTeams) {
-    console.warn(
-      `::warning title=E2E team owns no specs::@team-${slug} owns no spec in ${checkDir}; it contributes nothing to this run`,
-    );
-  }
-  if (unknownTeams.length > 0) {
-    console.warn(
-      `::error title=Unknown E2E team::${unknownTeams.join(", ")} — known teams: ${TEAM_SLUGS.map(slug => `@team-${slug}`).join(", ")}`,
     );
     ok = false;
   }
@@ -269,6 +237,9 @@ export function resolveE2eSelection({
   const filter = applySmokeFilter(baseFilter, smokeTests);
   if (!ok || !hasTeam) return { filter, runner_filter: filter, ok, notes };
 
+  const expander = specFiles.length
+    ? createTeamExpander({ files: specFiles, specRoot, runner })
+    : null;
   const teamPatterns = expander?.expand(selectedTeam) ?? [];
   if (teamPatterns.length === 0) {
     // Unconditional: a team that owns nothing intersected with ANY filter is still nothing. Falling
@@ -305,6 +276,9 @@ export function resolveE2eSelection({
         `::warning title=E2E team filter may select nothing::no ${selectedTeam} spec mentions "${conjunct}"; the run may select 0 tests`,
       );
     }
+    console.warn(
+      `::notice title=E2E team filter::team=${selectedTeam} -> ${expander.specCount(selectedTeam)} spec file(s) in ${checkDir}`,
+    );
     notes.push(`team ${selectedTeam} (${expander.specCount(selectedTeam)} spec files)`);
     return { filter, runner_filter: runnerFilter, ok, notes };
   }
@@ -333,6 +307,9 @@ export function resolveE2eSelection({
     );
     return { filter, runner_filter: filter, ok: false, notes };
   }
+  console.warn(
+    `::notice title=E2E team filter::team=${selectedTeam} -> ${selected.length} spec(s) selected in ${checkDir}`,
+  );
   notes.push(
     `team ${selectedTeam} (${expander.specCount(selectedTeam)} spec files) -> ${selected.length} selected`,
   );
@@ -392,8 +369,6 @@ function parseArgs(args) {
   return parsed;
 }
 
-// Heredoc-delimited, because a resolved value can now carry "|"-joined paths (~1 KB) and must
-// never be able to forge a second key in $GITHUB_OUTPUT.
 function formatGithubOutput(values) {
   const lines = [];
   for (const [key, value] of Object.entries(values)) {
@@ -407,14 +382,27 @@ if (process.argv[1] === currentFile) {
   const options = parseArgs(process.argv.slice(2));
 
   if (options.listTeams) {
+    if (!options.checkDir) {
+      console.error(
+        "--list-teams requires --check-dir, e.g.\n" +
+          "  node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/desktop/tests --runner playwright\n" +
+          "  node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/mobile/specs  --runner detox",
+      );
+      process.exit(1);
+    }
     const specRoot = path.resolve(repoRoot, options.checkDir);
-    const expander = createTeamExpander({
-      files: findSpecFiles(specRoot),
-      specRoot,
-      runner: options.runner,
-    });
+    const files = findSpecFiles(specRoot);
+    if (files.length === 0) {
+      // Distinguish a typo from a real but empty tree: both are useless to report counts for.
+      console.error(
+        `No .spec.ts files under ${options.checkDir} (resolved to ${specRoot}) — check the path.`,
+      );
+      process.exit(1);
+    }
+    const expander = createTeamExpander({ files, specRoot, runner: options.runner });
+    console.log(`# ${files.length} spec file(s) in ${options.checkDir}`);
     for (const slug of TEAM_SLUGS) {
-      console.log(`@team-${slug}\t${expander.specCount(slug)} spec file(s)`);
+      console.log(`${slug}\t${expander.specCount(slug)} spec file(s)`);
     }
   } else {
     const { filter, runner_filter: runnerFilter, ok } = resolveE2eSelection(options);

--- a/e2e/tooling/filter/resolve.mjs
+++ b/e2e/tooling/filter/resolve.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { joinFilter, splitFilter } from "./escaping.mjs";
 import { isRuntimeGeneratedTag } from "./generatedTags.mjs";
 import { findTestFiles as findSpecFiles, filterTestFiles } from "./selectSpecs.mjs";
+import { TEAM_SLUGS, createTeamExpander, parseTeamAlias } from "./teamSpecs.mjs";
 
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
@@ -31,35 +33,84 @@ function readEnabledGenericCoinFrameworkFamilies() {
     .map(([family]) => family);
 }
 
-export function resolveBaseFilter(
-  input,
-  enabledGenericCoinFrameworkFamilies = readEnabledGenericCoinFrameworkFamilies(),
-) {
+// A zero-width lookahead group. The desktop composite wraps whatever we emit as
+//   "$device_tag.*(RESOLVED)|(RESOLVED).*$device_tag"
+// and a zero-width RESOLVED matches at position 0 of the grep title, so the second alternative
+// evaluates every lookahead against the WHOLE title and then requires the device tag after it:
+// the result is a true AND of every conjunct with the device.
+function conjunction(groups) {
+  return groups
+    .filter(Boolean)
+    .map(group => `(?=.*(${group}))`)
+    .join("");
+}
+
+export function resolveBaseFilter(input, options = {}) {
+  const {
+    enabledGenericCoinFrameworkFamilies = readEnabledGenericCoinFrameworkFamilies(),
+    teamExpander = null,
+  } = options;
+
   const parts = splitFilter(input);
   const genericCoinFrameworkTags = enabledGenericCoinFrameworkFamilies.map(
     family => `@family-${family}`,
   );
   let expandedGenericCoinFramework = false;
   const resolvedParts = [];
+  const teams = []; // { slug, specCount } — expanded OK
+  const emptyTeams = []; // valid slug, owns nothing on this runner
+  const unknownTeams = []; // typo
 
   for (const part of parts) {
     if (GENERIC_COIN_FRAMEWORK_ALIASES.has(part)) {
       expandedGenericCoinFramework = true;
       resolvedParts.push(...genericCoinFrameworkTags);
-    } else {
-      resolvedParts.push(part);
+      continue;
     }
+
+    const slug = parseTeamAlias(part);
+    if (slug) {
+      if (!TEAM_SLUGS.includes(slug)) {
+        unknownTeams.push(part);
+        continue;
+      }
+      const patterns = teamExpander?.expand(slug) ?? [];
+      if (patterns.length === 0) {
+        emptyTeams.push(slug);
+        continue;
+      }
+      teams.push({ slug, specCount: teamExpander.specCount(slug) });
+      // OR: an alias inside test_filter is one more alternative, like every other token.
+      resolvedParts.push(...patterns);
+      continue;
+    }
+
+    resolvedParts.push(part);
   }
 
   return {
     filter: joinFilter(resolvedParts),
     expandedTags: expandedGenericCoinFramework ? genericCoinFrameworkTags : [],
+    teams,
+    emptyTeams,
+    unknownTeams,
   };
+}
+
+// Space-as-OR is the composite's documented behaviour; normalising here keeps it true once we
+// introduce a "|" of our own. Detox is unaffected either way (filterTestFiles splits on /[\s,|]+/).
+export function normalizeAlternatives(filter) {
+  return String(filter).split(/\s+/).filter(Boolean).join("|");
 }
 
 export function applySmokeFilter(filter, smokeTests) {
   if (!smokeTests) return filter;
-  return filter ? `@smoke ${filter}` : "@smoke";
+  // "|" not " ": the desktop composite only rewrites spaces to "|" when the filter carries no "|"
+  // of its own (run-e2e-playwright-tests/action.yml), so a space-joined prefix turned "@smoke"
+  // into a dead alternative for every multi-pattern filter. Mobile is unaffected
+  // (filterTestFiles splits on /[\s,|]+/ either way) and the INPUTS_TEST_FILTER
+  // `.includes("@smoke")` contract still holds.
+  return filter ? `@smoke|${filter}` : "@smoke";
 }
 
 function hasMatch(files, pattern) {
@@ -77,10 +128,9 @@ function hasMatch(files, pattern) {
   });
 }
 
-function warnZeroMatches(checkDir, baseFilter, expandedTags, runner) {
+function warnZeroMatches(checkDir, files, baseFilter, expandedTags, runner) {
   if (!checkDir) return;
 
-  const testDir = path.resolve(repoRoot, checkDir);
   // Decide "0 matches" the same way the target runner actually selects tests, so the warning
   // can't disagree with what runs:
   // - detox (mobile) selects whole spec files by path + declared @-tags (selectSpecs.filterTestFiles).
@@ -88,7 +138,6 @@ function warnZeroMatches(checkDir, baseFilter, expandedTags, runner) {
   // - playwright (desktop) selects by test title via --grep, approximated by a regex over the
   //   spec path and content.
   const isDetox = runner === "detox";
-  const files = findSpecFiles(testDir);
 
   if (files.length === 0) {
     console.warn(`::warning title=E2E filter check skipped::No test files found in ${checkDir}`);
@@ -138,12 +187,173 @@ function warnZeroMatches(checkDir, baseFilter, expandedTags, runner) {
   }
 }
 
+// Resolves the workflow inputs into the two values the jobs need:
+//   filter        — the resolved PATTERN string, unchanged in meaning. On mobile it is also the
+//                   INPUTS_TEST_FILTER contract that several specs read as `.includes("@smoke")`.
+//   runner_filter — what the runner actually selects with: the conjunct grep string on desktop,
+//                   the intersected spec list on mobile.
+// With no team selected the two are byte-identical, which is the acceptance criterion that keeps
+// every existing dispatch, scheduled run and external caller behaving exactly as before.
+export function resolveE2eSelection({
+  input = "",
+  smokeTests = false,
+  checkDir = "",
+  runner = "playwright",
+  team = "",
+  invertFilter = false,
+} = {}) {
+  const isDetox = runner === "detox";
+  const specRoot = checkDir ? path.resolve(repoRoot, checkDir) : "";
+  const specFiles = specRoot ? findSpecFiles(specRoot) : []; // scanned ONCE, reused below
+  const expander = specFiles.length
+    ? createTeamExpander({ files: specFiles, specRoot, runner })
+    : null;
+
+  const selectedTeam = String(team ?? "")
+    .trim()
+    .toLowerCase();
+  const hasTeam = Boolean(selectedTeam) && selectedTeam !== "all";
+
+  const {
+    filter: rawBaseFilter,
+    expandedTags,
+    teams,
+    emptyTeams,
+    unknownTeams,
+  } = resolveBaseFilter(input, { teamExpander: expander });
+  const baseFilter = isDetox ? rawBaseFilter : normalizeAlternatives(rawBaseFilter);
+
+  let ok = true;
+  const notes = [];
+
+  if (hasTeam && invertFilter) {
+    // The composite applies --grep-invert to the whole pattern, team conjunct included, so this
+    // would run every OTHER team's specs — the exact opposite of what the dropdown promises.
+    console.warn(
+      `::error title=E2E team filter cannot be inverted::team=${selectedTeam} with invert_filter=true would run every other team's specs; drop one of the two`,
+    );
+    ok = false;
+  }
+  if (hasTeam && !TEAM_SLUGS.includes(selectedTeam)) {
+    console.warn(
+      `::error title=Unknown E2E team::"${team}" is not a team. Pick one of: all, ${TEAM_SLUGS.join(", ")}`,
+    );
+    ok = false;
+  }
+  for (const entry of teams) {
+    console.warn(
+      `::notice title=E2E team filter::@team-${entry.slug} -> ${entry.specCount} spec(s) in ${checkDir}`,
+    );
+  }
+  for (const slug of emptyTeams) {
+    console.warn(
+      `::warning title=E2E team owns no specs::@team-${slug} owns no spec in ${checkDir}; it contributes nothing to this run`,
+    );
+  }
+  if (unknownTeams.length > 0) {
+    console.warn(
+      `::error title=Unknown E2E team::${unknownTeams.join(", ")} — known teams: ${TEAM_SLUGS.map(slug => `@team-${slug}`).join(", ")}`,
+    );
+    ok = false;
+  }
+  // Never let a deliberately narrow request silently widen into the whole suite.
+  if (String(input).trim() && !baseFilter && !hasTeam) {
+    console.warn(
+      `::error title=E2E filter resolved to nothing::"${input}" expanded to an empty filter; refusing to run the whole suite`,
+    );
+    ok = false;
+  }
+
+  warnZeroMatches(checkDir, specFiles, baseFilter, expandedTags, runner);
+
+  const filter = applySmokeFilter(baseFilter, smokeTests);
+  if (!ok || !hasTeam) return { filter, runner_filter: filter, ok, notes };
+
+  const teamPatterns = expander?.expand(selectedTeam) ?? [];
+  if (teamPatterns.length === 0) {
+    // Unconditional: a team that owns nothing intersected with ANY filter is still nothing. Falling
+    // through with the bare filter would drop the team constraint and run every other team's specs
+    // green, while the run-name and job summary still claimed the team.
+    console.warn(
+      `::warning title=E2E team owns no specs::team "${selectedTeam}" owns no spec in ${checkDir}`,
+    );
+    console.warn(
+      `::error title=E2E selection is empty::team=${selectedTeam} selects 0 specs in ${checkDir}; refusing to run the unnarrowed filter`,
+    );
+    return { filter, runner_filter: filter, ok: false, notes };
+  }
+
+  if (!isDetox) {
+    // team AND (test_filter alternatives) AND (@smoke) AND device (added by the composite).
+    const runnerFilter = conjunction([
+      teamPatterns.join("|"),
+      smokeTests ? "@smoke" : "",
+      baseFilter,
+    ]);
+    // Desktop cannot compute the true intersection here — that needs Playwright's own collection,
+    // which is not available until after the build. This static approximation over the team's own
+    // spec files still turns the common empty-AND (e.g. team=swap + Smoke, because swap tags its
+    // smoke tests @swapSmoke) into a first-minute warning instead of a 20-minute mystery.
+    const teamFiles = expander.specs(selectedTeam);
+    for (const conjunct of [smokeTests ? "@smoke" : "", baseFilter]) {
+      if (!conjunct) continue;
+      const pattern = conjunct.split(/\s+/).filter(Boolean).join("|");
+      if (hasMatch(teamFiles, pattern)) continue;
+      // A runtime-generated tag is invisible in the source, so its absence proves nothing.
+      if (splitFilter(conjunct).some(tag => isRuntimeGeneratedTag(tag))) continue;
+      console.warn(
+        `::warning title=E2E team filter may select nothing::no ${selectedTeam} spec mentions "${conjunct}"; the run may select 0 tests`,
+      );
+    }
+    notes.push(`team ${selectedTeam} (${expander.specCount(selectedTeam)} spec files)`);
+    return { filter, runner_filter: runnerFilter, ok, notes };
+  }
+
+  // detox: a real set intersection, using the runner's own selector on every side, so the check
+  // and the run cannot disagree (the invariant warnZeroMatches exists to protect).
+  const owned = new Set(expander.specs(selectedTeam));
+  let selected = specFiles.filter(file => owned.has(file));
+  if (baseFilter) selected = filterTestFiles(selected, baseFilter);
+  if (smokeTests) selected = filterTestFiles(selected, "@smoke");
+
+  if (selected.length === 0) {
+    console.warn(
+      `::error title=E2E selection is empty::team=${selectedTeam} combined with "${baseFilter || "(no filter)"}"${smokeTests ? " and @smoke" : ""} selects 0 specs in ${checkDir}`,
+    );
+    return { filter, runner_filter: filter, ok: false, notes };
+  }
+
+  const needles = selected.map(file => path.relative(repoRoot, file).replaceAll(path.sep, "/"));
+  const runnerFilter = needles.join("|");
+  // Assert the emitted needles select EXACTLY what we intended — catches a stale or over-broad
+  // needle before it silently widens or narrows the run.
+  if (filterTestFiles(specFiles, runnerFilter).length !== selected.length) {
+    console.warn(
+      `::error title=E2E selection is not exact::the emitted spec list does not round-trip through the mobile selector`,
+    );
+    return { filter, runner_filter: filter, ok: false, notes };
+  }
+  notes.push(
+    `team ${selectedTeam} (${expander.specCount(selectedTeam)} spec files) -> ${selected.length} selected`,
+  );
+  return { filter, runner_filter: runnerFilter, ok, notes };
+}
+
+// Kept for callers that only want the pattern string (and for the default CLI output).
+export function resolveTestFilter(options = {}) {
+  return resolveE2eSelection(options).filter;
+}
+
 function parseArgs(args) {
   const parsed = {
     input: "",
     smokeTests: false,
     checkDir: "",
     runner: "playwright",
+    team: "",
+    invertFilter: false,
+    githubOutput: false,
+    listTeams: false,
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -161,6 +371,18 @@ function parseArgs(args) {
       case "--runner":
         parsed.runner = args[++i] ?? "playwright";
         break;
+      case "--team":
+        parsed.team = args[++i] ?? "";
+        break;
+      case "--invert-filter":
+        parsed.invertFilter = args[++i] === "true";
+        break;
+      case "--github-output":
+        parsed.githubOutput = true;
+        break;
+      case "--list-teams":
+        parsed.listTeams = true;
+        break;
       default:
         if (!parsed.input) parsed.input = arg;
         break;
@@ -170,18 +392,36 @@ function parseArgs(args) {
   return parsed;
 }
 
-export function resolveTestFilter({
-  input = "",
-  smokeTests = false,
-  checkDir = "",
-  runner = "playwright",
-} = {}) {
-  const { filter: baseFilter, expandedTags } = resolveBaseFilter(input);
-  warnZeroMatches(checkDir, baseFilter, expandedTags, runner);
-  return applySmokeFilter(baseFilter, smokeTests);
+// Heredoc-delimited, because a resolved value can now carry "|"-joined paths (~1 KB) and must
+// never be able to forge a second key in $GITHUB_OUTPUT.
+function formatGithubOutput(values) {
+  const lines = [];
+  for (const [key, value] of Object.entries(values)) {
+    const delimiter = `__E2E_${key.toUpperCase()}_${randomUUID()}__`;
+    lines.push(`${key}<<${delimiter}`, String(value), delimiter);
+  }
+  return lines.join("\n");
 }
 
 if (process.argv[1] === currentFile) {
   const options = parseArgs(process.argv.slice(2));
-  console.log(resolveTestFilter(options));
+
+  if (options.listTeams) {
+    const specRoot = path.resolve(repoRoot, options.checkDir);
+    const expander = createTeamExpander({
+      files: findSpecFiles(specRoot),
+      specRoot,
+      runner: options.runner,
+    });
+    for (const slug of TEAM_SLUGS) {
+      console.log(`@team-${slug}\t${expander.specCount(slug)} spec file(s)`);
+    }
+  } else {
+    const { filter, runner_filter: runnerFilter, ok } = resolveE2eSelection(options);
+    // stdout must stay empty on failure so the workflow never captures a half-resolved value.
+    if (!ok) process.exit(1);
+    console.log(
+      options.githubOutput ? formatGithubOutput({ filter, runner_filter: runnerFilter }) : filter,
+    );
+  }
 }

--- a/e2e/tooling/filter/teamSpecs.mjs
+++ b/e2e/tooling/filter/teamSpecs.mjs
@@ -1,10 +1,10 @@
-// Maps every e2e spec file to the team(s) that own it, so a `@team-<slug>` token or the `team`
-// workflow input can be expanded into selectors the runners already understand — no new tag, no
-// spec annotation, no stored registry.
+// Maps every e2e spec file to the team(s) that own it, so the `team` workflow input can be expanded
+// into selectors the runners already understand — no new tag, no spec annotation, no stored
+// registry.
 //
 // Ownership is READ FROM THE SOURCE: desktop specs set the `teamOwner` fixture option and mobile
 // runners call `setTeamOwner()`, both through a `Team.<MEMBER>` reference. Coverage is 100% on
-// both suites, and teamSpecs.test.mjs asserts it stays that way.
+// both suites.
 //
 // CI-only (see ./README.md): never imported by the test runtime.
 import fs from "node:fs";
@@ -18,7 +18,7 @@ const repoRoot = path.resolve(currentDir, "../../..");
 
 // Closed vocabulary, mirroring libs/live-e2e-shared/src/enum/Team.ts. Duplicated here on purpose:
 // the mobile determine-builds job sparse-checks-out e2e/tooling/filter but NOT libs/, so this file
-// must not reach outside the checked-out tree. teamSpecs.test.mjs asserts the two lists match.
+// must not reach outside the checked-out tree.
 export const TEAM_SLUGS = Object.freeze([
   "bst",
   "buy-and-sell",
@@ -29,7 +29,6 @@ export const TEAM_SLUGS = Object.freeze([
   "wallet-xp",
 ]);
 
-const TEAM_ALIAS_PATTERN = /^@?team-([a-z0-9-]+)$/;
 const TEAM_REFERENCE = /\bTeam\.([A-Z][A-Z0-9_]*)\b/g;
 const IMPORT_SOURCE = /(?:from|import)\s*["']([^"']+)["']/g;
 
@@ -46,14 +45,21 @@ const TEAM_OWNER_HELPERS = new Map([["delegateTeamOwner", ["BST", "COIN_INTEGRAT
 
 const MAX_IMPORT_DEPTH = 3;
 
-export function parseTeamAlias(part) {
-  return String(part).trim().toLowerCase().match(TEAM_ALIAS_PATTERN)?.[1];
-}
-
 // Team.WALLET_XP -> "wallet-xp". The enum's *values* ("Wallet XP", "BuyAndSell") are Allure
 // display strings: inconsistent, and not safe to drop into a regex. The member name is the slug.
 export function teamSlug(member) {
   return member.toLowerCase().replaceAll("_", "-");
+}
+
+const fileCache = new Map();
+
+function readFileCached(filePath) {
+  let text = fileCache.get(filePath);
+  if (text === undefined) {
+    text = fs.readFileSync(filePath, "utf8");
+    fileCache.set(filePath, text);
+  }
+  return text;
 }
 
 function readTeamsIn(content) {
@@ -93,7 +99,7 @@ function resolveImport(fromFile, source) {
 // fallbacks a shared registrar/runner supplies (which is also how mobile's thin shims get an
 // owner at all). The walk stops at the first depth that contributes something new.
 function teamsForSpec(specPath) {
-  const content = fs.readFileSync(specPath, "utf8");
+  const content = readFileCached(specPath);
   const own = readTeamsIn(content);
   const found = new Set(own);
   const seen = new Set([specPath]);
@@ -107,7 +113,7 @@ function teamsForSpec(specPath) {
         seen.add(target);
         let targetText;
         try {
-          targetText = fs.readFileSync(target, "utf8");
+          targetText = readFileCached(target);
         } catch {
           continue;
         }
@@ -130,12 +136,6 @@ export function buildTeamIndex(files) {
     }
   }
   return new Map([...index].sort(([a], [b]) => a.localeCompare(b)));
-}
-
-// Specs with no discoverable owner. Asserted empty by the unit tests, so a new spec that no team
-// claims turns the PR red instead of silently vanishing from every team run.
-export function findUnownedSpecs(files) {
-  return files.filter(file => teamsForSpec(file).size === 0);
 }
 
 // Detox matches a spec by literal path substring, so a wholly-owned directory stands in for every

--- a/e2e/tooling/filter/teamSpecs.mjs
+++ b/e2e/tooling/filter/teamSpecs.mjs
@@ -1,0 +1,192 @@
+// Maps every e2e spec file to the team(s) that own it, so a `@team-<slug>` token or the `team`
+// workflow input can be expanded into selectors the runners already understand — no new tag, no
+// spec annotation, no stored registry.
+//
+// Ownership is READ FROM THE SOURCE: desktop specs set the `teamOwner` fixture option and mobile
+// runners call `setTeamOwner()`, both through a `Team.<MEMBER>` reference. Coverage is 100% on
+// both suites, and teamSpecs.test.mjs asserts it stays that way.
+//
+// CI-only (see ./README.md): never imported by the test runtime.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SPEC_ANCHOR, escapeLiteral } from "./escaping.mjs";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, "../../..");
+
+// Closed vocabulary, mirroring libs/live-e2e-shared/src/enum/Team.ts. Duplicated here on purpose:
+// the mobile determine-builds job sparse-checks-out e2e/tooling/filter but NOT libs/, so this file
+// must not reach outside the checked-out tree. teamSpecs.test.mjs asserts the two lists match.
+export const TEAM_SLUGS = Object.freeze([
+  "bst",
+  "buy-and-sell",
+  "coin-integration",
+  "earn",
+  "engagement",
+  "swap",
+  "wallet-xp",
+]);
+
+const TEAM_ALIAS_PATTERN = /^@?team-([a-z0-9-]+)$/;
+const TEAM_REFERENCE = /\bTeam\.([A-Z][A-Z0-9_]*)\b/g;
+const IMPORT_SOURCE = /(?:from|import)\s*["']([^"']+)["']/g;
+
+const IMPORT_ALIASES = [
+  ["@e2e/", "e2e/mobile/"],
+  ["tests/", "e2e/desktop/tests/"],
+];
+
+// Helpers that pick the owner at collection time from the currency. A spec that reaches one can
+// belong to any team it returns, so it is attributed to ALL of them: a team filter must
+// over-select a shared spec, never silently drop it.
+// Keep in sync with libs/live-e2e-shared/src/data/delegateTeamOwner.ts.
+const TEAM_OWNER_HELPERS = new Map([["delegateTeamOwner", ["BST", "COIN_INTEGRATION"]]]);
+
+const MAX_IMPORT_DEPTH = 3;
+
+export function parseTeamAlias(part) {
+  return String(part).trim().toLowerCase().match(TEAM_ALIAS_PATTERN)?.[1];
+}
+
+// Team.WALLET_XP -> "wallet-xp". The enum's *values* ("Wallet XP", "BuyAndSell") are Allure
+// display strings: inconsistent, and not safe to drop into a regex. The member name is the slug.
+export function teamSlug(member) {
+  return member.toLowerCase().replaceAll("_", "-");
+}
+
+function readTeamsIn(content) {
+  const teams = new Set();
+  for (const [, member] of content.matchAll(TEAM_REFERENCE)) teams.add(member);
+  for (const [helper, members] of TEAM_OWNER_HELPERS) {
+    if (content.includes(helper)) for (const member of members) teams.add(member);
+  }
+  return teams;
+}
+
+function resolveImport(fromFile, source) {
+  let target;
+  if (source.startsWith(".")) {
+    target = path.resolve(path.dirname(fromFile), source);
+  } else {
+    const alias = IMPORT_ALIASES.find(([prefix]) => source.startsWith(prefix));
+    if (!alias) return undefined;
+    target = path.join(repoRoot, alias[1], source.slice(alias[0].length));
+  }
+  for (const candidate of [`${target}.ts`, path.join(target, "index.ts")]) {
+    // A spec never owns another spec: only shared runners/helpers are followed.
+    if (candidate.endsWith(".spec.ts")) continue;
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+// ADDITIVE, because ownership is per-TEST, not per-file: a spec can legitimately have several
+// owners and the filter must over-select rather than silently drop.
+// e2e/desktop/tests/specs/newSendFlow.tx.spec.ts is the case that proves it — only 11 of its 30
+// entries carry `teamOwner: Team.BST`; the rest get `entry.teamOwner ?? Team.COIN_INTEGRATION`
+// from the registrar (utils/newSendFlowUtils.ts), so Coin-integration really is their runtime
+// owner and what Allure reports. Attributing the file to BST alone would hide those tests from
+// `team=coin-integration` and turn a green run into missing coverage.
+// The spec's own `Team.*` references seed the set; imports are then walked to pick up the
+// fallbacks a shared registrar/runner supplies (which is also how mobile's thin shims get an
+// owner at all). The walk stops at the first depth that contributes something new.
+function teamsForSpec(specPath) {
+  const content = fs.readFileSync(specPath, "utf8");
+  const own = readTeamsIn(content);
+  const found = new Set(own);
+  const seen = new Set([specPath]);
+  let level = [[specPath, content]];
+  for (let depth = 0; depth < MAX_IMPORT_DEPTH && found.size === own.size; depth += 1) {
+    const next = [];
+    for (const [file, text] of level) {
+      for (const [, source] of text.matchAll(IMPORT_SOURCE)) {
+        const target = resolveImport(file, source);
+        if (!target || seen.has(target)) continue;
+        seen.add(target);
+        let targetText;
+        try {
+          targetText = fs.readFileSync(target, "utf8");
+        } catch {
+          continue;
+        }
+        for (const member of readTeamsIn(targetText)) found.add(member);
+        next.push([target, targetText]);
+      }
+    }
+    level = next;
+  }
+  return found;
+}
+
+export function buildTeamIndex(files) {
+  const index = new Map();
+  for (const file of files) {
+    for (const member of teamsForSpec(file)) {
+      const slug = teamSlug(member);
+      if (!index.has(slug)) index.set(slug, []);
+      index.get(slug).push(file);
+    }
+  }
+  return new Map([...index].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+// Specs with no discoverable owner. Asserted empty by the unit tests, so a new spec that no team
+// claims turns the PR red instead of silently vanishing from every team run.
+export function findUnownedSpecs(files) {
+  return files.filter(file => teamsForSpec(file).size === 0);
+}
+
+// Detox matches a spec by literal path substring, so a wholly-owned directory stands in for every
+// spec beneath it. Never collapses to the scan root itself.
+function collapseToDirectories(teamPaths, allPaths, rootRel) {
+  const tally = (paths, into) => {
+    for (const filePath of paths) {
+      let dir = path.dirname(filePath);
+      while (dir.startsWith(`${rootRel}/`)) {
+        into.set(dir, (into.get(dir) ?? 0) + 1);
+        dir = path.dirname(dir);
+      }
+    }
+  };
+  const total = new Map();
+  const owned = new Map();
+  tally(allPaths, total);
+  tally(teamPaths, owned);
+
+  const needles = new Set();
+  for (const filePath of teamPaths) {
+    let best;
+    let dir = path.dirname(filePath);
+    while (dir.startsWith(`${rootRel}/`)) {
+      if (owned.get(dir) === total.get(dir)) best = dir;
+      dir = path.dirname(dir);
+    }
+    needles.add(best ? `${best}/` : filePath);
+  }
+  return [...needles].sort();
+}
+
+export function createTeamExpander({ files, specRoot, runner }) {
+  const index = buildTeamIndex(files);
+  const isDetox = runner === "detox";
+  const rootRel = path.relative(repoRoot, specRoot).replaceAll(path.sep, "/");
+  const toRel = filePath => path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+  const allRel = files.map(toRel);
+
+  return {
+    knownSlugs: TEAM_SLUGS,
+    ownedSlugs: [...index.keys()],
+    specCount: slug => index.get(slug)?.length ?? 0,
+    specs: slug => index.get(slug) ?? [],
+    // [] when the team owns nothing here. The caller warns; it must never mean "match everything".
+    expand(slug) {
+      const teamFiles = index.get(slug);
+      if (!teamFiles?.length) return [];
+      return isDetox
+        ? collapseToDirectories(teamFiles.map(toRel), allRel, rootRel)
+        : teamFiles.map(file => SPEC_ANCHOR + escapeLiteral(path.basename(file)));
+    },
+  };
+}

--- a/e2e/tooling/filter/test-filter-guide.md
+++ b/e2e/tooling/filter/test-filter-guide.md
@@ -41,17 +41,12 @@ addAccount,deeplinks
 - `@generic-coin-framework` / `@generic-family` expands to all **enabled** generic-coin-framework
   families (from `genericCoinFrameworkFamilies.json`).
 - `@smoke` is added automatically when you enable the **Smoke tests** toggle.
-- `@team-<slug>` expands to the specs owned by that team — one more OR alternative, so
-  `@team-swap,@team-earn` runs both teams' specs.
 
 ## Filter by team
 
-Both workflows have a **`team`** dropdown next to `test_filter`. The two are different tools:
-
-| Where | Meaning |
-| ----- | ------- |
-| the **`team` dropdown** | **AND** — narrows the run to that team, *combined with* `test_filter`, Smoke and the device. `team=swap` + `test_filter=@solana` runs the specs that are **both**. |
-| **`@team-<slug>`** inside `test_filter` | **OR** — one more alternative, like any other token. Use it to run two teams at once. |
+Both workflows have a **`team`** dropdown next to `test_filter`. It **narrows** the run: the team is
+ANDed with `test_filter`, Smoke and the device, so `team=swap` + `test_filter=@solana` runs the specs
+that are **both**. (`test_filter` itself is still an OR across its own patterns.)
 
 Teams: `bst`, `buy-and-sell`, `coin-integration`, `earn`, `engagement`, `swap`, `wallet-xp`
 (the dropdown's `all` is the default and changes nothing). List them with their spec counts:
@@ -70,6 +65,8 @@ Things worth knowing before you rely on it:
 - **Smoke is a separate axis.** `team=swap` + **Smoke** selects nothing, because swap tags its
   smoke tests `@swapSmoke`, not `@smoke` — use `test_filter=@swapSmoke` instead. The run warns
   about this in the first minute rather than failing at the end.
+- **The dropdown is single-select.** To cover several teams in one go, filter on something they
+  share (a path or coin tag) or dispatch once per team.
 - **An unknown team, an empty team ∩ filter, or a team that owns nothing on that app fails the run
   immediately**, with the valid list printed. It never falls back to running everything —
   `engagement` owns no desktop spec today, so picking it on Desktop is always an error.

--- a/e2e/tooling/filter/test-filter-guide.md
+++ b/e2e/tooling/filter/test-filter-guide.md
@@ -41,6 +41,42 @@ addAccount,deeplinks
 - `@generic-coin-framework` / `@generic-family` expands to all **enabled** generic-coin-framework
   families (from `genericCoinFrameworkFamilies.json`).
 - `@smoke` is added automatically when you enable the **Smoke tests** toggle.
+- `@team-<slug>` expands to the specs owned by that team — one more OR alternative, so
+  `@team-swap,@team-earn` runs both teams' specs.
+
+## Filter by team
+
+Both workflows have a **`team`** dropdown next to `test_filter`. The two are different tools:
+
+| Where | Meaning |
+| ----- | ------- |
+| the **`team` dropdown** | **AND** — narrows the run to that team, *combined with* `test_filter`, Smoke and the device. `team=swap` + `test_filter=@solana` runs the specs that are **both**. |
+| **`@team-<slug>`** inside `test_filter` | **OR** — one more alternative, like any other token. Use it to run two teams at once. |
+
+Teams: `bst`, `buy-and-sell`, `coin-integration`, `earn`, `engagement`, `swap`, `wallet-xp`
+(the dropdown's `all` is the default and changes nothing). List them with their spec counts:
+
+```bash
+node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/mobile/specs --runner detox
+```
+
+Things worth knowing before you rely on it:
+
+- **Selection is per spec _file_, never per test.** A spec two teams share runs in full for
+  both — the filter over-selects rather than silently dropping a spec.
+- **`bst` and `coin-integration` own about half the suite each**, because the owner of the
+  shared send/addAccount/delegate flows is decided per currency. Pair them with a coin tag
+  (`team=bst` + `test_filter=@bitcoin`) to get a run worth waiting for.
+- **Smoke is a separate axis.** `team=swap` + **Smoke** selects nothing, because swap tags its
+  smoke tests `@swapSmoke`, not `@smoke` — use `test_filter=@swapSmoke` instead. The run warns
+  about this in the first minute rather than failing at the end.
+- **An unknown team, an empty team ∩ filter, or a team that owns nothing on that app fails the run
+  immediately**, with the valid list printed. It never falls back to running everything —
+  `engagement` owns no desktop spec today, so picking it on Desktop is always an error.
+- **`team` and `invert_filter` cannot be combined.** Inversion is applied to the whole pattern, so
+  "only earn" would become "everything except earn". The run fails in the first minute instead.
+- **A spec can have more than one owning team**, because ownership is recorded per test — the
+  shared send/addAccount flows are split per currency between `bst` and `coin-integration`.
 
 ## Verify your filter did what you meant
 
@@ -49,6 +85,8 @@ addAccount,deeplinks
    `E2E filter has no matches` or `Missing E2E tag`. A filter that resolves to 0 specs
    is wasted — on **Mobile** the test jobs are skipped, on **Desktop** the run **fails**
    ("No tests executed"). Fix the pattern and re-dispatch.
+3. With a **team** selected, an empty selection is a hard failure on both apps, raised by the
+   resolve step before any build — look for `E2E selection is empty`.
 
 ## See also
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds a “filter by team” capability to the Desktop Playwright and Mobile Detox E2E GitHub workflows by resolving a new team workflow input into runner-specific selectors, derived from team ownership references already present in spec sources.

Known limitation: for spec files that include individual tests own by several teams, all tests are executed
### 🔗 Context

- Desktop: 
  - [All](https://github.com/LedgerHQ/ledger-live/actions/runs/34336292531)
  - [bst](https://github.com/LedgerHQ/ledger-live/actions/runs/34326778159)
  - [coin-inte](https://github.com/LedgerHQ/ledger-live/actions/runs/34336318740)
- Mobile:
  - [All](https://github.com/LedgerHQ/ledger-live/actions/runs/34326874163) 
  - [bst](https://github.com/LedgerHQ/ledger-live/actions/runs/34326900581)
  - [buy sell](https://github.com/LedgerHQ/ledger-live/actions/runs/34346071903)
  - [engagement](https://github.com/LedgerHQ/ledger-live/actions/runs/34346125846)
