### PR TITLE
[LWDM] feat(concordium): report PLT transfers in token sub-account history

### DIFF
--- a/.changeset/amber-crickets-hum.md
+++ b/.changeset/amber-crickets-hum.md
@@ -1,0 +1,17 @@
+---
+"@ledgerhq/coin-concordium": minor
+---
+
+Report PLT transfers in the history of the token sub-account they moved
+
+`tokenUpdate` transactions were parsed away, so a PLT transfer showed nowhere.
+They now become operations on the token sub-account, valued in the token rather
+than in the CCD a native transfer folds its fee into. The fee stays on the
+parent account as a separate operation, typed from whether the account actually
+paid one, so that an outgoing transfer is charged for it exactly once and an
+incoming one is charged nothing. A `tokenUpdate` that is not a transfer, such as
+a mint or a pause, still records the CCD it cost the account that paid. The
+`api/` surface describes these operations as the token they moved instead of as
+the native asset. Accounts now carry a `syncHash` covering the CAL and the token
+flag, so enabling tokens re-reads the history rather than leaving earlier
+transfers behind the sync watermark.

--- a/.changeset/amber-crickets-hum.md
+++ b/.changeset/amber-crickets-hum.md
@@ -15,3 +15,18 @@ a mint or a pause, still records the CCD it cost the account that paid. The
 the native asset. Accounts now carry a `syncHash` covering the CAL and the token
 flag, so enabling tokens re-reads the history rather than leaving earlier
 transfers behind the sync watermark.
+
+Reading that history now follows the proxy's cursor to the end instead of
+stopping at the first page, so an account with more transactions than one page
+holds no longer loses the rest of them, and a failed page reports the failure
+rather than passing for the end of the history. Pages are read at the size the
+proxy actually allows, and rewards are excluded from the request, having only
+ever been fetched and discarded. The account keeps what a re-read returns rather
+than merging it over what was already stored, which is what lets a correction
+reach an operation recorded by an earlier version.
+
+A rejected transfer is recorded rather than dropped. The proxy reports one
+without any of its transfer fields, so it used to parse to nothing and the CCD
+it cost the sender went unaccounted for; it now appears as a failed operation
+worth its fee, matching what a rejected token transfer already did. Neither
+reports an empty address as a counterparty any more.

--- a/libs/coin-modules/coin-concordium/src/api/index.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.ts
@@ -179,7 +179,7 @@ async function listOperations(
   const { items, next } = await listOperationsLogic(config, address, options, currencyId);
 
   return {
-    items: items.map(mapRawOperationToApiOperation),
+    items: items.map(op => mapRawOperationToApiOperation(op, address)),
     next,
   };
 }

--- a/libs/coin-modules/coin-concordium/src/api/utils.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/utils.test.ts
@@ -1,11 +1,13 @@
 import type { RawOperation } from "../types";
 import { mapRawOperationToApiOperation } from "./utils";
 
+const ADDRESS = "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w";
+
 function createRawOperation(overrides?: Partial<RawOperation>): RawOperation {
   return {
     hash: "aa".repeat(32),
     type: "OUT",
-    sender: "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w",
+    sender: ADDRESS,
     recipient: "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
     amount: "1000000",
     fee: "500",
@@ -23,14 +25,14 @@ function createRawOperation(overrides?: Partial<RawOperation>): RawOperation {
 describe("mapRawOperationToApiOperation", () => {
   it("should use tx hash as operation id", () => {
     const raw = createRawOperation();
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.id).toBe(raw.hash);
   });
 
   it("should map a RawOperation to an API Operation with BigInt values", () => {
     const raw = createRawOperation();
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.tx.block.height).toBe(500);
 
@@ -46,35 +48,35 @@ describe("mapRawOperationToApiOperation", () => {
 
   it("should include memo in details when present", () => {
     const raw = createRawOperation({ memo: "hello world" });
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.details?.memo).toBe("hello world");
   });
 
   it("should not include memo in details when absent", () => {
     const raw = createRawOperation({ memo: undefined });
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.details?.memo).toBeUndefined();
   });
 
   it("should include pagingToken in details", () => {
     const raw = createRawOperation({ id: 77 });
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.details?.pagingToken).toBe("77");
   });
 
   it("should use empty string as block hash when blockHash is null", () => {
     const raw = createRawOperation({ blockHash: null });
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.tx.block.hash).toBe("");
   });
 
   it("should map IN operations correctly", () => {
     const raw = createRawOperation({ type: "IN", value: "2000000", fee: "0" });
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.type).toBe("IN");
     expect(result.value).toBe(BigInt(2000000));
@@ -82,8 +84,54 @@ describe("mapRawOperationToApiOperation", () => {
 
   it("should mark failed transactions", () => {
     const raw = createRawOperation({ failed: true });
-    const result = mapRawOperationToApiOperation(raw);
+    const result = mapRawOperationToApiOperation(raw, ADDRESS);
 
     expect(result.tx.failed).toBe(true);
+  });
+
+  describe("PLT operations", () => {
+    it("reports the token rather than the native asset", () => {
+      const raw = createRawOperation({ tokenId: "trUSDT", decimals: 6, value: "3000000" });
+      const result = mapRawOperationToApiOperation(raw, ADDRESS);
+
+      expect(result.asset).toEqual({
+        type: "plt",
+        assetReference: "trUSDT",
+        assetOwner: ADDRESS,
+      });
+      expect(result.value).toBe(BigInt(3000000));
+    });
+
+    it("attributes the token to the account being listed, not to the counterparty", () => {
+      const raw = createRawOperation({ type: "IN", tokenId: "trUSDT", decimals: 6 });
+
+      expect(mapRawOperationToApiOperation(raw, ADDRESS).asset).toEqual({
+        type: "plt",
+        assetReference: "trUSDT",
+        assetOwner: ADDRESS,
+      });
+    });
+
+    it("publishes no unit, leaving the token's denomination to the CAL", () => {
+      const raw = createRawOperation({ tokenId: "trUSDT", decimals: 6 });
+
+      expect(mapRawOperationToApiOperation(raw, ADDRESS).asset).not.toHaveProperty("unit");
+    });
+
+    it("identifies a rejected transfer that carried no denomination", () => {
+      const raw = createRawOperation({ tokenId: "trUSDT", failed: true, value: "0" });
+
+      expect(mapRawOperationToApiOperation(raw, ADDRESS).asset).toEqual({
+        type: "plt",
+        assetReference: "trUSDT",
+        assetOwner: ADDRESS,
+      });
+    });
+
+    it("leaves a CCD operation native", () => {
+      expect(mapRawOperationToApiOperation(createRawOperation(), ADDRESS).asset).toEqual({
+        type: "native",
+      });
+    });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/api/utils.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/utils.test.ts
@@ -89,6 +89,12 @@ describe("mapRawOperationToApiOperation", () => {
     expect(result.tx.failed).toBe(true);
   });
 
+  it("names no counterparty when the chain named none, rather than an empty address", () => {
+    const raw = createRawOperation({ recipient: "", failed: true });
+
+    expect(mapRawOperationToApiOperation(raw, ADDRESS).recipients).toEqual([]);
+  });
+
   describe("PLT operations", () => {
     it("reports the token rather than the native asset", () => {
       const raw = createRawOperation({ tokenId: "trUSDT", decimals: 6, value: "3000000" });

--- a/libs/coin-modules/coin-concordium/src/api/utils.ts
+++ b/libs/coin-modules/coin-concordium/src/api/utils.ts
@@ -2,10 +2,9 @@ import type { AssetInfo, Operation } from "@ledgerhq/coin-module-framework/api/i
 import type { RawOperation } from "../types";
 
 /**
- * All three fields match what `getBalance` reports for the same token, because
- * the two are paired on them: a consumer matching an operation to a balance
- * reads `assetReference` and `assetOwner` together. No unit is published — the
- * CAL owns a token's name and ticker, and this surface resolves no CAL.
+ * Matches what `getBalance` reports for the same token: a consumer pairing an
+ * operation with a balance reads `assetReference` and `assetOwner` together. No
+ * unit is published, since the CAL owns a token's name and ticker.
  */
 function toAssetInfo(op: RawOperation, address: string): AssetInfo {
   if (op.tokenId === undefined) {

--- a/libs/coin-modules/coin-concordium/src/api/utils.ts
+++ b/libs/coin-modules/coin-concordium/src/api/utils.ts
@@ -1,7 +1,21 @@
-import type { Operation } from "@ledgerhq/coin-module-framework/api/index";
+import type { AssetInfo, Operation } from "@ledgerhq/coin-module-framework/api/index";
 import type { RawOperation } from "../types";
 
-export function mapRawOperationToApiOperation(op: RawOperation): Operation {
+/**
+ * All three fields match what `getBalance` reports for the same token, because
+ * the two are paired on them: a consumer matching an operation to a balance
+ * reads `assetReference` and `assetOwner` together. No unit is published — the
+ * CAL owns a token's name and ticker, and this surface resolves no CAL.
+ */
+function toAssetInfo(op: RawOperation, address: string): AssetInfo {
+  if (op.tokenId === undefined) {
+    return { type: "native" };
+  }
+
+  return { type: "plt", assetReference: op.tokenId, assetOwner: address };
+}
+
+export function mapRawOperationToApiOperation(op: RawOperation, address: string): Operation {
   const date = op.date;
 
   const details: Record<string, unknown> = {
@@ -11,7 +25,7 @@ export function mapRawOperationToApiOperation(op: RawOperation): Operation {
 
   return {
     id: op.hash,
-    asset: { type: "native" },
+    asset: toAssetInfo(op, address),
     tx: {
       hash: op.hash,
       fees: BigInt(op.fee),

--- a/libs/coin-modules/coin-concordium/src/api/utils.ts
+++ b/libs/coin-modules/coin-concordium/src/api/utils.ts
@@ -39,8 +39,10 @@ export function mapRawOperationToApiOperation(op: RawOperation, address: string)
     },
     type: op.type,
     value: BigInt(op.value),
-    senders: [op.sender],
-    recipients: [op.recipient],
+    // A fee-only or rejected operation names no counterparty, and `[""]` would
+    // publish an address the chain never saw.
+    senders: op.sender ? [op.sender] : [],
+    recipients: op.recipient ? [op.recipient] : [],
     details,
   };
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
@@ -79,6 +79,15 @@ describe("createBridges token visibility wiring", () => {
     expect(scan).toEqual(expect.any(Function));
   });
 
+  it("merges operations in the shape only, since makeSync's merge drops the oldest", () => {
+    // Not visible from `getAccountShape`: the outer `mergeOps` would re-merge
+    // against the stored account, discarding every refetched operation older
+    // than the oldest stored one and reinstating stale copies.
+    build(false);
+
+    expect(makeSync.mock.calls[0][0].shouldMergeOps).toBe(false);
+  });
+
   it.each([
     ["sync", (b: { sync: PostSync; scan: PostSync }) => b.sync],
     ["scan", (b: { sync: PostSync; scan: PostSync }) => b.scan],

--- a/libs/coin-modules/coin-concordium/src/bridge/index.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.ts
@@ -59,7 +59,10 @@ export function createBridges(
   };
 
   const signOperation = buildSignOperation(signerContext);
-  const sync = makeSync({ getAccountShape, postSync });
+  // `getAccountShape` already merged. Merging again against the stored account
+  // would undo the discard a re-read depends on and drop every refetched
+  // operation older than the oldest stored one.
+  const sync = makeSync({ getAccountShape, postSync, shouldMergeOps: false });
 
   const accountBridge: AccountBridge<Transaction, ConcordiumAccount> = {
     broadcast,

--- a/libs/coin-modules/coin-concordium/src/bridge/operations.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/operations.ts
@@ -1,0 +1,63 @@
+import BigNumber from "bignumber.js";
+import { mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
+import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import type { Operation, OperationType } from "@ledgerhq/types-live";
+import type { RawOperation } from "../types";
+
+/**
+ * The fields every operation this family builds shares, whatever account it
+ * lands on. `type` and `value` are the caller's to decide: a PLT transfer moves
+ * a token amount on the sub-account and a CCD fee on the parent.
+ */
+export function baseOperation(
+  op: RawOperation,
+  accountId: string,
+  type: OperationType,
+  value: BigNumber,
+): Operation {
+  return {
+    id: encodeOperationId(accountId, op.hash, type),
+    hash: op.hash,
+    accountId,
+    type,
+    value,
+    fee: new BigNumber(op.fee),
+    blockHash: op.blockHash,
+    blockHeight: op.blockHeight,
+    senders: [op.sender],
+    // A rejected transaction reports no destination, and `[""]` would render as
+    // a recipient the chain never saw.
+    recipients: op.recipient ? [op.recipient] : [],
+    date: op.date,
+    hasFailed: op.failed,
+    extra: {},
+  };
+}
+
+/** Maps a transfer onto the account that holds it, parent or sub-account alike. */
+export function toOperation(op: RawOperation, accountId: string): Operation {
+  return {
+    ...baseOperation(op, accountId, op.type, new BigNumber(op.value)),
+    extra: op.memo ? { memo: op.memo } : {},
+  };
+}
+
+/**
+ * `mergeOps` with the operations it drops put back.
+ *
+ * It walks `existing` and pushes an incoming operation only while that
+ * operation is at least as recent as the one it is looking at, so anything
+ * older than the oldest stored operation is still in its queue when the walk
+ * ends, and is never emitted. That is invisible in an incremental sync, which
+ * only ever fetches newer blocks, but it silently defeats a re-read from height
+ * zero: the older history it went back for is exactly what gets dropped.
+ */
+export function mergeOperations(existing: Operation[], incoming: Operation[]): Operation[] {
+  const merged = mergeOps(existing, incoming);
+
+  const emitted = new Set(merged.map(op => op.id));
+  const dropped = incoming.filter(op => !emitted.has(op.id));
+  if (dropped.length === 0) return merged;
+
+  return [...merged, ...dropped].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+}

--- a/libs/coin-modules/coin-concordium/src/bridge/operations.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/operations.ts
@@ -1,13 +1,13 @@
 import BigNumber from "bignumber.js";
-import { mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
-import type { Operation, OperationType } from "@ledgerhq/types-live";
+import { inferSubOperations } from "@ledgerhq/ledger-wallet-framework/serialization/index";
+import type { Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
 import type { RawOperation } from "../types";
 
 /**
- * The fields every operation this family builds shares, whatever account it
- * lands on. `type` and `value` are the caller's to decide: a PLT transfer moves
- * a token amount on the sub-account and a CCD fee on the parent.
+ * The fields every operation this family builds shares. `type` and `value` are
+ * the caller's: one PLT transfer moves a token on the sub-account and a CCD fee
+ * on the parent.
  */
 export function baseOperation(
   op: RawOperation,
@@ -34,7 +34,6 @@ export function baseOperation(
   };
 }
 
-/** Maps a transfer onto the account that holds it, parent or sub-account alike. */
 export function toOperation(op: RawOperation, accountId: string): Operation {
   return {
     ...baseOperation(op, accountId, op.type, new BigNumber(op.value)),
@@ -43,29 +42,24 @@ export function toOperation(op: RawOperation, accountId: string): Operation {
 }
 
 /**
- * `mergeOps` with the operations it drops put back.
+ * Hangs each PLT transfer under the CCD operation that paid its fee. Done here
+ * because a parent is built before the sub-accounts it points at exist.
  *
- * It walks `existing` and pushes an incoming operation only while that
- * operation is at least as recent as the one it is looking at, so anything
- * older than the oldest stored operation is still in its queue when the walk
- * ends, and is never emitted. That is invisible in an incremental sync, which
- * only ever fetches newer blocks, but it silently defeats a re-read from height
- * zero: the older history it went back for is exactly what gets dropped.
+ * Gated on the parent types so the scan costs the PLT slice of the history
+ * rather than all of it; a native transfer never shares a hash with a token
+ * operation. Skipping it only affects this sync — `fromOperationRaw` infers the
+ * same links when the account is read back.
  */
-export function mergeOperations(existing: Operation[], incoming: Operation[]): Operation[] {
-  const merged = mergeOps(existing, incoming);
+export function attachSubOperations(
+  operations: Operation[],
+  subAccounts: TokenAccount[],
+): Operation[] {
+  if (subAccounts.length === 0) return operations;
 
-  const emitted = new Set(merged.map(op => op.id));
+  return operations.map(op => {
+    if (op.type !== "FEES" && op.type !== "NONE") return op;
 
-  // Keyed rather than filtered, because a page that repeats a transaction would
-  // otherwise put every copy back: `mergeOps` guarantees the result holds no
-  // duplicate id, and restoring what it dropped must not cost that. Last wins,
-  // as it does there.
-  const dropped = new Map<string, Operation>();
-  for (const op of incoming) {
-    if (!emitted.has(op.id)) dropped.set(op.id, op);
-  }
-  if (dropped.size === 0) return merged;
-
-  return [...merged, ...dropped.values()].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+    const subOperations = inferSubOperations(op.hash, subAccounts);
+    return subOperations.length > 0 ? { ...op, subOperations } : op;
+  });
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/operations.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/operations.ts
@@ -56,8 +56,16 @@ export function mergeOperations(existing: Operation[], incoming: Operation[]): O
   const merged = mergeOps(existing, incoming);
 
   const emitted = new Set(merged.map(op => op.id));
-  const dropped = incoming.filter(op => !emitted.has(op.id));
-  if (dropped.length === 0) return merged;
 
-  return [...merged, ...dropped].sort((a, b) => b.date.valueOf() - a.date.valueOf());
+  // Keyed rather than filtered, because a page that repeats a transaction would
+  // otherwise put every copy back: `mergeOps` guarantees the result holds no
+  // duplicate id, and restoring what it dropped must not cost that. Last wins,
+  // as it does there.
+  const dropped = new Map<string, Operation>();
+  for (const op of incoming) {
+    if (!emitted.has(op.id)) dropped.set(op.id, op);
+  }
+  if (dropped.size === 0) return merged;
+
+  return [...merged, ...dropped.values()].sort((a, b) => b.date.valueOf() - a.date.valueOf());
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
@@ -366,6 +366,18 @@ describe("mapRawOperationToBridgeOperation", () => {
 
     expect(result.blockHash).toBeNull();
   });
+
+  it("marks a rejected transfer as failed, as the PLT parent operation does", () => {
+    const raw = createRawOperation({ failed: true });
+
+    expect(mapRawOperationToBridgeOperation(raw, ACCOUNT_ID).hasFailed).toBe(true);
+  });
+
+  it("lists no recipient for a transaction that never named one", () => {
+    const raw = createRawOperation({ recipient: "" });
+
+    expect(mapRawOperationToBridgeOperation(raw, ACCOUNT_ID).recipients).toEqual([]);
+  });
 });
 
 /**

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
@@ -1,6 +1,4 @@
-import BigNumber from "bignumber.js";
-import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
-import type { Account, AccountRaw, Operation, OperationType } from "@ledgerhq/types-live";
+import type { Account, AccountRaw, Operation } from "@ledgerhq/types-live";
 import type {
   ConcordiumAccount,
   ConcordiumAccountRaw,
@@ -8,6 +6,7 @@ import type {
   RawOperation,
 } from "../types";
 import coinConfig from "../config";
+import { toOperation } from "./operations";
 import { applyTokensToResources } from "./tokens";
 
 export function isConcordiumAccount(account: Account): account is ConcordiumAccount {
@@ -96,22 +95,5 @@ export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): 
 }
 
 export function mapRawOperationToBridgeOperation(op: RawOperation, accountId: string): Operation {
-  const type: OperationType = op.type;
-
-  const extra: Record<string, unknown> = op.memo ? { memo: op.memo } : {};
-
-  return {
-    id: encodeOperationId(accountId, op.hash, type),
-    hash: op.hash,
-    accountId,
-    type,
-    value: new BigNumber(op.value),
-    fee: new BigNumber(op.fee),
-    blockHash: op.blockHash,
-    blockHeight: op.blockHeight,
-    senders: [op.sender],
-    recipients: [op.recipient],
-    date: op.date,
-    extra,
-  };
+  return toOperation(op, accountId);
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
@@ -3,12 +3,14 @@ import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account"
 import {
   createFixtureCurrency,
   createFixtureOperation,
+  createFixtureTokenAccount,
   createFixtureTokenCurrency,
   PLT_TOKEN_ID,
   VALID_ADDRESS,
   VALID_ADDRESS_2,
   PUBLIC_KEY,
 } from "../test/fixtures";
+import type { Operation } from "@ledgerhq/types-live";
 import { createTestConcordiumAccount } from "../test/testHelpers";
 import type { ConcordiumAccount } from "../types";
 import { getAccountShape as getAccountShapeOriginal, getBalance, syncOperations } from "./sync";
@@ -24,12 +26,15 @@ jest.mock("../logic/history/listOperations", () => ({
   listOperations: jest.fn(),
 }));
 
-// Throwing by default is what lets a tokens-off test prove it never reached the
-// CAL. A tokens-on test installs a store for the span it needs one.
+// Recorded as well as throwing: a tokens-off test asserts the store was never
+// reached, which resolving successfully cannot show. A tokens-on test installs a
+// store for the span it needs one.
 let mockCryptoAssetsStore: unknown = null;
+const mockStoreAccess = jest.fn();
 
 jest.mock("@ledgerhq/ledger-wallet-framework/cryptoAssetsStore", () => ({
   getCryptoAssetsStore: () => {
+    mockStoreAccess();
     if (!mockCryptoAssetsStore) {
       throw new Error("the CAL must not be consulted while tokens are off");
     }
@@ -201,7 +206,7 @@ describe("syncOperations", () => {
     expect(listOperations).toHaveBeenCalledWith(
       config,
       VALID_ADDRESS,
-      { minHeight: 0, limit: 100, order: "desc" },
+      { minHeight: 0, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
     expect(result.operations).toEqual([]);
@@ -215,7 +220,7 @@ describe("syncOperations", () => {
     expect(listOperations).toHaveBeenCalledWith(
       config,
       VALID_ADDRESS,
-      { minHeight: 501, limit: 100, order: "desc" },
+      { minHeight: 501, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
   });
@@ -228,7 +233,7 @@ describe("syncOperations", () => {
     expect(listOperations).toHaveBeenCalledWith(
       config,
       VALID_ADDRESS,
-      { minHeight: 0, limit: 100, order: "desc" },
+      { minHeight: 0, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
   });
@@ -247,14 +252,72 @@ describe("syncOperations", () => {
     expect(result.operations.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("should return empty operations on listOperations failure", async () => {
+  it("fails the sync when a page cannot be fetched, leaving the stored history alone", async () => {
+    // Reporting an empty page would read as the end of history, so the
+    // watermark would advance past whatever the failed page held.
     listOperations.mockRejectedValue(new Error("network error"));
+
+    await expect(
+      syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], { enableTokens: false }),
+    ).rejects.toThrow("network error");
+  });
+
+  it("walks every page the proxy offers, not just the first", async () => {
+    const older = createRawOpFixture({ hash: "ab".repeat(32), id: 7, blockHeight: 10 });
+    listOperations
+      .mockResolvedValueOnce({ items: [createRawOpFixture()], next: "101" })
+      .mockResolvedValueOnce({ items: [older], next: undefined });
 
     const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
       enableTokens: false,
     });
 
-    expect(result.operations).toEqual([]);
+    expect(listOperations).toHaveBeenCalledTimes(2);
+    expect(listOperations.mock.calls[1][2]).toMatchObject({ cursor: "101" });
+    expect(result.operations).toHaveLength(2);
+  });
+
+  it("fails rather than looping when the proxy replays a cursor it already gave", async () => {
+    // A `from` the proxy cannot parse is ignored, so a bad cursor serves the
+    // same page again instead of failing.
+    listOperations.mockResolvedValue({ items: [createRawOpFixture()], next: "101" });
+
+    await expect(
+      syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], { enableTokens: false }),
+    ).rejects.toThrow("was served twice");
+  });
+
+  it("carries the height floor onto every page of an incremental walk", async () => {
+    const stored = createFixtureOperation({ blockHeight: 500 });
+    listOperations
+      .mockResolvedValueOnce({ items: [createRawOpFixture()], next: "9" })
+      .mockResolvedValueOnce({ items: [], next: undefined });
+
+    await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [stored], {
+      enableTokens: false,
+    });
+
+    expect(listOperations).toHaveBeenNthCalledWith(
+      2,
+      config,
+      VALID_ADDRESS,
+      { minHeight: 501, limit: 1000, order: "desc", cursor: "9" },
+      CURRENCY_ID,
+    );
+  });
+
+  it("keeps walking past a page whose rows all parsed away", async () => {
+    const older = createRawOpFixture({ hash: "ab".repeat(32), id: 7, blockHeight: 10 });
+    listOperations
+      .mockResolvedValueOnce({ items: [], next: "101" })
+      .mockResolvedValueOnce({ items: [older], next: undefined });
+
+    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+      enableTokens: false,
+    });
+
+    expect(listOperations).toHaveBeenCalledTimes(2);
+    expect(result.operations).toHaveLength(1);
   });
 
   describe("splitting PLT transfers from CCD ones", () => {
@@ -315,26 +378,24 @@ describe("syncOperations", () => {
       expect(listOperations).toHaveBeenCalledWith(
         config,
         VALID_ADDRESS,
-        { minHeight: 0, limit: 100, order: "desc" },
+        { minHeight: 0, limit: 1000, order: "desc" },
         CURRENCY_ID,
       );
     });
 
-    it("keeps what is already stored when re-reading, rather than replacing it", async () => {
-      // A fetch returns one page, so discarding first would truncate a longer
-      // history to its newest page.
-      const oldOp = createFixtureOperation({ id: "kept-op", blockHeight: 10 });
+    it("replaces the stored history when re-reading, since the walk covers every block", async () => {
+      const stale = createFixtureOperation({ id: "stale-op", blockHeight: 10 });
       listOperations.mockResolvedValue({ items: [], next: undefined });
 
-      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp], {
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [stale], {
         enableTokens: true,
         refetchAll: true,
       });
 
-      expect(result.operations.map(op => op.id)).toContain("kept-op");
+      expect(result.operations).toEqual([]);
     });
 
-    it("keeps transfers older than everything stored, which is the point of re-reading", async () => {
+    it("recovers transfers older than everything stored, which is the point of re-reading", async () => {
       const stored = createFixtureOperation({ id: "newest-stored", date: new Date("2024-06-01") });
       const older = { ...pltOp, date: new Date("2020-01-01") };
       listOperations.mockResolvedValue({ items: [older], next: undefined });
@@ -344,9 +405,19 @@ describe("syncOperations", () => {
         refetchAll: true,
       });
 
-      expect(result.operations.map(op => op.id)).toContain("newest-stored");
       expect(result.operations.filter(op => op.type === "FEES")).toHaveLength(1);
       expect(result.pltOperations).toEqual([older]);
+    });
+
+    it("keeps the stored history on an incremental sync", async () => {
+      const stored = createFixtureOperation({ id: "kept-op", blockHeight: 10 });
+      listOperations.mockResolvedValue({ items: [], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [stored], {
+        enableTokens: true,
+      });
+
+      expect(result.operations.map(op => op.id)).toContain("kept-op");
     });
 
     it("stores one operation when the page repeats a transaction", async () => {
@@ -456,6 +527,28 @@ describe("getAccountShape", () => {
     expect(result.concordiumResources?.isOnboarded).toBe(false);
     expect(result.used).toBe(false);
     expect(result.operations).toEqual([]);
+  });
+
+  it("keeps the stored history when the chain reports no such account", async () => {
+    // Nothing removes a transaction from a chain, so an empty account list is a
+    // fault. `shouldMergeOps` is off, so returning [] here would erase history.
+    getAccountsByPublicKey.mockResolvedValue([]);
+    const initialAccount = {
+      operations: [createFixtureOperation({ id: "kept-op" })],
+      concordiumResources: { publicKey: PUBLIC_KEY },
+    } as unknown as ConcordiumAccount;
+
+    const result = await getAccountShape({
+      currency: createFixtureCurrency(),
+      derivationMode: "",
+      derivationPath: "44'/1'/0'/0'/0'/0'",
+      index: 0,
+      initialAccount,
+      rest: { publicKey: PUBLIC_KEY },
+    });
+
+    expect(result.operations.map((op: { id: string }) => op.id)).toEqual(["kept-op"]);
+    expect(result.operationsCount).toBe(1);
   });
 
   it("should throw on network error when fetching accounts", async () => {
@@ -612,8 +705,9 @@ describe("getAccountShape with tokens disabled", () => {
   });
 
   it("never consults the CAL, so a CAL outage cannot affect a tokens-off sync", async () => {
-    // The store mock throws on access; reaching it would fail this test.
-    await expect(shape()).resolves.toBeDefined();
+    await shape();
+
+    expect(mockStoreAccess).not.toHaveBeenCalled();
   });
 
   it("stores no per-token state", async () => {
@@ -632,6 +726,28 @@ describe("getAccountShape with tokens disabled", () => {
   it("records a syncHash that names the off state", async () => {
     const result = await shape();
 
+    expect(result.syncHash).toBe("tokens=off");
+  });
+
+  it("drops PLT transfers entirely when the flag is switched back off", async () => {
+    // The rollback path: the stored hash names the on state, so the sync
+    // re-reads, and every PLT transfer must fall out of both accounts.
+    listOperations.mockResolvedValue({
+      items: [createRawOpFixture({ tokenId: PLT_TOKEN_ID, decimals: 6, fee: "595400" })],
+      next: undefined,
+    });
+
+    const result = await getAccountShape({
+      currency: createFixtureCurrency(),
+      derivationMode: "",
+      derivationPath: "44'/1'/0'/0'/0'/0'",
+      index: 0,
+      initialAccount: storedAccount({ syncHash: "0xabc:tokens=on" }),
+      rest: { publicKey: PUBLIC_KEY },
+    });
+
+    expect(result.operations).toEqual([]);
+    expect(result.subAccounts).toEqual([]);
     expect(result.syncHash).toBe("tokens=off");
   });
 
@@ -654,7 +770,27 @@ describe("getAccountShape with tokens disabled", () => {
     expect(listOperations).toHaveBeenCalledWith(
       config,
       VALID_ADDRESS,
-      { minHeight: 0, limit: 100, order: "desc" },
+      { minHeight: 0, limit: 1000, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+
+  it("re-reads once for an account stored before this family had a syncHash", async () => {
+    // What carries the corrected parsing onto history already on disk: nothing
+    // else revisits a stored operation, since `sameOp` ignores `hasFailed`.
+    await getAccountShape({
+      currency: createFixtureCurrency(),
+      derivationMode: "",
+      derivationPath: "44'/1'/0'/0'/0'/0'",
+      index: 0,
+      initialAccount: storedAccount(),
+      rest: { publicKey: PUBLIC_KEY },
+    });
+
+    expect(listOperations).toHaveBeenCalledWith(
+      config,
+      VALID_ADDRESS,
+      { minHeight: 0, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
   });
@@ -678,7 +814,7 @@ describe("getAccountShape with tokens disabled", () => {
     expect(listOperations).toHaveBeenCalledWith(
       config,
       VALID_ADDRESS,
-      { minHeight: 501, limit: 100, order: "desc" },
+      { minHeight: 501, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
   });
@@ -756,6 +892,25 @@ describe("getAccountShape with tokens enabled", () => {
     expect(subAccount?.operations[0].value).toEqual(new BigNumber("3000000"));
   });
 
+  it("hangs the token transfer under the CCD operation that paid for it", async () => {
+    listOperations.mockResolvedValue({ items: [pltRawOp()], next: undefined });
+
+    const result = await shape();
+
+    const parent = result.operations?.[0];
+    expect(parent.type).toBe("FEES");
+    expect(parent.subOperations).toHaveLength(1);
+    expect(parent.subOperations[0].accountId).toBe(SUB_ACCOUNT_ID);
+  });
+
+  it("leaves a plain CCD transfer without sub-operations", async () => {
+    listOperations.mockResolvedValue({ items: [createRawOpFixture()], next: undefined });
+
+    const result = await shape();
+
+    expect(result.operations?.[0]).not.toHaveProperty("subOperations");
+  });
+
   it("leaves only the CCD fee for that transfer on the parent account", async () => {
     listOperations.mockResolvedValue({ items: [pltRawOp()], next: undefined });
 
@@ -785,7 +940,7 @@ describe("getAccountShape with tokens enabled", () => {
     expect(listOperations).toHaveBeenCalledWith(
       tokensOnConfig,
       VALID_ADDRESS,
-      { minHeight: 0, limit: 100, order: "desc" },
+      { minHeight: 0, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
   });
@@ -802,7 +957,7 @@ describe("getAccountShape with tokens enabled", () => {
     expect(listOperations).toHaveBeenLastCalledWith(
       tokensOnConfig,
       VALID_ADDRESS,
-      { minHeight: 501, limit: 100, order: "desc" },
+      { minHeight: 501, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
   });
@@ -832,9 +987,20 @@ describe("getAccountShape with tokens enabled", () => {
     expect(listOperations).toHaveBeenLastCalledWith(
       tokensOnConfig,
       VALID_ADDRESS,
-      { minHeight: 0, limit: 100, order: "desc" },
+      { minHeight: 0, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
+  });
+
+  it("keeps asking for a re-read while the token list stays absent", async () => {
+    // The fault is the balance response, not the CAL, so nothing else re-arms:
+    // giving up after one attempt would strand these transfers for good.
+    getAccountBalance.mockRejectedValue(new Error("balance endpoint down"));
+    listOperations.mockResolvedValue({ items: [pltRawOp()], next: undefined });
+
+    const result = await shape(storedAccount({ syncHash: "refetch-pending" }));
+
+    expect(result.syncHash).toBe("refetch-pending");
   });
 
   it("defers that re-read while the CAL is still down, rather than losing it", async () => {
@@ -848,9 +1014,32 @@ describe("getAccountShape with tokens enabled", () => {
     expect(listOperations).toHaveBeenLastCalledWith(
       tokensOnConfig,
       VALID_ADDRESS,
-      { minHeight: 501, limit: 100, order: "desc" },
+      { minHeight: 501, limit: 1000, order: "desc" },
       CURRENCY_ID,
     );
+  });
+
+  it("fails the shape when a page cannot be fetched, rather than storing a fragment", async () => {
+    listOperations.mockRejectedValue(new Error("network error"));
+
+    await expect(shape()).rejects.toThrow("network error");
+  });
+
+  it("links sub-operations from the stored sub-accounts when the token list is absent", async () => {
+    // The `unchanged` arm: the account keeps the sub-accounts it had, so the
+    // links must come from those rather than from a resolution that did not run.
+    getAccountBalance.mockRejectedValue(new Error("balance endpoint down"));
+    const raw = pltRawOp();
+    listOperations.mockResolvedValue({ items: [raw], next: undefined });
+
+    const stored = createFixtureTokenAccount({
+      token: TOKEN,
+      operations: [{ hash: raw.hash, accountId: SUB_ACCOUNT_ID }] as unknown as Operation[],
+    });
+
+    const result = await shape(storedAccount({ subAccounts: [stored] }));
+
+    expect(result.operations?.[0].subOperations).toHaveLength(1);
   });
 
   it("keeps the computed syncHash when a balance failure cost it no transfers", async () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
@@ -349,6 +349,20 @@ describe("syncOperations", () => {
       expect(result.pltOperations).toEqual([older]);
     });
 
+    it("stores one operation when the page repeats a transaction", async () => {
+      const stored = createFixtureOperation({ id: "newest-stored", date: new Date("2024-06-01") });
+      const older = { ...pltOp, date: new Date("2020-01-01") };
+      listOperations.mockResolvedValue({ items: [older, older], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [stored], {
+        enableTokens: true,
+        refetchAll: true,
+      });
+
+      const ids = result.operations.map(op => op.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
     it("discards PLT transfers entirely when tokens are off", async () => {
       listOperations.mockResolvedValue({ items: [pltOp], next: undefined });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
@@ -1,12 +1,16 @@
 import BigNumber from "bignumber.js";
+import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
 import {
   createFixtureCurrency,
   createFixtureOperation,
+  createFixtureTokenCurrency,
+  PLT_TOKEN_ID,
   VALID_ADDRESS,
   VALID_ADDRESS_2,
   PUBLIC_KEY,
 } from "../test/fixtures";
 import { createTestConcordiumAccount } from "../test/testHelpers";
+import type { ConcordiumAccount } from "../types";
 import { getAccountShape as getAccountShapeOriginal, getBalance, syncOperations } from "./sync";
 const getAccountShape = getAccountShapeOriginal as any;
 
@@ -20,9 +24,16 @@ jest.mock("../logic/history/listOperations", () => ({
   listOperations: jest.fn(),
 }));
 
+// Throwing by default is what lets a tokens-off test prove it never reached the
+// CAL. A tokens-on test installs a store for the span it needs one.
+let mockCryptoAssetsStore: unknown = null;
+
 jest.mock("@ledgerhq/ledger-wallet-framework/cryptoAssetsStore", () => ({
   getCryptoAssetsStore: () => {
-    throw new Error("the CAL must not be consulted while tokens are off");
+    if (!mockCryptoAssetsStore) {
+      throw new Error("the CAL must not be consulted while tokens are off");
+    }
+    return mockCryptoAssetsStore;
   },
 }));
 
@@ -37,6 +48,8 @@ const { getAccountsByPublicKey, getAccountBalance, getConsensusInfo } =
   jest.requireMock("../network/proxyClient");
 
 const { listOperations } = jest.requireMock("../logic/history/listOperations");
+
+const coinConfig = jest.requireMock("../config").default;
 
 const CURRENCY_ID = "concordium_testnet";
 const ACCOUNT_ID = "js:2:concordium_testnet:test:";
@@ -60,6 +73,13 @@ function createRawOpFixture(overrides?: Record<string, unknown>) {
     ...overrides,
   };
 }
+
+const storedAccount = (over: Record<string, unknown> = {}) =>
+  ({
+    operations: [createFixtureOperation({ blockHeight: 500 })],
+    concordiumResources: { publicKey: PUBLIC_KEY },
+    ...over,
+  }) as unknown as ConcordiumAccount;
 
 describe("getBalance token list authority", () => {
   beforeEach(() => {
@@ -174,7 +194,9 @@ describe("syncOperations", () => {
   });
 
   it("should fetch with minHeight 0 when no old operations", async () => {
-    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, []);
+    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+      enableTokens: false,
+    });
 
     expect(listOperations).toHaveBeenCalledWith(
       config,
@@ -182,13 +204,13 @@ describe("syncOperations", () => {
       { minHeight: 0, limit: 100, order: "desc" },
       CURRENCY_ID,
     );
-    expect(result).toEqual([]);
+    expect(result.operations).toEqual([]);
   });
 
   it("should use blockHeight + 1 from newest old operation as minHeight", async () => {
     const oldOp = createFixtureOperation({ blockHeight: 500 });
 
-    await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp]);
+    await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp], { enableTokens: false });
 
     expect(listOperations).toHaveBeenCalledWith(
       config,
@@ -201,7 +223,7 @@ describe("syncOperations", () => {
   it("should use minHeight 0 when newest operation has blockHeight 0", async () => {
     const oldOp = createFixtureOperation({ blockHeight: 0 });
 
-    await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp]);
+    await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp], { enableTokens: false });
 
     expect(listOperations).toHaveBeenCalledWith(
       config,
@@ -218,17 +240,125 @@ describe("syncOperations", () => {
       next: undefined,
     });
 
-    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp]);
+    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp], {
+      enableTokens: false,
+    });
 
-    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result.operations.length).toBeGreaterThanOrEqual(1);
   });
 
   it("should return empty operations on listOperations failure", async () => {
     listOperations.mockRejectedValue(new Error("network error"));
 
-    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, []);
+    const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+      enableTokens: false,
+    });
 
-    expect(result).toEqual([]);
+    expect(result.operations).toEqual([]);
+  });
+
+  describe("splitting PLT transfers from CCD ones", () => {
+    const pltOp = createRawOpFixture({
+      hash: "dd".repeat(32),
+      id: 102,
+      tokenId: "t-USDT",
+      decimals: 6,
+      amount: "3000000",
+      value: "3000000",
+      fee: "595400",
+    });
+
+    it("hands the token half back unmapped, for the sub-account to claim", async () => {
+      listOperations.mockResolvedValue({ items: [pltOp], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+        enableTokens: true,
+      });
+
+      expect(result.pltOperations).toEqual([pltOp]);
+    });
+
+    it("leaves only the CCD fee on the parent account", async () => {
+      listOperations.mockResolvedValue({ items: [pltOp], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+        enableTokens: true,
+      });
+
+      expect(result.operations).toHaveLength(1);
+      expect(result.operations[0].type).toBe("FEES");
+      expect(result.operations[0].value).toEqual(new BigNumber("595400"));
+    });
+
+    it("keeps CCD operations untouched alongside them", async () => {
+      listOperations.mockResolvedValue({
+        items: [createRawOpFixture(), pltOp],
+        next: undefined,
+      });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+        enableTokens: true,
+      });
+
+      expect(result.operations.map(op => op.type).sort()).toEqual(["FEES", "OUT"]);
+    });
+
+    it("re-reads from height zero when asked to, ignoring the stored watermark", async () => {
+      listOperations.mockResolvedValue({ items: [], next: undefined });
+      const oldOp = createFixtureOperation({ blockHeight: 500 });
+
+      await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp], {
+        enableTokens: true,
+        refetchAll: true,
+      });
+
+      expect(listOperations).toHaveBeenCalledWith(
+        config,
+        VALID_ADDRESS,
+        { minHeight: 0, limit: 100, order: "desc" },
+        CURRENCY_ID,
+      );
+    });
+
+    it("keeps what is already stored when re-reading, rather than replacing it", async () => {
+      // A fetch returns one page, so discarding first would truncate a longer
+      // history to its newest page.
+      const oldOp = createFixtureOperation({ id: "kept-op", blockHeight: 10 });
+      listOperations.mockResolvedValue({ items: [], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [oldOp], {
+        enableTokens: true,
+        refetchAll: true,
+      });
+
+      expect(result.operations.map(op => op.id)).toContain("kept-op");
+    });
+
+    it("keeps transfers older than everything stored, which is the point of re-reading", async () => {
+      const stored = createFixtureOperation({ id: "newest-stored", date: new Date("2024-06-01") });
+      const older = { ...pltOp, date: new Date("2020-01-01") };
+      listOperations.mockResolvedValue({ items: [older], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [stored], {
+        enableTokens: true,
+        refetchAll: true,
+      });
+
+      expect(result.operations.map(op => op.id)).toContain("newest-stored");
+      expect(result.operations.filter(op => op.type === "FEES")).toHaveLength(1);
+      expect(result.pltOperations).toEqual([older]);
+    });
+
+    it("discards PLT transfers entirely when tokens are off", async () => {
+      listOperations.mockResolvedValue({ items: [pltOp], next: undefined });
+
+      const result = await syncOperations(CURRENCY_ID, VALID_ADDRESS, ACCOUNT_ID, [], {
+        enableTokens: false,
+      });
+
+      expect(result.operations).toEqual([]);
+      expect(result.pltOperations).toEqual([]);
+    });
   });
 });
 
@@ -483,5 +613,210 @@ describe("getAccountShape with tokens disabled", () => {
 
     // `postSync` then removes the key entirely; see bridge/index.test.ts.
     expect(result.subAccounts).toEqual([]);
+  });
+
+  it("records a syncHash that names the off state", async () => {
+    const result = await shape();
+
+    expect(result.syncHash).toBe("tokens=off");
+  });
+
+  it("re-reads the history from zero once the stored assumptions no longer hold", async () => {
+    const initialAccount = {
+      operations: [createFixtureOperation({ blockHeight: 500 })],
+      syncHash: "some-earlier-hash",
+      concordiumResources: { publicKey: PUBLIC_KEY },
+    } as unknown as ConcordiumAccount;
+
+    await getAccountShape({
+      currency: createFixtureCurrency(),
+      derivationMode: "",
+      derivationPath: "44'/1'/0'/0'/0'/0'",
+      index: 0,
+      initialAccount,
+      rest: { publicKey: PUBLIC_KEY },
+    });
+
+    expect(listOperations).toHaveBeenCalledWith(
+      config,
+      VALID_ADDRESS,
+      { minHeight: 0, limit: 100, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+
+  it("keeps the watermark when the stored assumptions still hold", async () => {
+    const initialAccount = {
+      operations: [createFixtureOperation({ blockHeight: 500 })],
+      syncHash: "tokens=off",
+      concordiumResources: { publicKey: PUBLIC_KEY },
+    } as unknown as ConcordiumAccount;
+
+    await getAccountShape({
+      currency: createFixtureCurrency(),
+      derivationMode: "",
+      derivationPath: "44'/1'/0'/0'/0'/0'",
+      index: 0,
+      initialAccount,
+      rest: { publicKey: PUBLIC_KEY },
+    });
+
+    expect(listOperations).toHaveBeenCalledWith(
+      config,
+      VALID_ADDRESS,
+      { minHeight: 501, limit: 100, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+});
+
+describe("getAccountShape with tokens enabled", () => {
+  const TOKEN = createFixtureTokenCurrency();
+  const SUB_ACCOUNT_ID = encodeTokenAccountId("js:2:concordium_testnet:" + PUBLIC_KEY + ":", TOKEN);
+  const tokensOnConfig = { ...config, enableTokens: true };
+
+  const PLT_ENTRY = {
+    token: { tokenId: PLT_TOKEN_ID, tokenState: { decimals: 6, moduleState: {} } },
+    tokenAccountState: { balance: { value: "500000", decimals: 6 } },
+  };
+
+  const pltRawOp = () =>
+    createRawOpFixture({
+      hash: "dd".repeat(32),
+      id: 102,
+      tokenId: PLT_TOKEN_ID,
+      decimals: 6,
+      amount: "3000000",
+      value: "3000000",
+      fee: "595400",
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    coinConfig.getCoinConfig.mockReturnValue(tokensOnConfig);
+    mockCryptoAssetsStore = {
+      findTokenById: async () => undefined,
+      getTokensSyncHash: jest.fn(async () => "cal-hash"),
+      findTokenByAddressInCurrency: async (address: string) =>
+        address === PLT_TOKEN_ID ? TOKEN : undefined,
+    };
+
+    getAccountsByPublicKey.mockResolvedValue([{ address: VALID_ADDRESS }]);
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: {
+        accountAmount: "10000000",
+        accountAtDisposal: "9900000",
+        accountTokens: [PLT_ENTRY],
+      },
+    });
+    listOperations.mockResolvedValue({ items: [], next: undefined });
+    getConsensusInfo.mockResolvedValue({ lastFinalizedBlockHeight: 5000 });
+  });
+
+  afterEach(() => {
+    mockCryptoAssetsStore = null;
+    coinConfig.getCoinConfig.mockReturnValue(config);
+  });
+
+  const shape = (initialAccount?: ConcordiumAccount, blacklistedTokenIds?: string[]) =>
+    getAccountShape(
+      {
+        currency: createFixtureCurrency(),
+        derivationMode: "",
+        derivationPath: "44'/1'/0'/0'/0'/0'",
+        index: 0,
+        ...(initialAccount ? { initialAccount } : {}),
+        rest: { publicKey: PUBLIC_KEY },
+      },
+      blacklistedTokenIds ? { blacklistedTokenIds } : undefined,
+    );
+
+  it("lands a fetched transfer on the sub-account of the token it moved", async () => {
+    listOperations.mockResolvedValue({ items: [pltRawOp()], next: undefined });
+
+    const result = await shape();
+
+    const subAccount = result.subAccounts?.[0];
+    expect(subAccount?.id).toBe(SUB_ACCOUNT_ID);
+    expect(subAccount?.operations).toHaveLength(1);
+    expect(subAccount?.operations[0].value).toEqual(new BigNumber("3000000"));
+  });
+
+  it("leaves only the CCD fee for that transfer on the parent account", async () => {
+    listOperations.mockResolvedValue({ items: [pltRawOp()], next: undefined });
+
+    const result = await shape();
+
+    expect(result.operations).toHaveLength(1);
+    expect(result.operations?.[0].type).toBe("FEES");
+    expect(result.operations?.[0].value).toEqual(new BigNumber("595400"));
+  });
+
+  it("records a syncHash that names both the CAL and the on state", async () => {
+    const result = await shape();
+
+    expect(result.syncHash).toMatch(/^0x[0-9a-f]+:tokens=on$/);
+  });
+
+  it("gives two different blacklists two different syncHashes", async () => {
+    const first = await shape(undefined, ["a"]);
+    const second = await shape(undefined, ["b"]);
+
+    expect(first.syncHash).not.toBe(second.syncHash);
+  });
+
+  it("re-reads from zero when the flag has just been turned on", async () => {
+    await shape(storedAccount({ syncHash: "tokens=off" }));
+
+    expect(listOperations).toHaveBeenCalledWith(
+      tokensOnConfig,
+      VALID_ADDRESS,
+      { minHeight: 0, limit: 100, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+
+  it("does not re-read on a transient CAL outage, keeping the stored hash", async () => {
+    const stored = await shape();
+    (mockCryptoAssetsStore as { getTokensSyncHash: jest.Mock }).getTokensSyncHash.mockRejectedValue(
+      new Error("CAL down"),
+    );
+
+    const result = await shape(storedAccount({ syncHash: stored.syncHash }));
+
+    expect(result.syncHash).toBe(stored.syncHash);
+    expect(listOperations).toHaveBeenLastCalledWith(
+      tokensOnConfig,
+      VALID_ADDRESS,
+      { minHeight: 501, limit: 100, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+
+  it("labels a first sync off when the CAL is down, so the next one re-reads", async () => {
+    (mockCryptoAssetsStore as { getTokensSyncHash: jest.Mock }).getTokensSyncHash.mockRejectedValue(
+      new Error("CAL down"),
+    );
+
+    const result = await shape();
+
+    expect(result.syncHash).toBe("tokens=off");
+  });
+
+  it("invalidates the syncHash when a balance failure leaves transfers unattributed", async () => {
+    getAccountBalance.mockRejectedValue(new Error("balance endpoint down"));
+    listOperations.mockResolvedValue({ items: [pltRawOp()], next: undefined });
+
+    const result = await shape();
+
+    expect(result.syncHash).toBe("refetch-pending");
+  });
+
+  it("keeps the computed syncHash when a balance failure cost it no transfers", async () => {
+    getAccountBalance.mockRejectedValue(new Error("balance endpoint down"));
+
+    const result = await shape();
+
+    expect(result.syncHash).toMatch(/:tokens=on$/);
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
@@ -826,6 +826,33 @@ describe("getAccountShape with tokens enabled", () => {
     expect(result.syncHash).toBe("refetch-pending");
   });
 
+  it("re-reads from zero on the first healthy sync after transfers went unattributed", async () => {
+    await shape(storedAccount({ syncHash: "refetch-pending" }));
+
+    expect(listOperations).toHaveBeenLastCalledWith(
+      tokensOnConfig,
+      VALID_ADDRESS,
+      { minHeight: 0, limit: 100, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+
+  it("defers that re-read while the CAL is still down, rather than losing it", async () => {
+    (mockCryptoAssetsStore as { getTokensSyncHash: jest.Mock }).getTokensSyncHash.mockRejectedValue(
+      new Error("CAL down"),
+    );
+
+    const result = await shape(storedAccount({ syncHash: "refetch-pending" }));
+
+    expect(result.syncHash).toBe("refetch-pending");
+    expect(listOperations).toHaveBeenLastCalledWith(
+      tokensOnConfig,
+      VALID_ADDRESS,
+      { minHeight: 501, limit: 100, order: "desc" },
+      CURRENCY_ID,
+    );
+  });
+
   it("keeps the computed syncHash when a balance failure cost it no transfers", async () => {
     getAccountBalance.mockRejectedValue(new Error("balance endpoint down"));
 

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.ts
@@ -22,6 +22,7 @@ import { mapRawOperationToBridgeOperation } from "./serialization";
 import {
   applyTokensToResources,
   buildParentOperation,
+  effectiveSubAccounts,
   resolveTokenSubAccounts,
   subAccountsPatch,
 } from "./tokens";
@@ -276,14 +277,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
     const unattributed =
       resolvedTokens.kind !== "cleared" && resolvedTokens.unattributedOperations === true;
 
-    // What the account ends up holding: `unchanged` keeps the stored list, and
-    // `cleared` has none, so neither can be read off `resolvedTokens` alone.
-    const subAccounts =
-      resolvedTokens.kind === "resolved"
-        ? resolvedTokens.subAccounts
-        : resolvedTokens.kind === "unchanged"
-          ? (initialAccount?.subAccounts ?? [])
-          : [];
+    const subAccounts = effectiveSubAccounts(resolvedTokens, initialAccount?.subAccounts);
 
     return {
       balance,

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
-import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
-import { type GetAccountShape, mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
+import { encodeAccountId, getSyncHash } from "@ledgerhq/ledger-wallet-framework/account/index";
+import type { GetAccountShape } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import type { Operation } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
 import coinConfig from "../config";
@@ -10,9 +10,20 @@ import {
   getConsensusInfo,
 } from "../network/proxyClient";
 import { listOperations } from "../logic/history/listOperations";
-import type { ConcordiumAccount, ConcordiumResources, PltAccountToken } from "../types";
+import type {
+  ConcordiumAccount,
+  ConcordiumResources,
+  PltAccountToken,
+  RawOperation,
+} from "../types";
+import { mergeOperations } from "./operations";
 import { mapRawOperationToBridgeOperation } from "./serialization";
-import { applyTokensToResources, resolveTokenSubAccounts, subAccountsPatch } from "./tokens";
+import {
+  applyTokensToResources,
+  buildParentOperation,
+  resolveTokenSubAccounts,
+  subAccountsPatch,
+} from "./tokens";
 
 const fillConcordiumResources = (
   existing: Partial<ConcordiumResources> = {},
@@ -76,14 +87,59 @@ export async function getBalance(
   };
 }
 
+const TOKENS_OFF_SYNC_HASH = "tokens=off";
+
+/**
+ * Stored in place of the computed hash by a sync that fetched PLT transfers it
+ * could not attribute. It matches nothing `computeSyncHash` returns, so the
+ * next sync re-reads from height zero and picks them up.
+ */
+const REFETCH_SYNC_HASH = "refetch-pending";
+
+/**
+ * Names the assumptions the stored history was built under. Operations are the
+ * one thing a sync does not re-derive, so PLT transfers dropped while the flag
+ * was off would stay behind the watermark once it went on. Both flag states are
+ * represented; preserving the stored hash through the off state, as coin-aleo
+ * does, would let the round trip go unnoticed.
+ *
+ * The off state is a constant so the CAL is never consulted while the feature
+ * is off, and a CAL failure while it is on keeps the stored hash rather than
+ * invalidating on a transient outage.
+ */
+async function computeSyncHash(
+  currencyId: string,
+  enableTokens: boolean,
+  blacklistedTokenIds: string[] | undefined,
+  previous: string | undefined,
+): Promise<string> {
+  if (!enableTokens) return TOKENS_OFF_SYNC_HASH;
+
+  try {
+    return `${await getSyncHash(currencyId, blacklistedTokenIds)}:tokens=on`;
+  } catch (error) {
+    log("concordium-sync", "Could not read the CAL sync hash, keeping the stored one", { error });
+    return previous ?? TOKENS_OFF_SYNC_HASH;
+  }
+}
+
+/**
+ * Fetches this account's operations and separates the two kinds it can hold.
+ * The token half is returned unmapped: attributing it needs the sub-account id,
+ * and that needs a CAL lookup this layer does not perform.
+ *
+ * With tokens off, PLT transfers are discarded outright rather than reduced to
+ * their fee; `syncHash` covers the flag, so turning it on re-reads from zero.
+ */
 export async function syncOperations(
   currencyId: string,
   address: string,
   accountId: string,
   oldOperations: Operation[],
-): Promise<Operation[]> {
+  { enableTokens, refetchAll = false }: { enableTokens: boolean; refetchAll?: boolean },
+): Promise<{ operations: Operation[]; pltOperations: RawOperation[] }> {
   const lastBlockHeight = oldOperations[0]?.blockHeight ?? 0;
-  const minHeight = lastBlockHeight > 0 ? lastBlockHeight + 1 : 0;
+  const minHeight = refetchAll || lastBlockHeight === 0 ? 0 : lastBlockHeight + 1;
 
   const config = coinConfig.getCoinConfig(currencyId);
   const result = await listOperations(
@@ -95,11 +151,26 @@ export async function syncOperations(
     log("concordium-sync", `Error fetching operations for account with address ${address}`, {
       error,
     });
-    return { items: [] as const, next: undefined };
+    return { items: [] as RawOperation[], next: undefined };
   });
 
-  const newOperations = result.items.map(op => mapRawOperationToBridgeOperation(op, accountId));
-  return mergeOps(oldOperations, newOperations);
+  const nativeItems: RawOperation[] = [];
+  const pltOperations: RawOperation[] = [];
+
+  for (const op of result.items) {
+    if (op.tokenId === undefined) {
+      nativeItems.push(op);
+    } else if (enableTokens) {
+      pltOperations.push(op);
+    }
+  }
+
+  const newOperations = [
+    ...nativeItems.map(op => mapRawOperationToBridgeOperation(op, accountId)),
+    ...pltOperations.map(op => buildParentOperation(op, accountId)),
+  ];
+
+  return { operations: mergeOperations(oldOperations, newOperations), pltOperations };
 }
 
 export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, syncConfig) => {
@@ -148,14 +219,31 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
 
     const account = accountsResponse[0];
 
-    const [{ balance, spendableBalance, accountTokens }, operations, blockHeight] =
-      await Promise.all([
-        getBalance(currency.id, account.address),
-        syncOperations(currency.id, account.address, accountId, initialAccount?.operations ?? []),
-        getConsensusInfo(config, currency.id)
-          .then(info => info.lastFinalizedBlockHeight)
-          .catch(() => 0),
-      ]);
+    const syncHash = await computeSyncHash(
+      currency.id,
+      config.enableTokens,
+      syncConfig?.blacklistedTokenIds,
+      initialAccount?.syncHash,
+    );
+
+    // Lowers the watermark rather than dropping what is stored: a fetch returns
+    // one page, so discarding first would truncate a longer history to it.
+    const refetchAll = initialAccount !== undefined && initialAccount.syncHash !== syncHash;
+
+    const [
+      { balance, spendableBalance, accountTokens },
+      { operations, pltOperations },
+      blockHeight,
+    ] = await Promise.all([
+      getBalance(currency.id, account.address),
+      syncOperations(currency.id, account.address, accountId, initialAccount?.operations ?? [], {
+        enableTokens: config.enableTokens,
+        refetchAll,
+      }),
+      getConsensusInfo(config, currency.id)
+        .then(info => info.lastFinalizedBlockHeight)
+        .catch(() => 0),
+    ]);
 
     const resolvedTokens = await resolveTokenSubAccounts({
       enableTokens: config.enableTokens,
@@ -163,10 +251,14 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
       accountId,
       accountTokens,
       initialAccount,
+      pltOperations,
       ...(syncConfig?.blacklistedTokenIds
         ? { blacklistedTokenIds: syncConfig.blacklistedTokenIds }
         : {}),
     });
+
+    const unattributed =
+      resolvedTokens.kind !== "cleared" && resolvedTokens.unattributedOperations === true;
 
     return {
       balance,
@@ -188,6 +280,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
       operations,
       operationsCount: operations.length,
       spendableBalance,
+      syncHash: unattributed ? REFETCH_SYNC_HASH : syncHash,
       used: true,
       xpub: publicKey,
     };

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.ts
@@ -91,8 +91,13 @@ const TOKENS_OFF_SYNC_HASH = "tokens=off";
 
 /**
  * Stored in place of the computed hash by a sync that fetched PLT transfers it
- * could not attribute. It matches nothing `computeSyncHash` returns, so the
- * next sync re-reads from height zero and picks them up.
+ * could not attribute, so that the next sync mismatches and re-reads from
+ * height zero.
+ *
+ * A CAL outage is the one case that echoes this value back rather than
+ * mismatching, deferring the re-read. That costs nothing: attributing those
+ * transfers needs the CAL that is down, and the first healthy sync computes a
+ * real hash, mismatches, and picks them up.
  */
 const REFETCH_SYNC_HASH = "refetch-pending";
 

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { encodeAccountId, getSyncHash } from "@ledgerhq/ledger-wallet-framework/account/index";
-import type { GetAccountShape } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
+import { type GetAccountShape, mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import type { Operation } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
 import coinConfig from "../config";
@@ -10,13 +10,14 @@ import {
   getConsensusInfo,
 } from "../network/proxyClient";
 import { listOperations } from "../logic/history/listOperations";
+import { paginateOperations } from "../logic/history/paginate";
 import type {
   ConcordiumAccount,
   ConcordiumResources,
   PltAccountToken,
   RawOperation,
 } from "../types";
-import { mergeOperations } from "./operations";
+import { attachSubOperations } from "./operations";
 import { mapRawOperationToBridgeOperation } from "./serialization";
 import {
   applyTokensToResources,
@@ -87,30 +88,30 @@ export async function getBalance(
   };
 }
 
+/** The proxy's documented ceiling; anything larger is silently clamped to it. */
+const PAGE_SIZE = 1000;
+
 const TOKENS_OFF_SYNC_HASH = "tokens=off";
 
 /**
- * Stored in place of the computed hash by a sync that fetched PLT transfers it
- * could not attribute, so that the next sync mismatches and re-reads from
- * height zero.
+ * Stored by a sync that fetched PLT transfers it could not attribute, so the
+ * next one mismatches and re-reads from height zero.
  *
- * A CAL outage is the one case that echoes this value back rather than
- * mismatching, deferring the re-read. That costs nothing: attributing those
- * transfers needs the CAL that is down, and the first healthy sync computes a
- * real hash, mismatches, and picks them up.
+ * It stays set for as long as the cause lasts. The causes are transient by
+ * construction — a balance response without its token list, a CAL that will not
+ * answer — so the re-read repeats while the fault does and stops when it lifts.
+ * Anything permanent is kept out of this marker at the `tokens.ts` end.
  */
 const REFETCH_SYNC_HASH = "refetch-pending";
 
 /**
- * Names the assumptions the stored history was built under. Operations are the
- * one thing a sync does not re-derive, so PLT transfers dropped while the flag
- * was off would stay behind the watermark once it went on. Both flag states are
- * represented; preserving the stored hash through the off state, as coin-aleo
- * does, would let the round trip go unnoticed.
+ * Names the assumptions the stored history was built under. Both flag states
+ * are represented, because preserving the stored hash through the off state (as
+ * coin-aleo does) would let a round trip go unnoticed.
  *
  * The off state is a constant so the CAL is never consulted while the feature
- * is off, and a CAL failure while it is on keeps the stored hash rather than
- * invalidating on a transient outage.
+ * is off, and a failure while it is on keeps the stored hash rather than
+ * invalidating on an outage.
  */
 async function computeSyncHash(
   currencyId: string,
@@ -133,6 +134,9 @@ async function computeSyncHash(
  * The token half is returned unmapped: attributing it needs the sub-account id,
  * and that needs a CAL lookup this layer does not perform.
  *
+ * Every page is walked, incrementally as well as on a re-read: stopping at the
+ * first would strand anything older behind the watermark.
+ *
  * With tokens off, PLT transfers are discarded outright rather than reduced to
  * their fee; `syncHash` covers the flag, so turning it on re-reads from zero.
  */
@@ -144,25 +148,25 @@ export async function syncOperations(
   { enableTokens, refetchAll = false }: { enableTokens: boolean; refetchAll?: boolean },
 ): Promise<{ operations: Operation[]; pltOperations: RawOperation[] }> {
   const lastBlockHeight = oldOperations[0]?.blockHeight ?? 0;
-  const minHeight = refetchAll || lastBlockHeight === 0 ? 0 : lastBlockHeight + 1;
+  // Reading from zero and discarding are one decision: the walk is a superset of
+  // what was stored only when it started at the bottom.
+  const fromScratch = refetchAll || lastBlockHeight === 0;
+  const minHeight = fromScratch ? 0 : lastBlockHeight + 1;
 
   const config = coinConfig.getCoinConfig(currencyId);
-  const result = await listOperations(
-    config,
-    address,
-    { minHeight, limit: 100, order: "desc" },
-    currencyId,
-  ).catch(error => {
-    log("concordium-sync", `Error fetching operations for account with address ${address}`, {
-      error,
-    });
-    return { items: [] as RawOperation[], next: undefined };
-  });
+  const items = await paginateOperations(cursor =>
+    listOperations(
+      config,
+      address,
+      { minHeight, limit: PAGE_SIZE, order: "desc", ...(cursor ? { cursor } : {}) },
+      currencyId,
+    ),
+  );
 
   const nativeItems: RawOperation[] = [];
   const pltOperations: RawOperation[] = [];
 
-  for (const op of result.items) {
+  for (const op of items) {
     if (op.tokenId === undefined) {
       nativeItems.push(op);
     } else if (enableTokens) {
@@ -175,7 +179,9 @@ export async function syncOperations(
     ...pltOperations.map(op => buildParentOperation(op, accountId)),
   ];
 
-  return { operations: mergeOperations(oldOperations, newOperations), pltOperations };
+  // Keeping the old copies would resurrect operations this parser no longer
+  // produces, and `sameOp` ignores `hasFailed`, so a stale one would win.
+  return { operations: mergeOps(fromScratch ? [] : oldOperations, newOperations), pltOperations };
 }
 
 export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, syncConfig) => {
@@ -199,6 +205,12 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
     if (!accountsResponse?.length) {
       // An account that does not exist on chain holds no tokens, so this is
       // authoritative: clear rather than preserve.
+      //
+      // Its operations are not: nothing removes a transaction from the chain, so
+      // an empty list here is a fault rather than news, and `shouldMergeOps` is
+      // off, meaning whatever this returns is what the account keeps.
+      const storedOperations = initialAccount?.operations ?? [];
+
       return {
         balance: new BigNumber(0),
         blockHeight: 0,
@@ -214,8 +226,8 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
         derivationPath,
         id: accountId,
         index,
-        operations: [],
-        operationsCount: 0,
+        operations: storedOperations,
+        operationsCount: storedOperations.length,
         spendableBalance: new BigNumber(0),
         used: false,
         xpub: publicKey,
@@ -231,8 +243,6 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
       initialAccount?.syncHash,
     );
 
-    // Lowers the watermark rather than dropping what is stored: a fetch returns
-    // one page, so discarding first would truncate a longer history to it.
     const refetchAll = initialAccount !== undefined && initialAccount.syncHash !== syncHash;
 
     const [
@@ -257,6 +267,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
       accountTokens,
       initialAccount,
       pltOperations,
+      refetchAll,
       ...(syncConfig?.blacklistedTokenIds
         ? { blacklistedTokenIds: syncConfig.blacklistedTokenIds }
         : {}),
@@ -264,6 +275,15 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
 
     const unattributed =
       resolvedTokens.kind !== "cleared" && resolvedTokens.unattributedOperations === true;
+
+    // What the account ends up holding: `unchanged` keeps the stored list, and
+    // `cleared` has none, so neither can be read off `resolvedTokens` alone.
+    const subAccounts =
+      resolvedTokens.kind === "resolved"
+        ? resolvedTokens.subAccounts
+        : resolvedTokens.kind === "unchanged"
+          ? (initialAccount?.subAccounts ?? [])
+          : [];
 
     return {
       balance,
@@ -282,7 +302,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, 
       derivationPath,
       id: accountId,
       index,
-      operations,
+      operations: attachSubOperations(operations, subAccounts),
       operationsCount: operations.length,
       spendableBalance,
       syncHash: unattributed ? REFETCH_SYNC_HASH : syncHash,

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
@@ -665,4 +665,23 @@ describe("token operations on sub-accounts", () => {
     if (result.kind !== "resolved") throw new Error("expected resolved");
     expect(result.subAccounts).toHaveLength(0);
   });
+
+  it("asks for no re-read when the token is merely uncurated", async () => {
+    // The CAL hash already covers curation, so asking would re-read the whole
+    // history on every sync for as long as the account holds the token.
+    useStore({});
+
+    const result = await resolve({ pltOperations: [makeRawOp()] });
+
+    expect(result).not.toHaveProperty("unattributedOperations");
+  });
+
+  it("asks for a re-read when an entry is too malformed to name its token", async () => {
+    const result = await resolve({
+      accountTokens: [{} as unknown as PltAccountToken, makeEntry()],
+      pltOperations: [makeRawOp()],
+    });
+
+    expect(result).toMatchObject({ unattributedOperations: true });
+  });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
@@ -9,6 +9,7 @@ import {
 import type { Operation, TokenAccount } from "@ledgerhq/types-live";
 import {
   applyTokensToResources,
+  buildParentOperation,
   mergeSubAccounts,
   resolveTokenSubAccounts,
   stripSubAccounts,
@@ -19,6 +20,7 @@ import type {
   ConcordiumResources,
   PltAccountToken,
   PltModuleState,
+  RawOperation,
 } from "../types";
 
 const CURRENCY_ID = "concordium";
@@ -502,5 +504,165 @@ describe("initialAccount continuity", () => {
     if (result.kind !== "resolved") throw new Error("expected resolved");
     expect(result.subAccounts[0].balance).toEqual(new BigNumber("77"));
     expect(result.subAccounts[0].operations.map(op => op.id)).toEqual(["kept"]);
+  });
+});
+
+const makeRawOp = (over: Partial<RawOperation> = {}): RawOperation => ({
+  hash: "aa".repeat(32),
+  type: "OUT",
+  sender: "sender-address",
+  recipient: "recipient-address",
+  amount: "3000000",
+  fee: "595400",
+  value: "3000000",
+  memo: undefined,
+  date: new Date("2026-03-02T00:00:00Z"),
+  blockHash: "bb",
+  blockHeight: 900,
+  failed: false,
+  id: 1,
+  tokenId: TOKEN_ID,
+  decimals: 6,
+  ...over,
+});
+
+describe("buildParentOperation", () => {
+  it("charges an outgoing transfer's fee to the CCD account", () => {
+    const op = buildParentOperation(makeRawOp(), ACCOUNT_ID);
+
+    expect(op.type).toBe("FEES");
+    expect(op.value).toEqual(new BigNumber("595400"));
+    expect(op.fee).toEqual(new BigNumber("595400"));
+  });
+
+  it("leaves an incoming transfer worth nothing on the CCD account", () => {
+    const op = buildParentOperation(makeRawOp({ type: "IN", fee: "0" }), ACCOUNT_ID);
+
+    expect(op.type).toBe("NONE");
+    expect(op.value).toEqual(new BigNumber(0));
+  });
+
+  it("does not raise a FEES row for a fee of zero", () => {
+    expect(buildParentOperation(makeRawOp({ fee: "0" }), ACCOUNT_ID).type).toBe("NONE");
+  });
+
+  it("gives one transaction two ids if its type is ever revised", () => {
+    // Why the type is decided from the transaction alone and never revised:
+    // the id embeds it and mergeOps dedups on the id, so a parent reclassified
+    // between syncs is stored alongside its old self rather than replacing it.
+    const paid = buildParentOperation(makeRawOp({ fee: "595400" }), ACCOUNT_ID);
+    const unpaid = buildParentOperation(makeRawOp({ fee: "0" }), ACCOUNT_ID);
+
+    expect(paid.hash).toBe(unpaid.hash);
+    expect(paid.id).toContain("-FEES");
+    expect(unpaid.id).toContain("-NONE");
+    expect(paid.id).not.toBe(unpaid.id);
+  });
+
+  it("marks a rejected transfer as failed while still charging its fee", () => {
+    const op = buildParentOperation(makeRawOp({ failed: true, value: "0" }), ACCOUNT_ID);
+
+    expect(op.hasFailed).toBe(true);
+    expect(op.value).toEqual(new BigNumber("595400"));
+  });
+});
+
+describe("token operations on sub-accounts", () => {
+  const subAccountId = encodeTokenAccountId(ACCOUNT_ID, makeToken(TOKEN_ID));
+
+  beforeEach(() => {
+    useStore({ [TOKEN_ID]: makeToken(TOKEN_ID) });
+  });
+
+  it("attaches a transfer to the sub-account of the token it moved", async () => {
+    const result = await resolve({ pltOperations: [makeRawOp()] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    const [operation] = result.subAccounts[0].operations;
+    expect(operation.accountId).toBe(subAccountId);
+    expect(operation.value).toEqual(new BigNumber("3000000"));
+    expect(result.subAccounts[0].operationsCount).toBe(1);
+  });
+
+  it("gives a token only its own operations", async () => {
+    const result = await resolve({
+      pltOperations: [makeRawOp(), makeRawOp({ tokenId: "OTHER", hash: "cc".repeat(32) })],
+    });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts[0].operations).toHaveLength(1);
+  });
+
+  it("skips a transfer denominated differently from the curated token", async () => {
+    const result = await resolve({ pltOperations: [makeRawOp({ decimals: 2 })] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts[0].operations).toHaveLength(0);
+  });
+
+  it("keeps a rejected transfer, which reports no denomination at all", async () => {
+    const rejected = makeRawOp({ failed: true, value: "0" });
+    delete rejected.decimals;
+
+    const result = await resolve({ pltOperations: [rejected] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts[0].operations).toHaveLength(1);
+  });
+
+  it("dates the sub-account from its oldest operation whichever way the page is ordered", async () => {
+    const older = makeRawOp({ hash: "dd".repeat(32), date: new Date("2020-01-01T00:00:00Z") });
+
+    const newestFirst = await resolve({ pltOperations: [makeRawOp(), older] });
+    const oldestFirst = await resolve({ pltOperations: [older, makeRawOp()] });
+
+    if (newestFirst.kind !== "resolved" || oldestFirst.kind !== "resolved") {
+      throw new Error("expected resolved");
+    }
+    expect(newestFirst.subAccounts[0].creationDate).toEqual(new Date("2020-01-01T00:00:00Z"));
+    expect(oldestFirst.subAccounts[0].creationDate).toEqual(new Date("2020-01-01T00:00:00Z"));
+  });
+
+  it("neither duplicates nor drops operations across a re-sync", async () => {
+    const stored = makeRawOp();
+    const first = await resolve({ pltOperations: [stored] });
+    if (first.kind !== "resolved") throw new Error("expected resolved");
+
+    const initialAccount = { subAccounts: first.subAccounts } as unknown as ConcordiumAccount;
+
+    // The same transfer comes back alongside a newer one, as it does whenever a
+    // page overlaps the stored history.
+    const second = await resolve({
+      initialAccount,
+      pltOperations: [makeRawOp({ hash: "ee".repeat(32), id: 2 }), stored],
+    });
+
+    if (second.kind !== "resolved") throw new Error("expected resolved");
+    const ids = second.subAccounts[0].operations.map(op => op.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toHaveLength(2);
+  });
+
+  it("keeps a transfer older than everything the sub-account already holds", async () => {
+    const stored = makeRawOp({ date: new Date("2024-06-01T00:00:00Z") });
+    const first = await resolve({ pltOperations: [stored] });
+    if (first.kind !== "resolved") throw new Error("expected resolved");
+
+    const initialAccount = { subAccounts: first.subAccounts } as unknown as ConcordiumAccount;
+    const older = makeRawOp({ hash: "ee".repeat(32), id: 2, date: new Date("2020-01-01") });
+
+    const second = await resolve({ initialAccount, pltOperations: [older] });
+
+    if (second.kind !== "resolved") throw new Error("expected resolved");
+    expect(second.subAccounts[0].operations.map(op => op.hash)).toContain("ee".repeat(32));
+  });
+
+  it("publishes no operations for a token the CAL does not curate", async () => {
+    useStore({});
+
+    const result = await resolve({ pltOperations: [makeRawOp()] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts).toHaveLength(0);
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
@@ -643,7 +643,7 @@ describe("token operations on sub-accounts", () => {
     expect(ids).toHaveLength(2);
   });
 
-  it("keeps a transfer older than everything the sub-account already holds", async () => {
+  it("replaces the sub-account's operations on a re-read, as the parent account does", async () => {
     const stored = makeRawOp({ date: new Date("2024-06-01T00:00:00Z") });
     const first = await resolve({ pltOperations: [stored] });
     if (first.kind !== "resolved") throw new Error("expected resolved");
@@ -651,10 +651,10 @@ describe("token operations on sub-accounts", () => {
     const initialAccount = { subAccounts: first.subAccounts } as unknown as ConcordiumAccount;
     const older = makeRawOp({ hash: "ee".repeat(32), id: 2, date: new Date("2020-01-01") });
 
-    const second = await resolve({ initialAccount, pltOperations: [older] });
+    const second = await resolve({ initialAccount, pltOperations: [older], refetchAll: true });
 
     if (second.kind !== "resolved") throw new Error("expected resolved");
-    expect(second.subAccounts[0].operations.map(op => op.hash)).toContain("ee".repeat(32));
+    expect(second.subAccounts[0].operations.map(op => op.hash)).toEqual(["ee".repeat(32)]);
   });
 
   it("publishes no operations for a token the CAL does not curate", async () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -96,6 +96,16 @@ export function applyTokensToResources(
   }
 }
 
+/** Reduced rather than spread into `Math.min`, which overflows the stack on a long history. */
+function oldestDate(operations: Operation[]): Date {
+  return new Date(
+    operations.reduce(
+      (earliest, operation) => Math.min(earliest, operation.date.valueOf()),
+      Infinity,
+    ),
+  );
+}
+
 function buildTokenAccount(
   id: string,
   parentId: string,
@@ -112,10 +122,7 @@ function buildTokenAccount(
     spendableBalance: balance,
     // Only used for a sub-account this sync invented; `mergeSubAccounts` keeps
     // the stored date for an existing one.
-    creationDate:
-      operations.length > 0
-        ? new Date(Math.min(...operations.map(operation => operation.date.valueOf())))
-        : new Date(),
+    creationDate: operations.length > 0 ? oldestDate(operations) : new Date(),
     operations,
     operationsCount: operations.length,
     pendingOperations: [],

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -1,18 +1,19 @@
 import BigNumber from "bignumber.js";
 import { emptyHistoryCache, encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
-import { mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
 import { log } from "@ledgerhq/logs";
-import type { TokenAccount } from "@ledgerhq/types-live";
+import type { Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { getAccountListStatus, isDecodedPltState } from "../network/plt";
+import { baseOperation, mergeOperations, toOperation } from "./operations";
 import type {
   ConcordiumAccount,
   ConcordiumResources,
   ConcordiumTokenResources,
   PltAccountToken,
   PltTransferStatus,
+  RawOperation,
   Transaction,
 } from "../types";
 
@@ -27,11 +28,12 @@ const CAL_LOOKUP_CONCURRENCY = 4;
  */
 export type ResolvedTokens =
   | { kind: "cleared" }
-  | { kind: "unchanged" }
+  | { kind: "unchanged"; unattributedOperations?: true }
   | {
       kind: "resolved";
       subAccounts: TokenAccount[];
       tokens: Record<string, ConcordiumTokenResources>;
+      unattributedOperations?: true;
     };
 
 /**
@@ -99,6 +101,7 @@ function buildTokenAccount(
   parentId: string,
   token: TokenCurrency,
   balance: BigNumber,
+  operations: Operation[],
 ): TokenAccount {
   return {
     type: "TokenAccount",
@@ -107,13 +110,43 @@ function buildTokenAccount(
     token,
     balance,
     spendableBalance: balance,
-    creationDate: new Date(),
-    operations: [],
-    operationsCount: 0,
+    // Only used for a sub-account this sync invented; `mergeSubAccounts` keeps
+    // the stored date for an existing one.
+    creationDate:
+      operations.length > 0
+        ? new Date(Math.min(...operations.map(operation => operation.date.valueOf())))
+        : new Date(),
+    operations,
+    operationsCount: operations.length,
     pendingOperations: [],
     balanceHistoryCache: emptyHistoryCache,
     swapHistory: [],
   };
+}
+
+/**
+ * Builds the CCD operation a PLT transfer leaves on the parent account.
+ *
+ * The type is decided from the transaction alone and never revised: an
+ * operation id embeds its type and `mergeOps` dedups on that id, so one retyped
+ * between syncs is stored twice, permanently. Promoting a stored `NONE` to
+ * `FEES` later is therefore not an option, and is never needed, since whether
+ * the account paid is known when the transaction is read.
+ *
+ * A zero fee stays `NONE`, which also keeps an incoming transfer out of the
+ * parent's history: `NONE` operations are dropped from every list.
+ */
+export function buildParentOperation(op: RawOperation, accountId: string): Operation {
+  const fee = new BigNumber(op.fee);
+  const paysFee = fee.isGreaterThan(0);
+
+  return baseOperation(
+    op,
+    accountId,
+    paysFee ? "FEES" : "NONE",
+    // `FEES` is an outgoing type, so this value is what gets debited from CCD.
+    paysFee ? fee : new BigNumber(0),
+  );
 }
 
 /**
@@ -183,7 +216,7 @@ export function mergeSubAccounts(
     const old = previousById.get(newSubAccount.id);
     if (!old) return newSubAccount;
 
-    const operations = mergeOps(old.operations, newSubAccount.operations);
+    const operations = mergeOperations(old.operations, newSubAccount.operations);
 
     return {
       ...old,
@@ -207,6 +240,37 @@ type ResolvedEntry =
   | { entry: PltAccountToken; token: TokenCurrency; tokenId: string; balance: BigNumber }
   | { untrusted: string; tokenId: string }
   | undefined;
+
+/**
+ * `resolveEntries` already refuses to publish a balance whose decimals disagree
+ * with CAL; the same disagreement per transfer would render the amount at the
+ * wrong scale, so it is dropped. A rejected transfer reports no denomination at
+ * all, which is an absence rather than a disagreement, and passes.
+ */
+function operationsForToken(
+  pltOperations: RawOperation[],
+  tokenId: string,
+  token: TokenCurrency,
+  subAccountId: string,
+): Operation[] {
+  const magnitude = token.units[0]?.magnitude;
+
+  return pltOperations
+    .filter(op => {
+      if (op.tokenId !== tokenId) return false;
+
+      if (op.decimals !== undefined && op.decimals !== magnitude) {
+        log(
+          "concordium-sync",
+          `PLT ${tokenId} operation ${op.hash} is denominated in ${op.decimals} decimals, not the curated ${magnitude}, skipping it`,
+        );
+        return false;
+      }
+
+      return true;
+    })
+    .map(op => toOperation(op, subAccountId));
+}
 
 /**
  * Resolves to `undefined` when the lookup itself failed, which is distinct from
@@ -290,6 +354,16 @@ function resolveEntries({
 }
 
 /**
+ * Reports that this sync fetched PLT transfers it could not place on a
+ * sub-account. The caller invalidates the stored `syncHash` on it, because the
+ * parent fee operations are kept either way: the watermark moves past those
+ * blocks and an incremental sync would never read them again.
+ */
+function unattributed(pltOperations: RawOperation[]): { unattributedOperations?: true } {
+  return pltOperations.length > 0 ? { unattributedOperations: true } : {};
+}
+
+/**
  * Builds the token sub-accounts and the per-token state for one sync.
  *
  * Only an actual array is authoritative enough to drop a token the account no
@@ -305,6 +379,7 @@ export async function resolveTokenSubAccounts({
   accountId,
   accountTokens,
   initialAccount,
+  pltOperations = [],
   blacklistedTokenIds = [],
 }: {
   enableTokens: boolean;
@@ -312,6 +387,7 @@ export async function resolveTokenSubAccounts({
   accountId: string;
   accountTokens: PltAccountToken[] | undefined;
   initialAccount: ConcordiumAccount | undefined;
+  pltOperations?: RawOperation[];
   blacklistedTokenIds?: string[];
 }): Promise<ResolvedTokens> {
   if (!enableTokens) {
@@ -320,7 +396,7 @@ export async function resolveTokenSubAccounts({
 
   if (!Array.isArray(accountTokens)) {
     log("concordium-sync", "PLT token list absent from the balance response, keeping known tokens");
-    return { kind: "unchanged" };
+    return { kind: "unchanged", ...unattributed(pltOperations) };
   }
 
   const resolved = await resolveEntries({
@@ -335,12 +411,13 @@ export async function resolveTokenSubAccounts({
   // it escape would discard an already-fetched CCD sync because a secondary
   // metadata service was down.
   if (resolved === undefined) {
-    return { kind: "unchanged" };
+    return { kind: "unchanged", ...unattributed(pltOperations) };
   }
 
   const newSubAccounts: TokenAccount[] = [];
   const tokens: Record<string, ConcordiumTokenResources> = {};
   const untrustedIds = new Set<string>();
+  const untrustedTokenIds = new Set<string>();
   const seenIds = new Set<string>();
 
   for (const item of resolved) {
@@ -348,6 +425,7 @@ export async function resolveTokenSubAccounts({
 
     if ("untrusted" in item) {
       untrustedIds.add(item.untrusted);
+      untrustedTokenIds.add(item.tokenId);
 
       // The sub-account survives through `keepIds`, but the resources map is
       // rebuilt wholesale, so its prior entry has to be carried over with it.
@@ -368,7 +446,15 @@ export async function resolveTokenSubAccounts({
     }
     seenIds.add(subAccountId);
 
-    newSubAccounts.push(buildTokenAccount(subAccountId, accountId, token, balance));
+    newSubAccounts.push(
+      buildTokenAccount(
+        subAccountId,
+        accountId,
+        token,
+        balance,
+        operationsForToken(pltOperations, tokenId, token, subAccountId),
+      ),
+    );
 
     const paused = readPaused(entry);
     tokens[tokenId] = {
@@ -381,6 +467,7 @@ export async function resolveTokenSubAccounts({
     kind: "resolved",
     subAccounts: mergeSubAccounts(initialAccount?.subAccounts, newSubAccounts, untrustedIds),
     tokens,
+    ...unattributed(pltOperations.filter(op => untrustedTokenIds.has(op.tokenId ?? ""))),
   };
 }
 

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -505,11 +505,12 @@ export async function resolveTokenSubAccounts({
     initialAccount,
   });
 
-  // Only for an entry too malformed to name its token. Every other reason a
-  // transfer is dropped here — uncurated, blacklisted, denomination disagreeing
-  // with the CAL — already moves `getSyncHash` when it is put right, so asking
-  // for a re-read would buy a wasted walk rather than a recovery.
-  const unreadableEntry = resolved.some(item => item === undefined);
+  // Asked of the entries rather than of `resolved`, which reports the same
+  // `undefined` for an uncurated or blacklisted token. Those are ordinary and
+  // are already covered by the CAL and blacklist inputs to `getSyncHash`, so
+  // treating them as unattributed would re-read the whole history every sync
+  // for as long as the account holds one.
+  const unreadableEntry = accountTokens.some(entry => !isUsableEntry(entry));
 
   return {
     kind: "resolved",

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -1,12 +1,13 @@
 import BigNumber from "bignumber.js";
 import { emptyHistoryCache, encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import { mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
 import { log } from "@ledgerhq/logs";
 import type { Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { getAccountListStatus, isDecodedPltState } from "../network/plt";
-import { baseOperation, mergeOperations, toOperation } from "./operations";
+import { baseOperation, toOperation } from "./operations";
 import type {
   ConcordiumAccount,
   ConcordiumResources,
@@ -214,6 +215,7 @@ export function mergeSubAccounts(
   previous: TokenAccount[] | undefined,
   newSubAccounts: TokenAccount[],
   keepIds: ReadonlySet<string> = new Set(),
+  refetchAll = false,
 ): TokenAccount[] {
   if (!previous?.length) return newSubAccounts;
 
@@ -223,7 +225,9 @@ export function mergeSubAccounts(
     const old = previousById.get(newSubAccount.id);
     if (!old) return newSubAccount;
 
-    const operations = mergeOperations(old.operations, newSubAccount.operations);
+    // Discarded on a re-read for the same reason the parent's history is: the
+    // walk covered every block, so it already holds everything stored here.
+    const operations = mergeOps(refetchAll ? [] : old.operations, newSubAccount.operations);
 
     return {
       ...old,
@@ -361,6 +365,77 @@ function resolveEntries({
 }
 
 /**
+ * Turns the resolved entries into the sub-accounts and per-token state one sync
+ * produces, plus the ids `mergeSubAccounts` must keep despite building none.
+ */
+function absorbEntries({
+  resolved,
+  accountId,
+  pltOperations,
+  initialAccount,
+}: {
+  resolved: ResolvedEntry[];
+  accountId: string;
+  pltOperations: RawOperation[];
+  initialAccount: ConcordiumAccount | undefined;
+}): {
+  newSubAccounts: TokenAccount[];
+  tokens: Record<string, ConcordiumTokenResources>;
+  keepIds: Set<string>;
+} {
+  const newSubAccounts: TokenAccount[] = [];
+  const tokens: Record<string, ConcordiumTokenResources> = {};
+  const keepIds = new Set<string>();
+  const seenIds = new Set<string>();
+
+  for (const item of resolved) {
+    if (!item) continue;
+
+    if ("untrusted" in item) {
+      keepIds.add(item.untrusted);
+
+      // The sub-account survives through `keepIds`, but the resources map is
+      // rebuilt wholesale, so its prior entry has to be carried over with it.
+      // Otherwise the send path sees a visible token with no transferStatus.
+      const priorState = initialAccount?.concordiumResources?.tokens?.[item.tokenId];
+      if (priorState) tokens[item.tokenId] = priorState;
+      continue;
+    }
+
+    const { entry, token, tokenId, balance } = item;
+    const subAccountId = encodeTokenAccountId(accountId, token);
+
+    // A duplicate id would otherwise produce two sub-accounts for one token,
+    // which the merge cannot reconcile. Only a malformed snapshot can cause it.
+    if (seenIds.has(subAccountId)) {
+      log("concordium-sync", `PLT ${tokenId} appears more than once, ignoring the repeat`);
+      continue;
+    }
+    seenIds.add(subAccountId);
+
+    newSubAccounts.push(
+      buildTokenAccount(
+        subAccountId,
+        accountId,
+        token,
+        balance,
+        // Through `mergeOps` so a fresh sub-account is deduped and ordered the
+        // same way an existing one is when this sync's operations reach it.
+        mergeOps([], operationsForToken(pltOperations, tokenId, token, subAccountId)),
+      ),
+    );
+
+    const paused = readPaused(entry);
+    tokens[tokenId] = {
+      transferStatus: resolveTransferStatus(entry),
+      ...(paused === undefined ? {} : { paused }),
+    };
+  }
+
+  return { newSubAccounts, tokens, keepIds };
+}
+
+/**
  * Reports that this sync fetched PLT transfers it could not place on a
  * sub-account. The caller invalidates the stored `syncHash` on it, because the
  * parent fee operations are kept either way: the watermark moves past those
@@ -388,6 +463,7 @@ export async function resolveTokenSubAccounts({
   initialAccount,
   pltOperations = [],
   blacklistedTokenIds = [],
+  refetchAll = false,
 }: {
   enableTokens: boolean;
   currencyId: string;
@@ -396,6 +472,7 @@ export async function resolveTokenSubAccounts({
   initialAccount: ConcordiumAccount | undefined;
   pltOperations?: RawOperation[];
   blacklistedTokenIds?: string[];
+  refetchAll?: boolean;
 }): Promise<ResolvedTokens> {
   if (!enableTokens) {
     return { kind: "cleared" };
@@ -421,60 +498,24 @@ export async function resolveTokenSubAccounts({
     return { kind: "unchanged", ...unattributed(pltOperations) };
   }
 
-  const newSubAccounts: TokenAccount[] = [];
-  const tokens: Record<string, ConcordiumTokenResources> = {};
-  const untrustedIds = new Set<string>();
-  const untrustedTokenIds = new Set<string>();
-  const seenIds = new Set<string>();
+  const { newSubAccounts, tokens, keepIds } = absorbEntries({
+    resolved,
+    accountId,
+    pltOperations,
+    initialAccount,
+  });
 
-  for (const item of resolved) {
-    if (!item) continue;
-
-    if ("untrusted" in item) {
-      untrustedIds.add(item.untrusted);
-      untrustedTokenIds.add(item.tokenId);
-
-      // The sub-account survives through `keepIds`, but the resources map is
-      // rebuilt wholesale, so its prior entry has to be carried over with it.
-      // Otherwise the send path sees a visible token with no transferStatus.
-      const priorState = initialAccount?.concordiumResources?.tokens?.[item.tokenId];
-      if (priorState) tokens[item.tokenId] = priorState;
-      continue;
-    }
-
-    const { entry, token, tokenId, balance } = item;
-    const subAccountId = encodeTokenAccountId(accountId, token);
-
-    // A duplicate id would otherwise produce two sub-accounts for one token,
-    // which the merge cannot reconcile. Only a malformed snapshot can cause it.
-    if (seenIds.has(subAccountId)) {
-      log("concordium-sync", `PLT ${tokenId} appears more than once, ignoring the repeat`);
-      continue;
-    }
-    seenIds.add(subAccountId);
-
-    newSubAccounts.push(
-      buildTokenAccount(
-        subAccountId,
-        accountId,
-        token,
-        balance,
-        operationsForToken(pltOperations, tokenId, token, subAccountId),
-      ),
-    );
-
-    const paused = readPaused(entry);
-    tokens[tokenId] = {
-      transferStatus: resolveTransferStatus(entry),
-      ...(paused === undefined ? {} : { paused }),
-    };
-  }
+  // Only for an entry too malformed to name its token. Every other reason a
+  // transfer is dropped here — uncurated, blacklisted, denomination disagreeing
+  // with the CAL — already moves `getSyncHash` when it is put right, so asking
+  // for a re-read would buy a wasted walk rather than a recovery.
+  const unreadableEntry = resolved.some(item => item === undefined);
 
   return {
     kind: "resolved",
-    subAccounts: mergeSubAccounts(initialAccount?.subAccounts, newSubAccounts, untrustedIds),
+    subAccounts: mergeSubAccounts(initialAccount?.subAccounts, newSubAccounts, keepIds, refetchAll),
     tokens,
-    ...unattributed(pltOperations.filter(op => untrustedTokenIds.has(op.tokenId ?? ""))),
+    ...(unreadableEntry ? unattributed(pltOperations) : {}),
   };
 }
 

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -76,6 +76,25 @@ export function subAccountsPatch(resolved: ResolvedTokens): { subAccounts?: Toke
 }
 
 /**
+ * The sub-accounts the account ends up holding, which {@link subAccountsPatch}
+ * cannot answer: it omits the key on `unchanged` precisely so the stored list
+ * survives, and the stored list is what anything reading the result needs.
+ */
+export function effectiveSubAccounts(
+  resolved: ResolvedTokens,
+  previous: TokenAccount[] | undefined,
+): TokenAccount[] {
+  switch (resolved.kind) {
+    case "resolved":
+      return resolved.subAccounts;
+    case "cleared":
+      return [];
+    case "unchanged":
+      return previous ?? [];
+  }
+}
+
+/**
  * Applies a {@link ResolvedTokens} to the account's resources.
  *
  * Clearing removes the key rather than setting it to `undefined`, matching

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.test.ts
@@ -175,6 +175,201 @@ describe("parseTransaction", () => {
   });
 });
 
+describe("parseTransaction, PLT", () => {
+  // Shaped after a real testnet tokenUpdate: a 6-decimal token, and a cost the
+  // proxy reports only to the sender.
+  const outgoingTx: WalletProxyTransaction = {
+    id: 2995554,
+    blockTime: 1761895039.005,
+    blockHash: "8372",
+    blockHeight: 34907771,
+    transactionHash: "4e41".repeat(16),
+    cost: 595400,
+    origin: { type: "self" },
+    total: -595400,
+    details: {
+      type: "tokenUpdate",
+      outcome: "success",
+      transferSource: VALID_ADDRESS,
+      transferDestination: VALID_ADDRESS_2,
+      tokenId: "trUSDT",
+      tokenTransferAmount: { value: "3000000", decimals: 6 },
+    },
+  };
+
+  // An incoming transfer omits `cost` entirely rather than reporting zero.
+  const incomingTx: WalletProxyTransaction = {
+    id: 2994831,
+    blockTime: 1761748654.85,
+    blockHash: "da2e",
+    blockHeight: 34834600,
+    transactionHash: "ebcf".repeat(16),
+    origin: { type: "account", address: VALID_ADDRESS_2 },
+    total: 0,
+    details: {
+      type: "tokenUpdate",
+      outcome: "success",
+      transferSource: VALID_ADDRESS_2,
+      transferDestination: VALID_ADDRESS,
+      tokenId: "trUSDT",
+      tokenTransferAmount: { value: "20000000", decimals: 6 },
+    },
+  };
+
+  beforeEach(() => {
+    const { decodeMemoFromCbor } = jest.requireMock("@ledgerhq/concordium-core");
+    decodeMemoFromCbor.mockReset();
+    decodeMemoFromCbor.mockReturnValue("decoded memo");
+  });
+
+  it("parses an outgoing PLT transfer, carrying the token and its denomination", () => {
+    expect(parseTransaction(outgoingTx, VALID_ADDRESS)).toMatchObject({
+      type: "OUT",
+      sender: VALID_ADDRESS,
+      recipient: VALID_ADDRESS_2,
+      amount: "3000000",
+      fee: "595400",
+      tokenId: "trUSDT",
+      decimals: 6,
+      failed: false,
+    });
+  });
+
+  it("values an outgoing PLT transfer at the token amount, never the amount plus the fee", () => {
+    expect(parseTransaction(outgoingTx, VALID_ADDRESS)!.value).toBe("3000000");
+  });
+
+  it("parses an incoming PLT transfer with no fee, since the recipient paid none", () => {
+    expect(parseTransaction(incomingTx, VALID_ADDRESS)).toMatchObject({
+      type: "IN",
+      value: "20000000",
+      fee: "0",
+      tokenId: "trUSDT",
+    });
+  });
+
+  it("ignores a cost reported on a row the account did not pay for", () => {
+    // Reading it would raise a FEES operation debiting the recipient's CCD, and
+    // an operation id embeds its type, so the correction could not replace it.
+    const withCost = { ...incomingTx, cost: 595400 } as WalletProxyTransaction;
+
+    expect(parseTransaction(withCost, VALID_ADDRESS)!.fee).toBe("0");
+  });
+
+  it("decodes a PLT memo, which is CBOR exactly as a CCD memo is", () => {
+    const tx = { ...outgoingTx, details: { ...outgoingTx.details, memo: "78ab31" } };
+
+    expect(parseTransaction(tx, VALID_ADDRESS)!.memo).toBe("decoded memo");
+  });
+
+  it("returns null when the address is neither source nor destination", () => {
+    expect(parseTransaction(outgoingTx, "someone-else")).toBeNull();
+  });
+
+  const nonTransfer: WalletProxyTransaction = {
+    ...outgoingTx,
+    details: { type: "tokenUpdate", outcome: "success", description: "Token update" },
+  };
+
+  it("charges the payer for a tokenUpdate that is not a transfer, rather than losing it", () => {
+    // A mint, burn, pause or batch: nothing token-side is readable, but the CCD
+    // left the account and would otherwise show as an unexplained debit.
+    expect(parseTransaction(nonTransfer, VALID_ADDRESS)).toMatchObject({
+      type: "OUT",
+      value: "595400",
+      fee: "595400",
+      failed: false,
+    });
+    expect(parseTransaction(nonTransfer, VALID_ADDRESS)).not.toHaveProperty("tokenId");
+  });
+
+  it("returns null for a non-transfer tokenUpdate the account did not pay for", () => {
+    const paidByAnother = { ...nonTransfer, origin: { type: "account" } } as WalletProxyTransaction;
+
+    expect(parseTransaction(paidByAnother, VALID_ADDRESS)).toBeNull();
+  });
+
+  it("does not read an absent transfer amount as zero", () => {
+    const { tokenTransferAmount: _dropped, ...detailsWithoutAmount } = outgoingTx.details;
+    const tx: WalletProxyTransaction = { ...outgoingTx, details: detailsWithoutAmount };
+
+    expect(parseTransaction(tx, VALID_ADDRESS)).toMatchObject({ amount: "0", value: "595400" });
+  });
+
+  it("refuses a denomination that is not a whole non-negative count of decimals", () => {
+    const withBadDecimals = {
+      ...outgoingTx,
+      details: {
+        ...outgoingTx.details,
+        tokenTransferAmount: { value: "3000000", decimals: -1 },
+      },
+    } as WalletProxyTransaction;
+
+    expect(parseTransaction(withBadDecimals, VALID_ADDRESS)).not.toHaveProperty("decimals");
+  });
+
+  describe("rejected", () => {
+    const rejectedTx: WalletProxyTransaction = {
+      ...outgoingTx,
+      details: {
+        type: "tokenUpdate",
+        outcome: "reject",
+        rejectReason: "Token update transaction failed",
+        rawRejectReason: {
+          tag: "TokenUpdateTransactionFailed",
+          contents: { tokenId: "trUSDT", type: "operationNotPermitted" },
+        },
+      },
+    };
+
+    it("keeps the operation on its token, worth nothing, when the reason names one", () => {
+      expect(parseTransaction(rejectedTx, VALID_ADDRESS)).toMatchObject({
+        type: "OUT",
+        tokenId: "trUSDT",
+        value: "0",
+        fee: "595400",
+        failed: true,
+      });
+    });
+
+    it("reads the token id NonExistentTokenId names directly", () => {
+      const tx: WalletProxyTransaction = {
+        ...rejectedTx,
+        details: {
+          ...rejectedTx.details,
+          rawRejectReason: { tag: "NonExistentTokenId", contents: "trUSDT" },
+        },
+      };
+
+      expect(parseTransaction(tx, VALID_ADDRESS)!.tokenId).toBe("trUSDT");
+    });
+
+    it("degrades to a plain CCD cost when the reason names no token", () => {
+      const tx: WalletProxyTransaction = {
+        ...rejectedTx,
+        details: {
+          ...rejectedTx.details,
+          rawRejectReason: { tag: "InvalidNonce" },
+        },
+      };
+
+      const result = parseTransaction(tx, VALID_ADDRESS);
+
+      expect(result!.tokenId).toBeUndefined();
+      expect(result!.value).toBe("595400");
+    });
+
+    it("reports nothing to an account that did not pay the fee", () => {
+      const tx: WalletProxyTransaction = {
+        ...rejectedTx,
+        origin: { type: "account", address: VALID_ADDRESS_2 },
+      };
+
+      expect(parseTransaction(tx, VALID_ADDRESS)).toBeNull();
+    });
+  });
+});
+
 describe("listOperations", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.test.ts
@@ -98,56 +98,33 @@ describe("parseTransaction", () => {
     expect(parseTransaction(tx, VALID_ADDRESS)).toBeNull();
   });
 
-  it("should mark failed transactions", () => {
-    const tx: WalletProxyTransaction = {
-      ...baseTx,
-      details: {
-        type: "transfer",
-        outcome: "reject",
-        transferSource: VALID_ADDRESS,
-        transferDestination: VALID_ADDRESS_2,
-        transferAmount: "500000",
-      },
-    };
-
-    const result = parseTransaction(tx, VALID_ADDRESS);
-    expect(result!.failed).toBe(true);
-  });
-
-  it("should compute value as fee only for failed outgoing transfers", () => {
-    const tx: WalletProxyTransaction = {
+  // A rejection is reported without any of the transfer fields, and only to the
+  // account that paid: there is no counterparty row to parse.
+  const rejectedTx = (overrides?: Partial<WalletProxyTransaction>): WalletProxyTransaction =>
+    ({
       ...baseTx,
       cost: 300,
-      details: {
-        type: "transfer",
-        outcome: "reject",
-        transferSource: VALID_ADDRESS,
-        transferDestination: VALID_ADDRESS_2,
-        transferAmount: "500000",
-      },
-    };
+      details: { type: "transfer", outcome: "reject", rejectReason: "InvalidNonce" },
+      ...overrides,
+    }) as WalletProxyTransaction;
 
-    const result = parseTransaction(tx, VALID_ADDRESS);
-    expect(result!.value).toBe("300");
-    expect(result!.amount).toBe("500000");
-    expect(result!.fee).toBe("300");
+  it("charges the sender for a rejected transfer, which reports no counterparty", () => {
+    const result = parseTransaction(rejectedTx(), VALID_ADDRESS);
+
+    expect(result).toMatchObject({
+      type: "OUT",
+      failed: true,
+      value: "300",
+      fee: "300",
+      amount: "0",
+      recipient: "",
+    });
   });
 
-  it("should compute value as 0 for failed incoming transfers", () => {
-    const tx: WalletProxyTransaction = {
-      ...baseTx,
-      cost: 300,
-      details: {
-        type: "transfer",
-        outcome: "reject",
-        transferSource: VALID_ADDRESS_2,
-        transferDestination: VALID_ADDRESS,
-        transferAmount: "500000",
-      },
-    };
+  it("returns null for a rejected transfer the account did not pay for", () => {
+    const paidByAnother = rejectedTx({ origin: { type: "account", address: VALID_ADDRESS_2 } });
 
-    const result = parseTransaction(tx, VALID_ADDRESS);
-    expect(result!.value).toBe("0");
+    expect(parseTransaction(paidByAnother, VALID_ADDRESS)).toBeNull();
   });
 
   it("should return memo as undefined when CBOR decoding fails", () => {
@@ -413,6 +390,7 @@ describe("listOperations", () => {
       limit: 100,
       order: "d",
       includeRawRejectReason: true,
+      includeRewards: "none",
     });
     expect(result.items).toHaveLength(1);
     expect(result.items[0]).toMatchObject({
@@ -456,6 +434,7 @@ describe("listOperations", () => {
       limit: 100,
       order: "d",
       includeRawRejectReason: true,
+      includeRewards: "none",
       blockHeightFrom: 500,
     });
   });
@@ -479,6 +458,7 @@ describe("listOperations", () => {
       limit: 100,
       order: "d",
       includeRawRejectReason: true,
+      includeRewards: "none",
       from: "42",
     });
   });
@@ -548,16 +528,19 @@ describe("listOperations", () => {
     expect(result.items).toHaveLength(0);
   });
 
-  it("should return empty array on error", async () => {
+  it("reports a fetch failure rather than an empty page, which reads as the end", async () => {
     getTransactionsMock.mockRejectedValue(new Error("network error"));
 
-    const result = await listOperations(
-      config,
-      VALID_ADDRESS,
-      { minHeight: 0 },
-      "concordium_testnet",
-    );
+    await expect(
+      listOperations(config, VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet"),
+    ).rejects.toThrow("network error");
+  });
 
-    expect(result).toEqual({ items: [], next: undefined });
+  it("excludes rewards, which the parser drops and which dominate a staking account", async () => {
+    getTransactionsMock.mockResolvedValue({ transactions: [], count: 0, limit: 100 });
+
+    await listOperations(config, VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet");
+
+    expect(getTransactionsMock.mock.calls[0][3]).toMatchObject({ includeRewards: "none" });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
@@ -1,5 +1,4 @@
 import type { ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/index";
-import { log } from "@ledgerhq/logs";
 import { isPltRejectReason } from "../../network/plt";
 import { getTransactions } from "../../network/proxyClient";
 import type {
@@ -13,10 +12,8 @@ import { decodeMemo } from "./memo";
 const DEFAULT_PAGE_SIZE = 100;
 
 /**
- * The `details.type` a PLT transaction carries in the `/v3/accTransactions`
- * response. Shares a spelling with the `type` sent to `/v0/transactionCost`
- * (`logic/transaction/estimateFees.ts`), but that is a request parameter in a
- * different wire namespace: deliberately not one constant.
+ * Shares a spelling with the `type` sent to `/v0/transactionCost`, which is a
+ * request parameter in another namespace: deliberately not one constant.
  */
 const TOKEN_UPDATE_DETAILS_TYPE = "tokenUpdate";
 
@@ -43,6 +40,13 @@ function isFeePayer(tx: WalletProxyTransaction): boolean {
 }
 
 function parseNativeTransfer(tx: WalletProxyTransaction, address: string): RawOperation | null {
+  // A rejection carries none of the transfer fields, so neither party can be
+  // read off it and only the payer's row exists at all. Without this the
+  // transaction disappears and the CCD it cost with it.
+  if (tx.details.outcome === "reject") {
+    return isFeePayer(tx) ? feeOnlyOperation(tx, address, true) : null;
+  }
+
   const sender = tx.details.transferSource || "";
   const recipient = tx.details.transferDestination || "";
 
@@ -53,16 +57,8 @@ function parseNativeTransfer(tx: WalletProxyTransaction, address: string): RawOp
     return null;
   }
 
-  const failed = tx.details.outcome === "reject";
   const amount = tx.details.transferAmount || "0";
   const fee = String(tx.cost || 0);
-
-  let value: string;
-  if (isOutgoing) {
-    value = failed ? fee : String(BigInt(amount) + BigInt(fee));
-  } else {
-    value = failed ? "0" : amount;
-  }
 
   return {
     ...transactionFields(tx),
@@ -71,9 +67,9 @@ function parseNativeTransfer(tx: WalletProxyTransaction, address: string): RawOp
     recipient,
     amount,
     fee,
-    value,
+    value: isOutgoing ? String(BigInt(amount) + BigInt(fee)) : amount,
     memo: tx.details.memo ? decodeMemo(tx.details.memo, tx.transactionHash) : undefined,
-    failed,
+    failed: false,
   };
 }
 
@@ -88,10 +84,8 @@ function rejectedTokenId(tx: WalletProxyTransaction): string | undefined {
 }
 
 /**
- * The CCD an unreadable `tokenUpdate` cost, for a transaction whose token
- * movement cannot be recovered. With a token named it stays a token operation
- * worth nothing; without one the fee is real regardless, so it degrades to a
- * plain CCD cost.
+ * The CCD an unreadable `tokenUpdate` cost. Naming a token keeps it a token
+ * operation worth nothing; without one it degrades to a plain CCD cost.
  */
 function feeOnlyOperation(
   tx: WalletProxyTransaction,
@@ -135,8 +129,7 @@ function isTokenDecimals(decimals: unknown): decimals is number {
 /**
  * The proxy renders the transfer fields only for a summary holding exactly one
  * account-to-account `TokenTransfer`; a mint, burn, list update, pause or batch
- * falls through to details carrying only the type and outcome. Every field is
- * therefore required rather than defaulted.
+ * carries only the type and outcome, so none of them are defaulted here.
  */
 function parseTokenUpdate(tx: WalletProxyTransaction, address: string): RawOperation | null {
   if (tx.details.outcome === "reject") {
@@ -179,7 +172,6 @@ function parseTokenUpdate(tx: WalletProxyTransaction, address: string): RawOpera
   };
 }
 
-/** Parses a wallet-proxy transaction into a RawOperation, or null if it moved nothing for this address. */
 export function parseTransaction(tx: WalletProxyTransaction, address: string): RawOperation | null {
   if (tx.details.type === TOKEN_UPDATE_DETAILS_TYPE) {
     return parseTokenUpdate(tx, address);
@@ -193,7 +185,11 @@ export function parseTransaction(tx: WalletProxyTransaction, address: string): R
 }
 
 /**
- * Returns list of raw operations associated to an account.
+ * Fetches one page of this account's operations.
+ *
+ * A fetch failure propagates: the caller walks pages newest first, so reporting
+ * a failed page as the end of history would truncate what gets stored and move
+ * the sync watermark past the gap for good.
  */
 export async function listOperations(
   config: ConcordiumCoinConfig,
@@ -209,6 +205,10 @@ export async function listOperations(
     // The proxy tests this parameter for presence, not value, so it must be
     // omitted rather than set to false to disable it.
     includeRawRejectReason: true,
+    // `parseTransaction` drops every reward entry, and on a delegator or
+    // validator account they outnumber the transfers by orders of magnitude.
+    // Excluding them server-side is what keeps a full walk to a few requests.
+    includeRewards: "none",
   };
 
   if (options.minHeight > 0) {
@@ -219,27 +219,28 @@ export async function listOperations(
     params.from = options.cursor;
   }
 
-  try {
-    const response = await getTransactions(config, currencyId, address, params);
+  const response = await getTransactions(config, currencyId, address, params);
 
-    if (!("transactions" in response) || !Array.isArray(response.transactions)) {
-      return { items: [], next: undefined };
-    }
-
-    const items = response.transactions
-      .map(tx => parseTransaction(tx, address))
-      .filter((op): op is RawOperation => op !== null);
-
-    const hasMore = response.count >= limit;
-    let next: string | undefined;
-    if (hasMore && response.transactions.length > 0) {
-      const lastTx = response.transactions[response.transactions.length - 1];
-      next = String(lastTx.id);
-    }
-
-    return { items, next };
-  } catch (error) {
-    log("concordium", `Error fetching transactions for ${address}`, { error });
-    return { items: [], next: undefined };
+  if (!("transactions" in response) || !Array.isArray(response.transactions)) {
+    // Reporting this as an empty page would read as the end of the history, and
+    // the caller stores that as the whole of it.
+    throw new Error("concordium: transaction response carried no transactions array");
   }
+
+  const items = response.transactions
+    .map(tx => parseTransaction(tx, address))
+    .filter((op): op is RawOperation => op !== null);
+
+  // A short page proves the end. Counted from the rows themselves rather than
+  // `count`, which a malformed response can omit, ending the walk silently.
+  const hasMore = response.transactions.length >= (response.limit ?? limit);
+  let next: string | undefined;
+  if (hasMore && response.transactions.length > 0) {
+    const lastTx = response.transactions[response.transactions.length - 1];
+    // The cursor is exclusive and ids are not contiguous per account, so it has
+    // to be the last id seen rather than one past it.
+    next = String(lastTx.id);
+  }
+
+  return { items, next };
 }

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
@@ -1,5 +1,6 @@
 import type { ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/index";
 import { log } from "@ledgerhq/logs";
+import { isPltRejectReason } from "../../network/plt";
 import { getTransactions } from "../../network/proxyClient";
 import type {
   ConcordiumCoinConfig,
@@ -11,20 +12,37 @@ import { decodeMemo } from "./memo";
 
 const DEFAULT_PAGE_SIZE = 100;
 
+/**
+ * The `details.type` a PLT transaction carries in the `/v3/accTransactions`
+ * response. Shares a spelling with the `type` sent to `/v0/transactionCost`
+ * (`logic/transaction/estimateFees.ts`), but that is a request parameter in a
+ * different wire namespace: deliberately not one constant.
+ */
+const TOKEN_UPDATE_DETAILS_TYPE = "tokenUpdate";
+
 export interface RawOperationPage {
   items: RawOperation[];
   next: string | undefined;
 }
 
-/**
- * Parses a wallet-proxy transaction into a RawOperation.
- * Returns null for non-transfer transactions or transactions unrelated to the address.
- */
-export function parseTransaction(tx: WalletProxyTransaction, address: string): RawOperation | null {
-  if (tx.details.type !== "transfer" && tx.details.type !== "transferWithMemo") {
-    return null;
-  }
+function transactionFields(
+  tx: WalletProxyTransaction,
+): Pick<RawOperation, "hash" | "date" | "blockHash" | "blockHeight" | "id"> {
+  return {
+    hash: tx.transactionHash,
+    date: new Date(Math.floor(tx.blockTime) * 1000),
+    blockHash: tx.blockHash || null,
+    blockHeight: tx.blockHeight,
+    id: tx.id,
+  };
+}
 
+/** `cost` is reported only to the payer, so elsewhere it is absent, not zero. */
+function isFeePayer(tx: WalletProxyTransaction): boolean {
+  return tx.origin.type === "self";
+}
+
+function parseNativeTransfer(tx: WalletProxyTransaction, address: string): RawOperation | null {
   const sender = tx.details.transferSource || "";
   const recipient = tx.details.transferDestination || "";
 
@@ -35,7 +53,6 @@ export function parseTransaction(tx: WalletProxyTransaction, address: string): R
     return null;
   }
 
-  const type = isOutgoing ? "OUT" : "IN";
   const failed = tx.details.outcome === "reject";
   const amount = tx.details.transferAmount || "0";
   const fee = String(tx.cost || 0);
@@ -47,26 +64,132 @@ export function parseTransaction(tx: WalletProxyTransaction, address: string): R
     value = failed ? "0" : amount;
   }
 
-  let memo: string | undefined;
-  if (tx.details.memo) {
-    memo = decodeMemo(tx.details.memo, tx.transactionHash);
-  }
-
   return {
-    hash: tx.transactionHash,
-    type,
+    ...transactionFields(tx),
+    type: isOutgoing ? "OUT" : "IN",
     sender,
     recipient,
     amount,
     fee,
     value,
-    memo,
-    date: new Date(Math.floor(tx.blockTime) * 1000),
-    blockHash: tx.blockHash || null,
-    blockHeight: tx.blockHeight,
+    memo: tx.details.memo ? decodeMemo(tx.details.memo, tx.transactionHash) : undefined,
     failed,
-    id: tx.id,
   };
+}
+
+/**
+ * Only the two chain-level PLT tags carry the token: `NonExistentTokenId` names
+ * it directly, `TokenUpdateTransactionFailed` nests it in the module's reason.
+ */
+function rejectedTokenId(tx: WalletProxyTransaction): string | undefined {
+  const reason = tx.details.rawRejectReason;
+  if (!isPltRejectReason(reason)) return undefined;
+  return reason.tag === "NonExistentTokenId" ? reason.contents : reason.contents.tokenId;
+}
+
+/**
+ * The CCD an unreadable `tokenUpdate` cost, for a transaction whose token
+ * movement cannot be recovered. With a token named it stays a token operation
+ * worth nothing; without one the fee is real regardless, so it degrades to a
+ * plain CCD cost.
+ */
+function feeOnlyOperation(
+  tx: WalletProxyTransaction,
+  address: string,
+  failed: boolean,
+  tokenId?: string,
+): RawOperation {
+  const fee = String(tx.cost || 0);
+
+  return {
+    ...transactionFields(tx),
+    type: "OUT",
+    sender: address,
+    recipient: "",
+    amount: "0",
+    fee,
+    value: tokenId === undefined ? fee : "0",
+    memo: undefined,
+    failed,
+    ...(tokenId === undefined ? {} : { tokenId }),
+  };
+}
+
+/** A rejection carries none of the transfer fields, and only the payer moved anything. */
+function parseRejectedTokenUpdate(
+  tx: WalletProxyTransaction,
+  address: string,
+): RawOperation | null {
+  if (!isFeePayer(tx)) return null;
+
+  return feeOnlyOperation(tx, address, true, rejectedTokenId(tx));
+}
+
+/** Bounded because it only ever selects a power of ten to divide the amount by. */
+function isTokenDecimals(decimals: unknown): decimals is number {
+  return (
+    typeof decimals === "number" && Number.isInteger(decimals) && decimals >= 0 && decimals <= 255
+  );
+}
+
+/**
+ * The proxy renders the transfer fields only for a summary holding exactly one
+ * account-to-account `TokenTransfer`; a mint, burn, list update, pause or batch
+ * falls through to details carrying only the type and outcome. Every field is
+ * therefore required rather than defaulted.
+ */
+function parseTokenUpdate(tx: WalletProxyTransaction, address: string): RawOperation | null {
+  if (tx.details.outcome === "reject") {
+    return parseRejectedTokenUpdate(tx, address);
+  }
+
+  const { transferSource, transferDestination, tokenId, tokenTransferAmount } = tx.details;
+
+  if (
+    !transferSource ||
+    !transferDestination ||
+    !tokenId ||
+    typeof tokenTransferAmount?.value !== "string" ||
+    !isTokenDecimals(tokenTransferAmount.decimals)
+  ) {
+    // Not a transfer this layer can read, but the CCD it cost still left the
+    // payer's account, and dropping it would show up as an unexplained debit.
+    return isFeePayer(tx) ? feeOnlyOperation(tx, address, false) : null;
+  }
+
+  const isOutgoing = transferSource === address;
+  if (!isOutgoing && transferDestination !== address) {
+    return null;
+  }
+
+  return {
+    ...transactionFields(tx),
+    type: isOutgoing ? "OUT" : "IN",
+    sender: transferSource,
+    recipient: transferDestination,
+    amount: tokenTransferAmount.value,
+    fee: isFeePayer(tx) ? String(tx.cost || 0) : "0",
+    // The token amount alone: the fee is CCD and belongs to the parent
+    // operation, so folding it in here would put µCCD into a token balance.
+    value: tokenTransferAmount.value,
+    memo: tx.details.memo ? decodeMemo(tx.details.memo, tx.transactionHash) : undefined,
+    failed: false,
+    tokenId,
+    decimals: tokenTransferAmount.decimals,
+  };
+}
+
+/** Parses a wallet-proxy transaction into a RawOperation, or null if it moved nothing for this address. */
+export function parseTransaction(tx: WalletProxyTransaction, address: string): RawOperation | null {
+  if (tx.details.type === TOKEN_UPDATE_DETAILS_TYPE) {
+    return parseTokenUpdate(tx, address);
+  }
+
+  if (tx.details.type !== "transfer" && tx.details.type !== "transferWithMemo") {
+    return null;
+  }
+
+  return parseNativeTransfer(tx, address);
 }
 
 /**

--- a/libs/coin-modules/coin-concordium/src/logic/history/paginate.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/paginate.test.ts
@@ -1,0 +1,60 @@
+import type { RawOperation } from "../../types";
+import type { RawOperationPage } from "./listOperations";
+import { paginateOperations } from "./paginate";
+
+const op = (hash: string): RawOperation =>
+  ({ hash, type: "OUT", value: "1", fee: "0" }) as unknown as RawOperation;
+
+const page = (items: RawOperation[], next?: string): RawOperationPage => ({ items, next });
+
+describe("paginateOperations", () => {
+  it("follows the cursor until a page offers none", async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(page([op("a")], "1"))
+      .mockResolvedValueOnce(page([op("b")], "2"))
+      .mockResolvedValueOnce(page([op("c")]));
+
+    expect((await paginateOperations(fetchPage)).map(o => o.hash)).toEqual(["a", "b", "c"]);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, undefined);
+    expect(fetchPage).toHaveBeenNthCalledWith(3, "2");
+  });
+
+  it("treats an empty cursor as the end, since that is how it can arrive", async () => {
+    const fetchPage = jest.fn().mockResolvedValue(page([op("a")], ""));
+
+    expect(await paginateOperations(fetchPage)).toHaveLength(1);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps going past a page that parsed to nothing, since older rows remain", async () => {
+    // Whole pages parse away: this family keeps three transaction types out of
+    // dozens, so contract calls or delegation updates fill a page with nothing.
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(page([], "1"))
+      .mockResolvedValueOnce(page([op("a")]));
+
+    expect((await paginateOperations(fetchPage)).map(o => o.hash)).toEqual(["a"]);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a replayed cursor rather than returning the fragment it gathered", async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(page([op("a")], "1"))
+      .mockResolvedValueOnce(page([op("b")], "2"))
+      .mockResolvedValue(page([op("c")], "1"));
+
+    await expect(paginateOperations(fetchPage)).rejects.toThrow("was served twice");
+  });
+
+  it("reports a failed page rather than the operations gathered before it", async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(page([op("a")], "1"))
+      .mockRejectedValueOnce(new Error("network error"));
+
+    await expect(paginateOperations(fetchPage)).rejects.toThrow("network error");
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/history/paginate.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/paginate.ts
@@ -1,0 +1,42 @@
+import type { RawOperation } from "../../types";
+import type { RawOperationPage } from "./listOperations";
+
+/**
+ * Walks every page the proxy will hand back, newest first.
+ *
+ * Ported from the generic coin framework's paginator, which a coin module
+ * cannot import: `live-common` depends on this package.
+ *
+ * Errors are deliberately not caught. The next sync resumes from the newest
+ * operation stored, so persisting a partial history would move the watermark
+ * past the gap and nothing would fetch it again.
+ */
+export async function paginateOperations(
+  fetchPage: (cursor: string | undefined) => Promise<RawOperationPage>,
+): Promise<RawOperation[]> {
+  const items: RawOperation[] = [];
+  const followed = new Set<string>();
+  let cursor: string | undefined;
+
+  for (;;) {
+    const page = await fetchPage(cursor);
+    for (const item of page.items) items.push(item);
+
+    // The only terminator. A page can be empty and still have more behind it:
+    // `items` holds what parsed, and this family keeps three transaction types
+    // out of dozens, so a page of contract calls yields nothing while the
+    // cursor still points at older rows.
+    if (!page.next) return items;
+
+    // A `from` the proxy cannot parse is ignored rather than rejected, so a bad
+    // cursor replays a page instead of failing. Tracking every cursor catches a
+    // longer loop, which comparing against the last one misses. It throws for
+    // the reason a failed page does: what came back is a fragment.
+    if (followed.has(page.next)) {
+      throw new Error(`concordium: transaction cursor ${page.next} was served twice`);
+    }
+
+    followed.add(page.next);
+    cursor = page.next;
+  }
+}

--- a/libs/coin-modules/coin-concordium/src/types/network.ts
+++ b/libs/coin-modules/coin-concordium/src/types/network.ts
@@ -120,7 +120,8 @@ export interface TransactionQueryParams {
   limit?: number;
   order?: "a" | "d"; // ascending or descending
   from?: string; // transaction ID to start from (exclusive cursor)
-  includeRewards?: boolean;
+  // A name, not a flag, and omitting it returns every reward.
+  includeRewards?: "none" | "allButFinalization" | "all";
   includeRawRejectReason?: boolean;
   onlyEncrypted?: boolean;
   blockTimeFrom?: number; // Unix seconds

--- a/libs/coin-modules/coin-concordium/src/types/operation.ts
+++ b/libs/coin-modules/coin-concordium/src/types/operation.ts
@@ -1,3 +1,9 @@
+/**
+ * `tokenId` marks a PLT operation; it and `decimals` are absent on CCD ones.
+ *
+ * `type` stays the movement: the `NONE`/`FEES` parent stand-in is built in
+ * `bridge/`, and widening this would leak it into the `api/` surface.
+ */
 export interface RawOperation {
   hash: string;
   type: "OUT" | "IN";
@@ -12,4 +18,6 @@ export interface RawOperation {
   blockHeight: number;
   failed: boolean;
   id: number;
+  tokenId?: string;
+  decimals?: number;
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`tokenUpdate` transactions were parsed away, so a PLT transfer appeared nowhere in an account's history. They now become operations on the token sub-account, valued in the token, with the CCD fee left on the parent as a separate operation typed from whether the account actually paid one. The `api/` surface reports them as the token they moved rather than as native CCD.

Turning the flag on has to recover history already behind the sync watermark, which needed three changes rather than one. The proxy's cursor is followed to the end, instead of one page of a hundred being read and the cursor dropped. A re-read replaces the stored operations rather than merging over them. And `shouldMergeOps: false` keeps `makeSync` from undoing that — its `mergeOps` drops every refetched operation older than the oldest stored one, so without it the walk recovers pages that are then discarded. Six families disable it for the same reason.

The walk is unbounded, matching the framework's own paginator: a page cap would relocate the bug rather than fix it, since a truncated walk that gets persisted moves the watermark past the gap for good. Page size is the proxy's documented ceiling of 1000, and rewards are excluded from the request — they were only ever fetched and thrown away, and they dominate a staking account's history.

Two changes ride along that were invisible rather than new. A rejected transfer is now recorded with the fee it cost: the proxy reports one without any of its transfer fields, so it previously parsed to nothing and the CCD went unaccounted for. And a PLT transfer is linked under the CCD operation that paid for it.

Regression cover is mutation-tested — reverting the pagination, the discard, the wiring flag or the rejected-transfer branch each fails the suite.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28333](https://ledgerhq.atlassian.net/browse/LIVE-28333?atlOrigin=eyJpIjoiMDZlZTNlYjg3MjE4NDNmMzk4YWM5YTkwMTdiZWM5ZWEiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-28333]: https://ledgerhq.atlassian.net/browse/LIVE-28333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ