### PR TITLE
[LWDM] feat(pay-card): add freeze button to desktop

### DIFF
--- a/.changeset/forty-olives-clean.md
+++ b/.changeset/forty-olives-clean.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card": minor
+---
+
+add freeze button in desktop app

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -919,7 +919,9 @@
     },
     "card": {
       "title": "Crypto card",
-      "balanceLabel": "Balance"
+      "balanceLabel": "Balance",
+      "freeze": "Freeze",
+      "unfreeze": "Unfreeze"
     },
     "cardOnboarding": {
       "widget": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10209,7 +10209,9 @@
       }
     },
     "card": {
-      "title": "Crypto card"
+      "title": "Crypto card",
+      "freeze": "Freeze",
+      "unfreeze": "Unfreeze"
     },
     "selectContact": {
       "placeholder": "Enter contact"

--- a/features/flow/pay-card-details/package.json
+++ b/features/flow/pay-card-details/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@domain/api-card-management": "workspace:*",
-    "@ledgerhq/lumen-utils-shared": "catalog:"
+    "@ledgerhq/lumen-utils-shared": "catalog:",
+    "@shared/i18n": "workspace:*"
   },
   "devDependencies": {
     "@features/platform-style": "workspace:*",

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TileButton } from "@ledgerhq/lumen-ui-rnative";
 import { Snow } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "@shared/i18n";
 import type { FreezeViewProps } from "../../types";
 
 export function FreezeView({
@@ -12,6 +13,8 @@ export function FreezeView({
   onFreeze,
   onUnfreeze,
 }: FreezeViewProps) {
+  const { t } = useTranslation();
+
   return (
     <TileButton
       icon={Snow}
@@ -19,7 +22,7 @@ export function FreezeView({
       disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
       isFull
     >
-      {isFrozen ? "Unfreeze" : "Freeze"}
+      {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
     </TileButton>
   );
 }

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TileButton } from "@ledgerhq/lumen-ui-react";
 import { Snow } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "@shared/i18n";
 import type { FreezeViewProps } from "../../types";
 
 export function FreezeView({
@@ -12,6 +13,8 @@ export function FreezeView({
   onFreeze,
   onUnfreeze,
 }: FreezeViewProps) {
+  const { t } = useTranslation();
+
   return (
     <TileButton
       icon={Snow}
@@ -19,7 +22,7 @@ export function FreezeView({
       disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
       isFull
     >
-      {isFrozen ? "Unfreeze" : "Freeze"}
+      {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
     </TileButton>
   );
 }

--- a/features/flow/pay-card/src/Card.web.test.tsx
+++ b/features/flow/pay-card/src/Card.web.test.tsx
@@ -10,6 +10,7 @@ jest.mock("@features/flow-pay-card-auth", () => ({
 jest.mock("@features/flow-pay-card-details", () => ({
   CardArtwork: () => <div data-testid="card-artwork" />,
   CardVisual: () => <div data-testid="card-visual" />,
+  Freeze: () => <div data-testid="card-freeze" />,
 }));
 
 jest.mock("@features/flow-pay-card-widget", () => ({

--- a/features/flow/pay-card/src/CardView.web.tsx
+++ b/features/flow/pay-card/src/CardView.web.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CardLogin, CardMore } from "@features/flow-pay-card-auth";
-import { CardArtwork, CardVisual } from "@features/flow-pay-card-details";
+import { CardArtwork, CardVisual, Freeze } from "@features/flow-pay-card-details";
 import { CardOnboardingWidget } from "@features/flow-pay-card-widget";
 import { Divider } from "@ledgerhq/lumen-ui-react";
 import type { CardViewProps } from "./Card.types";
@@ -14,6 +14,7 @@ export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewP
           face shows once the holder is signed in and has a card, while the login shows only while
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}
       {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
+      <Freeze />
       <Divider />
       <CardLogin key={`${oauthConfig.apiUrl}`} oauthConfig={oauthConfig} callback={callback} />
       <CardMore />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6892,6 +6892,9 @@ importers:
       '@ledgerhq/lumen-utils-shared':
         specifier: 'catalog:'
         version: 0.1.11(react@19.1.4)
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@features/platform-style':
         specifier: workspace:*
@@ -23050,7 +23053,6 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -65323,9 +65325,7 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:


### PR DESCRIPTION

📝 Description

Wires up the Freeze component into the desktop Pay Card view and adds i18n support for its labels.


https://github.com/user-attachments/assets/c6319752-ec92-4642-b5db-f65b691a88aa



Changes:
- Renders <Freeze /> in CardView.web.tsx
- Adds payTab.card.freeze / payTab.card.unfreeze keys to en/app.json
- Replaces hardcoded strings in FreezeView.web.tsx with useTranslation

🔗 Context

- JIRA / GitHub issue: LIVE-35435 (https://ledgerhq.atlassian.net/browse/LIVE-35435)