### PR TITLE
[LWDM] chore(xrp): add memo on xrp operation details

### DIFF
--- a/.changeset/fluffy-dragons-accept.md
+++ b/.changeset/fluffy-dragons-accept.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Add memo on xrp operation details

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/index.ts
@@ -1,10 +1,14 @@
-import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/xrp/types";
+import {
+  Transaction,
+  TransactionStatus,
+  XrpOperation,
+} from "@ledgerhq/live-common/families/xrp/types";
 import { LLDCoinFamily } from "../types";
 import sendRecipientFields from "./SendRecipientFields";
 import operationDetails from "./operationDetails";
-import { Account, Operation } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
 
-const family: LLDCoinFamily<Account, Transaction, TransactionStatus, Operation> = {
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus, XrpOperation> = {
   operationDetails,
   sendRecipientFields,
   sendRecipientCanNext: status => !status.errors.transaction,

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/operationDetails.tsx
@@ -1,14 +1,32 @@
-import { Operation, AccountLike } from "@ledgerhq/types-live";
+import React from "react";
+import { Account } from "@ledgerhq/types-live";
+import { XrpOperation } from "@ledgerhq/live-common/families/xrp/types";
+import { Trans } from "react-i18next";
+import {
+  OpDetailsTitle,
+  OpDetailsData,
+  OpDetailsSection,
+} from "~/renderer/drawers/OperationDetails/styledComponents";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import { OperationDetailsExtraProps } from "../types";
 
-type Props = {
-  operation: Operation;
-  type: string;
-  account: AccountLike;
-};
+function OperationDetailsExtra({
+  operation: { extra },
+}: OperationDetailsExtraProps<Account, XrpOperation>) {
+  const memo = extra?.memo;
 
-function OperationDetailsExtra(_props: Props) {
-  // Return nothing - no extra fields should be displayed for XRP
-  return null;
+  if (!memo) return null;
+
+  return (
+    <OpDetailsSection>
+      <OpDetailsTitle>
+        <Trans i18nKey="operationDetails.extra.memo" defaults="memo" />
+      </OpDetailsTitle>
+      <OpDetailsData>
+        <Ellipsis>{memo}</Ellipsis>
+      </OpDetailsData>
+    </OpDetailsSection>
+  );
 }
 
 export default {

--- a/apps/ledger-live-mobile/src/families/xrp/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/xrp/operationDetails.tsx
@@ -1,14 +1,19 @@
-import { Operation, AccountLike } from "@ledgerhq/types-live";
+import React from "react";
+import { XrpOperation } from "@ledgerhq/live-common/families/xrp/types";
+import { useTranslation } from "~/context/Locale";
+import Section from "~/screens/OperationDetails/Section";
 
 type Props = {
-  operation: Operation;
-  type: string;
-  account: AccountLike;
+  operation: XrpOperation;
 };
 
-function OperationDetailsExtra(_props: Props) {
-  // Return nothing - no extra fields should be displayed for XRP
-  return null;
+function OperationDetailsExtra({ operation: { extra } }: Props) {
+  const { t } = useTranslation();
+  const memo = extra?.memo;
+
+  if (!memo) return null;
+
+  return <Section title={t("operationDetails.extra.memo")} value={memo} />;
 }
 
 export default {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -1588,6 +1588,30 @@ describe("coin-framework utils", () => {
       const result = adaptCoreOperationToLiveOperation(accountId, baseOp);
       expect("transferId" in (result.extra as Record<string, unknown>)).toBe(false);
     });
+
+    it("maps details.destinationTag to extra.memo", () => {
+      const op = { ...baseOp, details: { destinationTag: 42 } };
+      const result = adaptCoreOperationToLiveOperation(accountId, op);
+      expect((result.extra as Record<string, unknown>).memo).toBe("42");
+    });
+
+    it("maps a zero details.destinationTag to extra.memo", () => {
+      const op = { ...baseOp, details: { destinationTag: 0 } };
+      const result = adaptCoreOperationToLiveOperation(accountId, op);
+      expect((result.extra as Record<string, unknown>).memo).toBe("0");
+    });
+
+    it("prefers details.memo over details.destinationTag when both are present", () => {
+      const op = { ...baseOp, details: { memo: "a-memo", destinationTag: 42 } };
+      const result = adaptCoreOperationToLiveOperation(accountId, op);
+      expect((result.extra as Record<string, unknown>).memo).toBe("a-memo");
+    });
+
+    it("does not set extra.memo when neither memo nor destinationTag is present", () => {
+      const op = { ...baseOp, details: {} };
+      const result = adaptCoreOperationToLiveOperation(accountId, op);
+      expect("memo" in (result.extra as Record<string, unknown>)).toBe(false);
+    });
   });
 
   describe("nextSequenceWithPending", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -663,6 +663,10 @@ function buildOperationExtra(op: CoreOperation): FrameworkOperationExtra {
     extra.memo = op.details.memo as string;
   }
 
+  if (extra.memo === undefined && typeof op.details?.destinationTag === "number") {
+    extra.memo = op.details.destinationTag.toString();
+  }
+
   if (op.details?.internal === true) {
     extra.internal = op.details?.internal;
   }

--- a/libs/ledger-live-common/src/families/xrp/types.ts
+++ b/libs/ledger-live-common/src/families/xrp/types.ts
@@ -4,12 +4,19 @@ export * from "@ledgerhq/coin-xrp/types";
 // Bridge related types
 import type { NetworkInfo, NetworkInfoRaw } from "@ledgerhq/coin-xrp/types";
 import type {
+  Operation,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
   TransactionStatusCommonRaw,
 } from "@ledgerhq/types-live";
 import type { BigNumber } from "bignumber.js";
+
+export type XrpOperationExtra = {
+  memo?: string;
+};
+
+export type XrpOperation = Operation<XrpOperationExtra>;
 
 export type Transaction = TransactionCommon & {
   family: "xrp";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

When I send XRP between my own accounts in LWM and LWD with a memo, the memo no appear in Transaction Details after completion.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

<img width="350" height="580" alt="Screenshot 2026-09-08 at 08 26 14" src="https://github.com/user-attachments/assets/2f70398c-9ec8-4a83-abe9-a06f0fafa0ec" />

<img width="1061" height="848" alt="Screenshot 2026-09-08 at 09 48 19" src="https://github.com/user-attachments/assets/099276f1-7f71-4c48-ad76-2932ce4654e6" />

### 🔗 Context
- **JIRA / GitHub issue**: [LIVE-35909](https://ledgerhq.atlassian.net/browse/LIVE-35909)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35909]: https://ledgerhq.atlassian.net/browse/LIVE-35909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ