### PR TITLE
[LWDM] feat(concordium): validate PLT transfers and max spendable (LIVE-28334)

### DIFF
--- a/.changeset/concordium-validate-plt-transfers.md
+++ b/.changeset/concordium-validate-plt-transfers.md
@@ -1,0 +1,15 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/concordium-core": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Validate PLT transfers and fix estimateMaxSpendable for tokens
+
+`getTransactionStatus` checks a PLT amount against the token sub-account and its fee
+against the CCD at the parent's disposal, and blocks on token state and device limits.
+`estimateMaxSpendable` returns the full token balance instead of subtracting µCCD fees.
+A PLT fee is priced from the buffered energy, so it covers the deposit the chain
+requires. `concordium-core` lowers the PLT decimals ceiling to 18. Adds the English
+error strings.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7833,6 +7833,34 @@
     "ConcordiumAddressVerificationFailedError": {
       "title": "Address verification failed"
     },
+    "ConcordiumInsufficientCcdForFee": {
+      "title": "Not enough CCD for the network fee",
+      "description": "The network fee is paid in CCD, not in the token you are sending. Add CCD to this account and try again."
+    },
+    "ConcordiumTokenPaused": {
+      "title": "Transfers are paused for this token",
+      "description": "The token issuer has paused all transfers. You can try again once transfers resume."
+    },
+    "ConcordiumTokenTransferNotPermitted": {
+      "title": "This account cannot send this token",
+      "description": "The token issuer restricts who may send it, and this account is not permitted. Contact the token issuer for access."
+    },
+    "ConcordiumTokenRestrictionsUnverified": {
+      "title": "Token restrictions could not be verified",
+      "description": "This token's transfer rules could not be read, so the transfer cannot be confirmed as allowed. Please resync your account and try again."
+    },
+    "ConcordiumUnsupportedTokenDecimals": {
+      "title": "This token cannot be signed on your Ledger device",
+      "description": "The token uses {{decimals}} decimal places, and your device supports at most {{maxDecimals}}. Receiving and holding it are unaffected."
+    },
+    "ConcordiumTokenAccountUnavailable": {
+      "title": "This token is no longer in your account",
+      "description": "The token you selected is not available any more. Please start the transaction again."
+    },
+    "ConcordiumInvalidPltPayloadError": {
+      "title": "This transaction cannot be prepared",
+      "description": "The token's details are outside what your Ledger device accepts, so the transaction cannot be built. Please contact Ledger Support."
+    },
     "StacksMemoTooLong": {
       "title": "Memo length is too long"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -234,6 +234,34 @@
       "title": "Session expired",
       "description": "The Concordium ID App session is no longer active. Please pair again."
     },
+    "ConcordiumInsufficientCcdForFee": {
+      "title": "Not enough CCD for the network fee",
+      "description": "The network fee is paid in CCD, not in the token you are sending. Add CCD to this account and try again."
+    },
+    "ConcordiumTokenPaused": {
+      "title": "Transfers are paused for this token",
+      "description": "The token issuer has paused all transfers. You can try again once transfers resume."
+    },
+    "ConcordiumTokenTransferNotPermitted": {
+      "title": "This account cannot send this token",
+      "description": "The token issuer restricts who may send it, and this account is not permitted. Contact the token issuer for access."
+    },
+    "ConcordiumTokenRestrictionsUnverified": {
+      "title": "Token restrictions could not be verified",
+      "description": "This token's transfer rules could not be read, so the transfer cannot be confirmed as allowed. Please resync your account and try again."
+    },
+    "ConcordiumUnsupportedTokenDecimals": {
+      "title": "This token cannot be signed on your Ledger device",
+      "description": "The token uses {{decimals}} decimal places, and your device supports at most {{maxDecimals}}. Receiving and holding it are unaffected."
+    },
+    "ConcordiumTokenAccountUnavailable": {
+      "title": "This token is no longer in your account",
+      "description": "The token you selected is not available any more. Please start the transaction again."
+    },
+    "ConcordiumInvalidPltPayloadError": {
+      "title": "This transaction cannot be prepared",
+      "description": "The token's details are outside what your Ledger device accepts, so the transaction cannot be built. Please contact Ledger Support."
+    },
     "CosmosBroadcastCodeInternal": {
       "title": "Something went wrong (Error #1)",
       "description": "Please save your logs using the button below and provide them to Ledger Support."

--- a/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.test.ts
@@ -1,5 +1,9 @@
 import BigNumber from "bignumber.js";
-import { createFixtureAccount } from "../test/fixtures";
+import {
+  createFixtureAccount,
+  createFixtureTokenAccount,
+  createFixtureTransaction,
+} from "../test/fixtures";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
 
 jest.mock("./prepareTransaction", () => ({
@@ -176,6 +180,41 @@ describe("estimateMaxSpendable", () => {
 
     // THEN
     expect(result).toEqual(new BigNumber(0));
+  });
+
+  describe("a PLT sub-account", () => {
+    // No estimate is needed at all, which is what the second assertion pins.
+    it("returns the whole token balance, unreduced by CCD fees", async () => {
+      const { prepareTransaction } = jest.requireMock("./prepareTransaction");
+      const parent = createFixtureAccount();
+      const subAccount = createFixtureTokenAccount({ parentId: parent.id });
+
+      const result = await estimateMaxSpendable({
+        account: subAccount,
+        parentAccount: parent,
+        transaction: null,
+      });
+
+      expect(result).toEqual(subAccount.spendableBalance);
+      expect(prepareTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("an unresolved sub-account reference", () => {
+    // Signing is already blocked, so any figure here is one for a send that
+    // cannot happen.
+    it("reports zero rather than the parent's CCD balance", async () => {
+      const parent = createFixtureAccount();
+
+      const result = await estimateMaxSpendable({
+        account: parent,
+        transaction: createFixtureTransaction({
+          subAccountId: "js:2:concordium_testnet:gone:+plt",
+        }),
+      });
+
+      expect(result).toEqual(new BigNumber(0));
+    });
   });
 
   describe("a failed preparation", () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.ts
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
+import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import type { Transaction } from "../types";
 import { CONCORDIUM_DUMMY_ADDRESS } from "../constants";
 import { getTransactionStatus } from "./getTransactionStatus";
@@ -13,6 +14,21 @@ export const estimateMaxSpendable: AccountBridge<Transaction>["estimateMaxSpenda
   parentAccount,
   transaction,
 }) => {
+  // The fee is paid in CCD from the parent account and never reduces the token
+  // balance, so all of it is spendable. The native line below subtracts µCCD
+  // fees from `spendableBalance`, which on a sub-account is the token balance —
+  // a unit error, and the reason this returns before reaching it.
+  if (account.type === "TokenAccount") {
+    return account.spendableBalance;
+  }
+
+  // The caller's transaction is spread below, so a stale `subAccountId` reaches
+  // here too. Nothing here reads `status.errors`, so without this the native
+  // path answers with the parent's whole CCD balance for an unsendable send.
+  if (transaction?.subAccountId && !findSubAccountById(account, transaction.subAccountId)) {
+    return new BigNumber(0);
+  }
+
   const mainAccount = getMainAccount(account, parentAccount);
 
   try {

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
@@ -7,16 +7,82 @@ import {
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
-import { MAX_MEMO_LENGTH } from "@ledgerhq/concordium-core";
+import { MAX_MEMO_LENGTH, PLT_MAX_MEMO_SIZE } from "@ledgerhq/concordium-core";
 import {
   createFixtureAccount,
+  createFixtureTokenAccount,
+  createFixtureTokenCurrency,
   createFixtureTransaction,
   setupTestnetCoinConfig,
   VALID_ADDRESS,
   VALID_ADDRESS_2,
 } from "../test/fixtures";
-import { ConcordiumInsufficientFunds, ConcordiumMemoTooLong } from "../types/errors";
+import {
+  ConcordiumInsufficientCcdForFee,
+  ConcordiumInsufficientFunds,
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumMemoTooLong,
+  ConcordiumTokenAccountUnavailable,
+  ConcordiumTokenPaused,
+  ConcordiumTokenRestrictionsUnverified,
+  ConcordiumTokenTransferNotPermitted,
+  ConcordiumUnsupportedTokenDecimals,
+} from "../types/errors";
+import type { ConcordiumAccount, ConcordiumTokenResources } from "../types";
 import { getTransactionStatus } from "./getTransactionStatus";
+
+const PLT_ID = "t-USDT";
+
+/**
+ * A parent holding one PLT sub-account, with the per-token state on the parent
+ * where sync puts it — `TokenAccount` is closed and has no family slot.
+ */
+const withToken = ({
+  tokenState = { transferStatus: "allowed" } as ConcordiumTokenResources,
+  magnitude = 6,
+  balance = new BigNumber(5000000),
+  ccdBalance,
+  ccdSpendable,
+}: {
+  tokenState?: ConcordiumTokenResources | null;
+  magnitude?: number;
+  balance?: BigNumber;
+  ccdBalance?: BigNumber;
+  ccdSpendable?: BigNumber;
+} = {}) => {
+  const parent = createFixtureAccount();
+  const token = createFixtureTokenCurrency({
+    units: magnitude === -1 ? [] : [{ name: PLT_ID, code: PLT_ID, magnitude }],
+  });
+  const subAccount = createFixtureTokenAccount({
+    parentId: parent.id,
+    token,
+    balance,
+    spendableBalance: balance,
+  });
+
+  const account = {
+    ...parent,
+    ...(ccdBalance ? { balance: ccdBalance } : {}),
+    ...(ccdSpendable ? { spendableBalance: ccdSpendable } : {}),
+    subAccounts: [subAccount],
+    concordiumResources: {
+      ...(parent as ConcordiumAccount).concordiumResources,
+      ...(tokenState ? { tokens: { [PLT_ID]: tokenState } } : {}),
+    },
+  } as ConcordiumAccount;
+
+  return { account, subAccount };
+};
+
+const tokenTx = (subAccountId: string, over = {}) =>
+  createFixtureTransaction({
+    subAccountId,
+    recipient: VALID_ADDRESS_2,
+    amount: new BigNumber(1000000),
+    fee: new BigNumber(3600),
+    ...over,
+  });
 
 describe("getTransactionStatus", () => {
   beforeEach(() => {
@@ -381,6 +447,328 @@ describe("getTransactionStatus", () => {
 
       // THEN
       expect(result.errors.memo).toBeInstanceOf(ConcordiumMemoTooLong);
+    });
+  });
+
+  describe("PLT transfers", () => {
+    it("compares the amount against the token balance, not the CCD balance", async () => {
+      const { account, subAccount } = withToken({ balance: new BigNumber(1000) });
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { amount: new BigNumber(2000) }),
+      );
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumInsufficientFunds);
+    });
+
+    it("accepts an amount the CCD balance could never cover", async () => {
+      const { account, subAccount } = withToken({ balance: new BigNumber("999999999999") });
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { amount: new BigNumber("999999999999") }),
+      );
+
+      expect(status.errors).toEqual({});
+    });
+
+    // The token balance is untouched here; only the CCD balance is short.
+    it("reports a distinct error when CCD cannot cover the fee", async () => {
+      const { account, subAccount } = withToken({ ccdBalance: new BigNumber(100) });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumInsufficientCcdForFee);
+    });
+
+    // A staked account: 10 CCD held, 1000 µCCD at its disposal. `minReserve` is 0
+    // on both networks, so a balance-based check would wave this through.
+    it("gates the fee on what is at the account's disposal, not its balance", async () => {
+      const { account, subAccount } = withToken({
+        ccdBalance: new BigNumber(10000000),
+        ccdSpendable: new BigNumber(1000),
+      });
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { fee: new BigNumber(3600) }),
+      );
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumInsufficientCcdForFee);
+    });
+
+    it("accepts a fee the disposable balance covers", async () => {
+      const { account, subAccount } = withToken({
+        ccdBalance: new BigNumber(10000000),
+        ccdSpendable: new BigNumber(50000),
+      });
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { fee: new BigNumber(3600) }),
+      );
+
+      expect(status.errors).toEqual({});
+    });
+
+    it("keeps the fee out of totalSpent, which is the token amount alone", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { amount: new BigNumber(1000000) }),
+      );
+
+      expect(status.totalSpent).toEqual(new BigNumber(1000000));
+      expect(status.estimatedFees).toEqual(new BigNumber(3600));
+    });
+
+    it("sends the whole token balance on useAllAmount, unreduced by the fee", async () => {
+      const { account, subAccount } = withToken({ balance: new BigNumber(777) });
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { useAllAmount: true, amount: new BigNumber(0) }),
+      );
+
+      expect(status.amount).toEqual(new BigNumber(777));
+      expect(status.errors).toEqual({});
+    });
+
+    // A paused token's verdict is also `"blocked"`, so order decides this one.
+    it("reports a paused token as paused, not as a list rejection", async () => {
+      const { account, subAccount } = withToken({
+        tokenState: { transferStatus: "blocked", paused: true },
+      });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.sender).toBeInstanceOf(ConcordiumTokenPaused);
+    });
+
+    it("blocks a rejected sender without naming which list refused them", async () => {
+      const { account, subAccount } = withToken({ tokenState: { transferStatus: "blocked" } });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.sender).toBeInstanceOf(ConcordiumTokenTransferNotPermitted);
+    });
+
+    it("distinguishes an unreadable policy from a rejection", async () => {
+      const { account, subAccount } = withToken({ tokenState: { transferStatus: "unknown" } });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.sender).toBeInstanceOf(ConcordiumTokenRestrictionsUnverified);
+      expect(status.errors.sender).not.toBeInstanceOf(ConcordiumTokenTransferNotPermitted);
+    });
+
+    it("blocks when sync recorded no state for the token at all", async () => {
+      const { account, subAccount } = withToken({ tokenState: null });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.sender).toBeInstanceOf(ConcordiumTokenRestrictionsUnverified);
+    });
+
+    // A corrupted store or a newer app version can produce this.
+    it("blocks an off-union transferStatus", async () => {
+      const { account, subAccount } = withToken({
+        tokenState: { transferStatus: "something-newer" } as unknown as ConcordiumTokenResources,
+      });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.sender).toBeInstanceOf(ConcordiumTokenTransferNotPermitted);
+    });
+
+    it("rejects a token declaring more decimals than the device signs", async () => {
+      const { account, subAccount } = withToken({ magnitude: 19 });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumUnsupportedTokenDecimals);
+    });
+
+    it("accepts exactly 18 decimals", async () => {
+      const { account, subAccount } = withToken({ magnitude: 18 });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors).toEqual({});
+    });
+
+    // Reported as a payload defect, not as unsupported decimals: that message
+    // interpolates the count, and there is none to interpolate.
+    it("rejects a token whose magnitude is missing", async () => {
+      const { account, subAccount } = withToken({ magnitude: -1 });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumInvalidPltPayloadError);
+    });
+
+    // The message renders `{{decimals}}`, so a non-numeric value would reach the
+    // user as "The token uses undefined decimal places".
+    it("carries a real number in the decimals message", async () => {
+      const { account, subAccount } = withToken({ magnitude: 19 });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.amount).toMatchObject({ decimals: "19", maxDecimals: "18" });
+    });
+
+    it("rejects an out-of-range token id as a payload defect", async () => {
+      const parent = createFixtureAccount();
+      const token = createFixtureTokenCurrency({ contractAddress: "x".repeat(129) });
+      const subAccount = createFixtureTokenAccount({ parentId: parent.id, token });
+      const account = {
+        ...parent,
+        subAccounts: [subAccount],
+        concordiumResources: {
+          ...(parent as ConcordiumAccount).concordiumResources,
+          tokens: { ["x".repeat(129)]: { transferStatus: "allowed" } },
+        },
+      } as ConcordiumAccount;
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id));
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumInvalidPltPayloadError);
+    });
+
+    it("rejects a memo past the chain's limit", async () => {
+      const { account, subAccount } = withToken();
+      const memo = "x".repeat(PLT_MAX_MEMO_SIZE + 1);
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id, { memo }));
+
+      expect(status.errors.memo).toBeInstanceOf(ConcordiumMemoTooLong);
+    });
+
+    it("accepts a memo at exactly the limit", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { memo: "x".repeat(PLT_MAX_MEMO_SIZE) }),
+      );
+
+      expect(status.errors).toEqual({});
+    });
+
+    // 64 bytes: past what the device renders, well inside what it signs.
+    it("accepts a memo longer than the device displays", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { memo: "x".repeat(64) }),
+      );
+
+      expect(status.errors).toEqual({});
+    });
+
+    it("counts memo bytes, not characters", async () => {
+      const { account, subAccount } = withToken();
+      // 86 characters, 258 bytes.
+      const memo = "€".repeat(86);
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id, { memo }));
+
+      expect(status.errors.memo).toBeInstanceOf(ConcordiumMemoTooLong);
+      expect(memo.length).toBeLessThanOrEqual(PLT_MAX_MEMO_SIZE);
+    });
+
+    // The second assertion is the point: one problem, one field.
+    it("reports an over-long memo only on the memo field", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { memo: "x".repeat(PLT_MAX_MEMO_SIZE + 1) }),
+      );
+
+      expect(status.errors.memo).toBeInstanceOf(ConcordiumMemoTooLong);
+      expect(status.errors.amount).toBeUndefined();
+    });
+
+    // 254 against 256 — close enough to conflate, and different limits on
+    // different transaction types.
+    it("does not use the CCD memo limit", async () => {
+      expect(PLT_MAX_MEMO_SIZE).not.toBe(MAX_MEMO_LENGTH);
+    });
+
+    it("still validates the recipient", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { recipient: "not-an-address" }),
+      );
+
+      expect(status.errors.recipient).toBeInstanceOf(InvalidAddress);
+    });
+
+    it("reports a missing fee, as the native path does", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id, { fee: null }));
+
+      expect(status.errors.fee).toBeInstanceOf(FeeRequired);
+    });
+
+    it("requires a non-zero amount", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { amount: new BigNumber(0) }),
+      );
+
+      expect(status.errors.amount).toBeInstanceOf(AmountRequired);
+    });
+
+    // The amount is deliberately one the parent's CCD balance could cover, so a
+    // fall-through would pass validation rather than fail it.
+    it("blocks a subAccountId that no longer resolves", async () => {
+      const { account, subAccount } = withToken();
+      const withoutTokens = { ...account, subAccounts: [] };
+
+      const status = await getTransactionStatus(
+        withoutTokens,
+        tokenTx(subAccount.id, { amount: new BigNumber(1000) }),
+      );
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumTokenAccountUnavailable);
+    });
+
+    it("leaves a plain CCD transfer alone", async () => {
+      const { account } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        createFixtureTransaction({
+          recipient: VALID_ADDRESS_2,
+          amount: new BigNumber(1000),
+          fee: new BigNumber(500),
+        }),
+      );
+
+      expect(status.errors).toEqual({});
+    });
+
+    // The parent's CCD balance is irrelevant to the token amount, so the
+    // native fee-vs-amount ratio warning must not fire on a token send.
+    it("does not warn that the fee is high relative to a token amount", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { amount: new BigNumber(1) }),
+      );
+
+      expect(status.warnings).toEqual({});
     });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
@@ -7,12 +7,37 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
-import type { Account, AccountBridge } from "@ledgerhq/types-live";
+import type { Account, AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { MAX_MEMO_LENGTH, AccountAddress } from "@ledgerhq/concordium-core";
+import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import {
+  MAX_MEMO_LENGTH,
+  AccountAddress,
+  encodePltTransferOperations,
+  PLT_MAX_DECIMALS,
+  PLT_MAX_MEMO_SIZE,
+  PLT_TOKEN_ID_MAX_LENGTH,
+  PLT_TOKEN_ID_MIN_LENGTH,
+} from "@ledgerhq/concordium-core";
 import coinConfig from "../config";
-import type { Transaction, TransactionStatus } from "../types";
-import { ConcordiumInsufficientFunds, ConcordiumMemoTooLong } from "../types/errors";
+import { effectivePltAmount } from "./tokens";
+import type {
+  ConcordiumAccount,
+  ConcordiumTokenResources,
+  Transaction,
+  TransactionStatus,
+} from "../types";
+import {
+  ConcordiumInsufficientCcdForFee,
+  ConcordiumInsufficientFunds,
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumMemoTooLong,
+  ConcordiumTokenAccountUnavailable,
+  ConcordiumTokenPaused,
+  ConcordiumTokenRestrictionsUnverified,
+  ConcordiumTokenTransferNotPermitted,
+  ConcordiumUnsupportedTokenDecimals,
+} from "../types/errors";
 
 function validateAmount(
   transaction: Transaction,
@@ -69,6 +94,216 @@ function validateRecipient(transaction: Transaction, account: Account): Error | 
   }
 }
 
+/**
+ * Folds the token's own restrictions into one blocking error.
+ *
+ * Pause is read before the verdict because sync folds it in: `resolveTransferStatus`
+ * returns `"blocked"` for a paused token, so the verdict alone cannot mean "a
+ * list refused you".
+ *
+ * Neither {@link ConcordiumAccountNotAllowed} nor {@link ConcordiumAccountDenied}
+ * is reachable from here — see {@link ConcordiumTokenTransferNotPermitted}.
+ *
+ * Gates on `!== "allowed"` rather than `=== "blocked"`, so a value from a
+ * corrupted store or a newer app version blocks instead of passing.
+ */
+function validateTokenPolicy(state: ConcordiumTokenResources | undefined): Error | undefined {
+  if (!state) return new ConcordiumTokenRestrictionsUnverified();
+  if (state.paused === true) return new ConcordiumTokenPaused();
+  if (state.transferStatus === "allowed") return undefined;
+  if (state.transferStatus === "unknown") return new ConcordiumTokenRestrictionsUnverified();
+  return new ConcordiumTokenTransferNotPermitted();
+}
+
+/**
+ * An absent magnitude blocks too, but as a payload defect rather than an
+ * unsupported count: there is no number to report, and its own message
+ * interpolates the token's decimals. Sync only builds a sub-account whose CAL
+ * magnitude matches the chain's decimals, so an absence is a data fault the user
+ * cannot act on.
+ */
+function validateTokenDecimals(decimals: number | undefined): Error | undefined {
+  if (decimals === undefined) {
+    return new ConcordiumInvalidPltPayloadError("", { reason: "missing token magnitude" });
+  }
+
+  if (decimals > PLT_MAX_DECIMALS) {
+    return new ConcordiumUnsupportedTokenDecimals("", {
+      decimals: String(decimals),
+      maxDecimals: String(PLT_MAX_DECIMALS),
+    });
+  }
+}
+
+/**
+ * A defect rather than a rejected transaction: the id comes from CAL, so the
+ * user chose a token the wallet listed and cannot act on it being out of range.
+ */
+function validateTokenId(tokenId: string): Error | undefined {
+  const bytes = Buffer.byteLength(tokenId, "utf-8");
+  if (bytes < PLT_TOKEN_ID_MIN_LENGTH || bytes > PLT_TOKEN_ID_MAX_LENGTH) {
+    return new ConcordiumInvalidPltPayloadError("", {
+      tokenIdLength: String(bytes),
+    });
+  }
+}
+
+/**
+ * {@link MAX_MEMO_LENGTH} is the CCD cap and does not apply here. The device's
+ * 14-byte display limit is not enforced either — see {@link PLT_MAX_MEMO_SIZE}.
+ */
+function validatePltMemo(memo: string): Error | undefined {
+  const memoBytes = Buffer.byteLength(memo, "utf-8");
+
+  if (memoBytes > PLT_MAX_MEMO_SIZE) {
+    return new ConcordiumMemoTooLong("", {
+      memoLength: memoBytes.toString(),
+      maxLength: PLT_MAX_MEMO_SIZE.toString(),
+    });
+  }
+}
+
+/**
+ * Confirms the payload the send would build stays inside the device's CBOR
+ * budget.
+ *
+ * Close to reachable now that the memo may run to 256 bytes: `app_sizes.h` puts
+ * a worst-case single transfer at ~355 of the 512 bytes. The token id is not in
+ * this blob — it is a separate field, bounded by {@link validateTokenId} — so
+ * the memo is what moves the total.
+ *
+ * Runs only once its inputs are known good, so a throw here means the size, not
+ * an invalid recipient or exponent.
+ */
+function validatePayloadSize(
+  subAccount: TokenAccount,
+  transaction: Transaction,
+  decimals: number,
+): Error | undefined {
+  try {
+    encodePltTransferOperations({
+      recipient: AccountAddress.fromBase58(transaction.recipient),
+      amount: effectivePltAmount(subAccount, transaction),
+      decimals,
+      ...(transaction.memo ? { memo: Buffer.from(transaction.memo, "utf-8") } : {}),
+    });
+  } catch (error) {
+    return new ConcordiumInvalidPltPayloadError("", {
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Status for a PLT transfer.
+ *
+ * Two balances, not one. The native path compares `amount + fee` against a
+ * single balance; here the amount is owed to the token sub-account and the fee
+ * to the parent's CCD, so an account can hold enough of the token and still
+ * fail on the fee. `totalSpent` is therefore the token amount alone.
+ *
+ * No network call: every value comes from what sync already persisted.
+ */
+function getTokenTransactionStatus(
+  account: Account,
+  transaction: Transaction,
+  subAccount: TokenAccount,
+  estimatedFees: BigNumber,
+  reserveAmount: BigNumber,
+): TransactionStatus {
+  const errors: Record<string, Error> = {};
+  const warnings: Record<string, Error> = {};
+
+  const tokenId = subAccount.token.contractAddress;
+  const decimals = subAccount.token.units[0]?.magnitude;
+  const tokenState = (account as ConcordiumAccount).concordiumResources?.tokens?.[tokenId];
+
+  const amount = transaction.useAllAmount
+    ? subAccount.spendableBalance
+    : new BigNumber(transaction.amount);
+  const totalSpent = amount;
+
+  const recipientError = validateRecipient(transaction, account);
+
+  const memoError = transaction.memo ? validatePltMemo(transaction.memo) : undefined;
+
+  // `validatePayloadSize` encodes, so it runs last: it can only mean the size
+  // once the exponent, recipient and memo have each been cleared. An over-long
+  // memo would otherwise also surface as a payload defect on `amount`, which is
+  // the field desktop renders first.
+  const sizeError =
+    decimals === undefined || recipientError || memoError
+      ? undefined
+      : validatePayloadSize(subAccount, transaction, decimals);
+
+  Object.assign(errors, {
+    sender: validateTokenPolicy(tokenState),
+    amount:
+      validateTokenDecimals(decimals) ??
+      validateTokenId(tokenId) ??
+      validateTokenAmount(transaction, subAccount, amount) ??
+      validateCcdForFee(account, estimatedFees, reserveAmount) ??
+      sizeError,
+    // Filed under `fee` to match the native path. It does not render in the
+    // desktop send flow — see LIVE-37061, which covers both paths.
+    fee: validateFee(estimatedFees),
+    recipient: recipientError,
+  });
+
+  Object.assign(errors, { memo: memoError });
+
+  return {
+    errors: Object.fromEntries(Object.entries(errors).filter(([, v]) => !!v)),
+    warnings,
+    estimatedFees,
+    amount,
+    totalSpent,
+  };
+}
+
+function validateTokenAmount(
+  transaction: Transaction,
+  subAccount: TokenAccount,
+  amount: BigNumber,
+): Error | undefined {
+  if (amount.eq(0) && !transaction.useAllAmount) {
+    return new AmountRequired();
+  }
+
+  if (amount.gt(subAccount.spendableBalance)) {
+    return new ConcordiumInsufficientFunds();
+  }
+}
+
+/**
+ * The fee is paid in CCD by the parent, out of what is actually at its disposal.
+ *
+ * Not `balance`: the chain gates the fee on the account's *available* amount,
+ * which is `total - max(stake, locked)` with stake counting both active and
+ * cooldown, so an account holding most of its CCD staked would pass a
+ * balance-based check and then fail on chain with `NormalTransactionInsufficientFunds`.
+ * Sync stores that figure as `spendableBalance`, taking the proxy's
+ * `accountAtDisposal` when it is present.
+ *
+ * The reserve is applied with `min` rather than subtracted, because
+ * `spendableBalance` already nets it out in the branch that has no
+ * `accountAtDisposal` to use — subtracting again would double-count it.
+ */
+function validateCcdForFee(
+  account: Account,
+  estimatedFees: BigNumber,
+  reserveAmount: BigNumber,
+): Error | undefined {
+  const availableForFee = BigNumber.min(
+    account.spendableBalance,
+    account.balance.minus(reserveAmount),
+  );
+
+  if (estimatedFees.gt(availableForFee)) {
+    return new ConcordiumInsufficientCcdForFee();
+  }
+}
+
 export const getTransactionStatus: AccountBridge<
   Transaction,
   Account,
@@ -80,6 +315,30 @@ export const getTransactionStatus: AccountBridge<
   // reserveAmount is the minimum amount of currency that an account must hold in order to stay activated
   const reserveAmount = new BigNumber(coinConfig.getCoinConfig(account.currency.id).minReserve);
   const estimatedFees = new BigNumber(transaction.fee || 0);
+
+  const subAccount = findSubAccountById(account, transaction.subAccountId ?? "");
+  if (subAccount?.type === "TokenAccount") {
+    return getTokenTransactionStatus(
+      account,
+      transaction,
+      subAccount,
+      estimatedFees,
+      reserveAmount,
+    );
+  }
+
+  // Blocks rather than falling through to native validation — see
+  // {@link ConcordiumTokenAccountUnavailable}.
+  if (transaction.subAccountId) {
+    const amount = new BigNumber(transaction.amount);
+    return {
+      errors: { amount: new ConcordiumTokenAccountUnavailable() },
+      warnings: {},
+      estimatedFees,
+      amount,
+      totalSpent: amount,
+    };
+  }
 
   // Calculate amount based on useAllAmount flag
   const amount = transaction.useAllAmount

--- a/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.test.ts
@@ -1,5 +1,9 @@
 import BigNumber from "bignumber.js";
-import { AccountAddress, encodePltTransferOperations } from "@ledgerhq/concordium-core";
+import {
+  AccountAddress,
+  encodePltTransferOperations,
+  PLT_MAX_MEMO_SIZE,
+} from "@ledgerhq/concordium-core";
 import {
   createFixtureAccount,
   createFixtureConfig,
@@ -23,11 +27,12 @@ const { estimateFees, estimateTokenFees } = jest.requireMock("../logic");
 const config = createFixtureConfig();
 
 /** The real encoder, so the expected size is derived rather than asserted as a magic number. */
-const blobSize = (recipient: string, amount: number, decimals = 6) =>
+const blobSize = (recipient: string, amount: number | bigint, decimals = 6, memo?: string) =>
   encodePltTransferOperations({
     recipient: AccountAddress.fromBase58(recipient),
     amount: BigInt(amount),
     decimals,
+    ...(memo ? { memo: Buffer.from(memo, "utf-8") } : {}),
   }).length;
 
 const tokenAccountFor = (account: ReturnType<typeof createFixtureAccount>) =>
@@ -277,6 +282,62 @@ describe("prepareTransaction", () => {
 
       expect(result).not.toBe(tx);
       expect(result).not.toHaveProperty("energy");
+    });
+
+    // 200 bytes of memo, which the second assertion shows the size must grow by.
+    it("counts the memo toward the priced size", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const memo = "x".repeat(200);
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        recipient: VALID_ADDRESS_2,
+        amount: new BigNumber(1500000),
+        memo,
+      });
+
+      await prepareTransaction(account, tx);
+
+      const [, , params] = estimateTokenFees.mock.calls[0];
+      expect(params.listOperationsSize).toBe(blobSize(VALID_ADDRESS_2, 1500000, 6, memo));
+      expect(params.listOperationsSize).toBeGreaterThan(blobSize(VALID_ADDRESS_2, 1500000));
+    });
+
+    // The transaction carries amount 0, so pricing it would encode the wrong size.
+    it("prices the balance that useAllAmount will send", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        recipient: VALID_ADDRESS_2,
+        useAllAmount: true,
+        amount: new BigNumber(0),
+      });
+
+      await prepareTransaction(account, tx);
+
+      const [, , params] = estimateTokenFees.mock.calls[0];
+      expect(params.listOperationsSize).toBe(
+        blobSize(VALID_ADDRESS_2, BigInt(subAccount.spendableBalance.toFixed(0))),
+      );
+    });
+
+    it("prices nothing when the memo is past the chain's limit", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        memo: "x".repeat(PLT_MAX_MEMO_SIZE + 1),
+      });
+
+      expect(await prepareTransaction(account, tx)).toBe(tx);
+      expect(estimateTokenFees).not.toHaveBeenCalled();
+    });
+
+    it("prices nothing when the subAccountId no longer resolves", async () => {
+      const account = createFixtureAccount();
+      const tx = createFixtureTransaction({ subAccountId: "js:2:concordium_testnet:gone:+plt" });
+
+      expect(await prepareTransaction(account, tx)).toBe(tx);
+      expect(estimateFees).not.toHaveBeenCalled();
+      expect(estimateTokenFees).not.toHaveBeenCalled();
     });
 
     it("stays on the native path when no sub-account is selected", async () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.ts
@@ -1,11 +1,17 @@
 import type { AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { AccountAddress, encodePltTransferOperations } from "@ledgerhq/concordium-core";
+import {
+  AccountAddress,
+  encodePltTransferOperations,
+  PLT_MAX_DECIMALS,
+  PLT_MAX_MEMO_SIZE,
+} from "@ledgerhq/concordium-core";
 import type { ConcordiumCoinConfig, Transaction } from "../types";
 import { estimateFees, estimateTokenFees } from "../logic";
 import type { FeeEstimation } from "../logic/transaction/estimateFees";
 import { CONCORDIUM_DUMMY_ADDRESS } from "../constants";
+import { effectivePltAmount } from "./tokens";
 import coinConfig from "../config";
 
 /**
@@ -30,10 +36,19 @@ function recipientForEstimation(recipient: string): AccountAddress {
  * The order is the reverse of the CCD path's because `listOperationsSize` is the
  * blob's byte length, so the payload has to exist before it can be priced.
  *
- * Resolves to `undefined` when the token's magnitude is missing. Sync only
- * builds a sub-account whose CAL magnitude matches the chain's decimals, so
- * this should not occur; leaving the fee unset is still preferable to pricing a
- * blob encoded with a guessed exponent, which the chain would reject outright.
+ * The memo counts toward `listOperationsSize`, so omitting it underprices the
+ * transfer — a 256-byte memo is worth more energy than the buffer absorbs.
+ *
+ * Resolves to `undefined` when the transfer cannot be priced at all: a missing
+ * magnitude, more decimals than the device will sign, or a memo past the chain's
+ * limit. Sync only builds a sub-account whose CAL magnitude matches the chain's
+ * decimals, so the first should not occur.
+ *
+ * The decimals check has to happen here rather than being left to the encoder.
+ * `encodePltTransferOperations` throws above {@link PLT_MAX_DECIMALS}, and a
+ * throw from this function rejects `prepareTransaction`, which the send flow
+ * reports as a generic failure and retries. Returning `undefined` leaves the
+ * fee unset instead, so `getTransactionStatus` runs and names the real problem.
  */
 async function estimatePltFees(
   config: ConcordiumCoinConfig,
@@ -42,12 +57,16 @@ async function estimatePltFees(
   transaction: Transaction,
 ): Promise<FeeEstimation | undefined> {
   const decimals = subAccount.token.units[0]?.magnitude;
-  if (decimals === undefined) return undefined;
+  if (decimals === undefined || decimals > PLT_MAX_DECIMALS) return undefined;
+
+  const memo = transaction.memo ? Buffer.from(transaction.memo, "utf-8") : undefined;
+  if (memo && memo.length > PLT_MAX_MEMO_SIZE) return undefined;
 
   const operations = encodePltTransferOperations({
     recipient: recipientForEstimation(transaction.recipient),
-    amount: BigInt(transaction.amount.toFixed(0)),
+    amount: effectivePltAmount(subAccount, transaction),
     decimals,
+    ...(memo ? { memo } : {}),
   });
 
   return estimateTokenFees(config, currencyId, {
@@ -62,6 +81,11 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
 ) => {
   const config = coinConfig.getCoinConfig(account.currency.id);
   const subAccount = findSubAccountById(account, transaction.subAccountId ?? "");
+
+  // Leaving the fee unset is what lets status report the stale reference.
+  if (subAccount?.type !== "TokenAccount" && transaction.subAccountId) {
+    return transaction;
+  }
 
   if (subAccount?.type === "TokenAccount") {
     const estimation = await estimatePltFees(config, account.currency.id, subAccount, transaction);

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -1,4 +1,5 @@
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ConcordiumTokenAccountUnavailable } from "../types/errors";
 import BigNumber from "bignumber.js";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountAddress } from "@ledgerhq/concordium-core";
@@ -488,7 +489,7 @@ describe("signOperation", () => {
     it("does not re-estimate when preparation persisted the energy", async () => {
       const { account, transaction } = tokenTransaction();
 
-      await expect(sign(transaction, account)).rejects.toThrow();
+      await expect(sign(transaction, account)).rejects.toThrow(/not supported yet/);
 
       expect(estimateFees).not.toHaveBeenCalled();
     });
@@ -524,16 +525,17 @@ describe("signOperation", () => {
       );
     });
 
-    it("ignores a stale energy when the sub-account is not a token account", async () => {
-      await sign(
-        createFixtureTransaction({
-          subAccountId: "js:2:concordium_testnet:nope:",
-          fee: new BigNumber(1000),
-          energy: 1080,
-        }),
-      );
+    // The second assertion is the point: nothing reaches the crafting step.
+    it("refuses a subAccountId that no longer resolves", async () => {
+      const transaction = createFixtureTransaction({
+        subAccountId: "js:2:concordium_testnet:gone:+plt",
+        fee: new BigNumber(1000),
+      });
 
-      expect(estimateFees).toHaveBeenCalled();
+      // Asserted by instance, not by message: a regex would have passed against
+      // the invariant this replaced.
+      await expect(sign(transaction)).rejects.toBeInstanceOf(ConcordiumTokenAccountUnavailable);
+      expect(craftTransaction).not.toHaveBeenCalled();
     });
 
     // The energy half of the pair is missing, so the fee on screen has no

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -7,6 +7,7 @@ import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { Observable } from "rxjs";
 import type { ConcordiumSigner, Transaction } from "../types";
+import { ConcordiumTokenAccountUnavailable } from "../types/errors";
 import { combine, craftTransaction, estimateFees, getNextValidSequence } from "../logic";
 import { getTransactionStatus } from "./getTransactionStatus";
 import coinConfig from "../config";
@@ -42,6 +43,15 @@ export const buildSignOperation =
         const isTokenTransfer =
           findSubAccountById(account, transaction.subAccountId ?? "")?.type === "TokenAccount";
 
+        // Fails closed: the alternative is a signed CCD transfer. Typed rather
+        // than an invariant because a user can reach this, so it needs to reach
+        // them translated.
+        if (!isTokenTransfer && transaction.subAccountId) {
+          throw new ConcordiumTokenAccountUnavailable(
+            "concordium: transaction references a token sub-account that no longer exists",
+          );
+        }
+
         if (isTokenTransfer && transaction.energy === undefined) throw new FeeNotLoaded();
 
         const estimation =
@@ -55,6 +65,9 @@ export const buildSignOperation =
         // a PLT intent for this reason (`assertNativeAsset`); the bridge had no
         // equivalent. Removed by LIVE-28337, which crafts the `TokenUpdate`
         // payload.
+        //
+        // An invariant, not a typed error: unreachable unless the token UI ships
+        // before PLT crafting does.
         invariant(!isTokenTransfer, "concordium: signing a PLT transfer is not supported yet");
 
         const signature = await signerContext(deviceId, async signer => {

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -13,6 +13,7 @@ import type {
   ConcordiumTokenResources,
   PltAccountToken,
   PltTransferStatus,
+  Transaction,
 } from "../types";
 
 const CAL_LOOKUP_CONCURRENCY = 4;
@@ -381,4 +382,15 @@ export async function resolveTokenSubAccounts({
     subAccounts: mergeSubAccounts(initialAccount?.subAccounts, newSubAccounts, untrustedIds),
     tokens,
   };
+}
+
+/**
+ * The amount a PLT transfer will carry. Under `useAllAmount` that is the
+ * sub-account's balance, since `transaction.amount` is zero in that case.
+ *
+ * Shared by pricing and validation so the two cannot encode different payloads.
+ */
+export function effectivePltAmount(subAccount: TokenAccount, transaction: Transaction): bigint {
+  const amount = transaction.useAllAmount ? subAccount.spendableBalance : transaction.amount;
+  return BigInt(amount.toFixed(0));
 }

--- a/libs/coin-modules/coin-concordium/src/constants.ts
+++ b/libs/coin-modules/coin-concordium/src/constants.ts
@@ -33,13 +33,15 @@ export const CONCORDIUM_ENERGY = {
 } as const;
 
 /**
- * Buffer added to a PLT fee estimate, as a percentage of the proxy's figure.
+ * Buffer added to the energy of a PLT fee estimate, as a percentage. The fee is
+ * then priced from the buffered energy rather than buffered in its own right —
+ * see `estimateTokenFees`.
  *
  * Energy is a ceiling, not a charge: the chain bills actual execution, so the
  * buffer costs the user nothing while absorbing any drift between preparing the
  * transaction and submitting it.
  *
- * A percentage rather than a float multiplier because energy and cost are both
- * bigints, and a float would need rounding rules of its own.
+ * A percentage rather than a float multiplier because the energy is a bigint,
+ * and a float would need rounding rules of its own.
  */
 export const PLT_ENERGY_BUFFER_PERCENT = BigInt(20);

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.test.ts
@@ -102,6 +102,21 @@ describe("estimateTokenFees", () => {
     });
   });
 
+  // At energy 1001 and rate 2, buffering each half independently gives a fee of
+  // 2403 against a deposit of 2404 — one µCCD short of its own header.
+  it("prices the buffered energy rather than buffering the cost", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "2002", energy: 1001 });
+
+    const result = await estimateTokenFees(config, CURRENCY_ID, {
+      tokenId: "t-USDT",
+      listOperationsSize: 42,
+    });
+
+    expect(result.energy).toBe(BigInt(1202));
+    expect(result.cost).toBe(BigInt(2404));
+    expect(result.cost).toBeGreaterThan(applyEnergyBuffer(BigInt(2002)));
+  });
+
   // Both halves carry the buffer, or the fee shown and the energy signed drift
   // apart and the device contradicts the wallet.
   it("buffers cost and energy alike", async () => {

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
@@ -17,10 +17,11 @@ export interface PltFeeParams {
 }
 
 /**
- * Applies {@link PLT_ENERGY_BUFFER_PERCENT}, rounding up.
+ * Applies {@link PLT_ENERGY_BUFFER_PERCENT} to an energy figure, rounding up.
  *
  * Rounding up rather than truncating keeps a small estimate from losing its
- * buffer entirely to integer division.
+ * buffer entirely to integer division. The cost is not buffered with this: it is
+ * derived from the buffered energy instead — see {@link estimateTokenFees}.
  */
 export function applyEnergyBuffer(value: bigint): bigint {
   const scale = BigInt(100);
@@ -80,8 +81,20 @@ export async function estimateTokenFees(
     tokenOperationTypeCount: { transfer: 1 },
   });
 
-  return {
-    cost: applyEnergyBuffer(BigInt(result.cost)),
-    energy: applyEnergyBuffer(BigInt(result.energy)),
-  };
+  const energy = BigInt(result.energy);
+  const cost = BigInt(result.cost);
+  const bufferedEnergy = applyEnergyBuffer(energy);
+
+  // The fee has to fund the buffered energy, not merely carry the same buffer.
+  // The chain deposits `ceil(rate * headerEnergy)` (`Types.hs` `computeCost`) and
+  // compares that against the account's available amount, so buffering cost and
+  // energy independently can leave the fee a few µCCD short of the header it is
+  // paired with. Scaling by the proxy's own ratio is a safe upper bound, because
+  // `cost` is already `ceil(rate * energy)` and so `cost / energy >= rate`.
+  const bufferedCost =
+    energy === BigInt(0)
+      ? applyEnergyBuffer(cost)
+      : (cost * bufferedEnergy + energy - BigInt(1)) / energy;
+
+  return { cost: bufferedCost, energy: bufferedEnergy };
 }

--- a/libs/coin-modules/coin-concordium/src/types/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.ts
@@ -206,3 +206,67 @@ export class ConcordiumAppOutdatedError extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/**
+ * The sender may not transfer this token, and the stored state cannot say which
+ * rule refused them.
+ *
+ * Deliberately not {@link ConcordiumAccountNotAllowed} or
+ * {@link ConcordiumAccountDenied}: `getAccountListStatus` folds "absent from an
+ * allow list" and "present on a deny list" into one verdict, and only that
+ * verdict is persisted, so naming either cause would assert something unproven.
+ */
+export class ConcordiumTokenTransferNotPermitted extends Error {
+  override name = "ConcordiumTokenTransferNotPermitted";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumTokenTransferNotPermitted");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The token's restrictions could not be read, so nothing can be concluded about
+ * whether the sender may transfer it.
+ *
+ * Distinct from {@link ConcordiumTokenTransferNotPermitted}: the policy did not
+ * refuse the account, it failed to decode. Telling a permitted user they are
+ * denied is its own defect.
+ */
+export class ConcordiumTokenRestrictionsUnverified extends Error {
+  override name = "ConcordiumTokenRestrictionsUnverified";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumTokenRestrictionsUnverified");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The token declares more decimals than the device can sign.
+ *
+ * Such a token syncs and shows a balance and can never be sent, so this is
+ * reported in status rather than left to the device. See `PLT_MAX_DECIMALS`.
+ */
+export class ConcordiumUnsupportedTokenDecimals extends Error {
+  override name = "ConcordiumUnsupportedTokenDecimals";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumUnsupportedTokenDecimals");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The transaction names a token sub-account the account no longer has.
+ *
+ * `subAccountId` survives a raw round-trip independently of the sub-account it
+ * names, so a draft outlives its token: sync can drop one when it is delisted
+ * or blacklisted, and the `enableTokens` kill switch strips them all. Every
+ * layer classifies a transfer by resolving that id, so an unresolved one would
+ * otherwise reclassify the send as native and move CCD at the token's amount.
+ */
+export class ConcordiumTokenAccountUnavailable extends Error {
+  override name = "ConcordiumTokenAccountUnavailable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumTokenAccountUnavailable");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/concordium-core/src/plt.test.ts
+++ b/libs/concordium-core/src/plt.test.ts
@@ -37,18 +37,17 @@ describe("plt/encodePltAmount", () => {
     expect(() => encodePltAmount(amount, decimals)).toThrow();
   });
 
-  it.each([-1, 129, 256, 1.5])("rejects decimals of %s", decimals => {
+  it.each([-1, 19, 129, 256, 1.5])("rejects decimals of %s", decimals => {
     expect(() => encodePltAmount(1n, decimals)).toThrow();
   });
 
-  // The device holds the exponent in an int8_t and rejects a raw negative
-  // argument above 127, capping decimals at 128 — tighter than the chain's 255.
-  it("accepts 128 decimals, the device's ceiling", () => {
-    expect(encodePltAmount(1n, 128).toString("hex")).toBe("c482387f01");
+  // 128 is the int8_t exponent width, not the binding limit. See PLT_MAX_DECIMALS.
+  it("accepts 18 decimals, the device's ceiling", () => {
+    expect(encodePltAmount(1n, 18).toString("hex")).toBe("c4823101");
   });
 
-  it("rejects 129 decimals, which the chain allows but the device does not", () => {
-    expect(() => encodePltAmount(1n, 129)).toThrow(/0\.\.128/);
+  it("rejects 19 decimals, which the chain allows but the device does not", () => {
+    expect(() => encodePltAmount(1n, 19)).toThrow(/0\.\.18/);
   });
 });
 

--- a/libs/concordium-core/src/plt.ts
+++ b/libs/concordium-core/src/plt.ts
@@ -58,18 +58,29 @@ const MAX_SIGNIFICAND = 2n ** 64n - 1n;
  *
  * The chain caps this independently of the CBOR budget, so the 512-byte budget
  * is not a sufficient check: a 400-byte memo fits it and still fails on chain.
+ *
+ * The device signs the full length. `app_sizes.h` sizes `APP_PLT_CBOR_MAX` for
+ * "~260B memo (4B header + 256B payload)" and its PLT handler rejects no memo
+ * for its length, so this is the only cap that applies.
  */
-const MAX_MEMO_SIZE = 256;
+export const PLT_MAX_MEMO_SIZE = 256;
 
 /**
  * Largest number of decimals a PLT amount may carry.
  *
- * The chain accepts up to 255, but the device is tighter: it holds the exponent
- * in a signed byte and rejects a raw negative-integer argument above 127, which
- * caps the exponent at -128. Take the tighter bound, so a payload we accept
- * locally is one both sides accept.
+ * The chain accepts up to 255. Two device limits are tighter, and this is the
+ * tighter of those two: the app rejects an amount whose exponent magnitude
+ * exceeds 18 with `0x6B11 ERROR_PLT_UNSUPPORTED_DECIMALS`. The CBOR encoding
+ * imposes a separate ceiling of 128 — the exponent is a signed byte, so a raw
+ * negative-integer argument above 127 does not fit — but a payload can satisfy
+ * that and still be refused for its decimals.
+ *
+ * A token declaring more than 18 decimals is therefore legal on chain and
+ * unsignable on Ledger. Rejecting it here keeps the encoder from building a
+ * payload the device will refuse; LIVE-28334 rejects it earlier still, in
+ * transaction status, so the user learns before plugging in.
  */
-const MAX_DECIMALS = 128;
+export const PLT_MAX_DECIMALS = 18;
 
 /**
  * A PLT transfer, in the terms the wallet holds it.
@@ -110,7 +121,8 @@ export interface PltTransfer {
  * The exponent is the negated decimals, so it is always `<= 0`. Both the device
  * and the chain reject a positive exponent.
  *
- * @throws If `amount` is negative or exceeds 64 bits, or `decimals` is outside 0..128
+ * @throws If `amount` is negative or exceeds 64 bits, or `decimals` is outside
+ * 0..{@link PLT_MAX_DECIMALS}
  */
 export function encodePltAmount(amount: bigint, decimals: number): Buffer {
   if (amount < 0n) {
@@ -119,8 +131,8 @@ export function encodePltAmount(amount: bigint, decimals: number): Buffer {
   if (amount > MAX_SIGNIFICAND) {
     throw new Error(`PLT amount ${amount} exceeds the unsigned 64-bit range`);
   }
-  if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_DECIMALS) {
-    throw new Error(`PLT decimals must be an integer in 0..${MAX_DECIMALS}, got ${decimals}`);
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > PLT_MAX_DECIMALS) {
+    throw new Error(`PLT decimals must be an integer in 0..${PLT_MAX_DECIMALS}, got ${decimals}`);
   }
 
   return encodeCborTag(
@@ -164,9 +176,9 @@ export function encodePltAddress(address: AccountAddress, includeCoinInfo = fals
  * @throws If the memo exceeds the chain's 256-byte limit
  */
 export function encodePltMemo(memo: Buffer, tagged = false): Buffer {
-  if (memo.length > MAX_MEMO_SIZE) {
+  if (memo.length > PLT_MAX_MEMO_SIZE) {
     throw new Error(
-      `PLT memo is ${memo.length} bytes, exceeding the chain limit of ${MAX_MEMO_SIZE}`,
+      `PLT memo is ${memo.length} bytes, exceeding the chain limit of ${PLT_MAX_MEMO_SIZE}`,
     );
   }
 


### PR DESCRIPTION
### 📝 Description

PLT validation in `getTransactionStatus` and a PLT branch in `estimateMaxSpendable`, both keyed on `subAccountId`. No network call — every value comes from what sync persisted.

- **Two balances.** Amount against the token sub-account, fee against the CCD *at the parent's disposal*. The chain gates the fee on `total - max(stake, locked)`, so `balance` would pass an account holding most of its CCD staked.
- **Token state.** `paused` is read before the list verdict, since sync folds pause into `blocked`. An unreadable policy is distinguished from a rejection, and the verdict gates on `!== "allowed"` so an off-union value fails closed.
- **Device limits.** Over 18 decimals, a token id outside 1..128 bytes, a memo past the chain's 256. `concordium-core` lowers the decimals ceiling to 18 as `PLT_MAX_DECIMALS` — the old 128 came from the CBOR exponent width, not the device's `0x6B11`.
- **Fee priced from the buffered energy.** The chain deposits `ceil(rate * headerEnergy)`, so buffering cost and energy separately left the fee up to 4 µCCD short of its own header.
- **`estimateMaxSpendable`** returns the full token balance instead of subtracting µCCD fees.
- **A stale `subAccountId` fails closed** in status, preparation, signing and max-spendable. The id outlives the sub-account it names, and every layer classifies a transfer by resolving it, so an unresolved one would send the token's amount as CCD.

The memo follows the chain's 256 bytes, not the 14 the device displays: the device signs the full length, so the truncation is a firmware defect raised separately. `errors.fee` does not render in the desktop send flow — pre-existing, LIVE-37061.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28334](https://ledgerhq.atlassian.net/browse/LIVE-28334)
- **ADR** (if any): —


[LIVE-28334]: https://ledgerhq.atlassian.net/browse/LIVE-28334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ