### PR TITLE
feat(card): read a wallet's history (LIVE-34780)

### DIFF
--- a/.changeset/pay-card-wallet-history.md
+++ b/.changeset/pay-card-wallet-history.md
@@ -1,0 +1,9 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add `getWalletHistory` for `GET /v1/wallet/history`.
+
+- One wallet at a time, newest first, ten to a page. A card has several linked, so reading them all means one call per wallet.
+- `walletCurrency` is required for an internal wallet and checked before the request goes out, because the provider errors without it.
+- `sign` is lowercase here and uppercase on a card transaction. The schema keeps the wire's own case rather than hiding the difference from whatever has to reconcile the two.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -30,6 +30,7 @@ shape and the reasons.
 | `unfreezeCard` | POST | `/v1/card/unfreeze` | Move a frozen card back to `ACTIVE` |
 | `getInternalWallets` | GET | `/v1/wallet/internal` | Read every custodial wallet, with balances |
 | `getCardLinkedWallets` | GET | `/v1/wallet/internal/card_linked` | Read the wallets funding the card, in charging order |
+| `getWalletHistory` | GET | `/v1/wallet/history` | Read one wallet's own history, newest first |
 
 ## OAuth2 grants
 

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -128,6 +128,7 @@ describe("cardManagementApi configuration", () => {
       "getCardTransactions",
       "getInternalWallets",
       "getUser",
+      "getWalletHistory",
       "logout",
       "orderCard",
       "refreshSession",
@@ -507,6 +508,114 @@ describe("cardManagementApi requests", () => {
       const store = makeStore("session-token");
       const result = await store.dispatch(
         cardManagementApi.endpoints.getCardTransactions.initiate(undefined),
+      );
+
+      expect(result.data).toEqual([]);
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe("getWalletHistory", () => {
+    const HISTORY_PATH = "/v1/wallet/history";
+
+    const entry = {
+      name: "Credit withdrawal",
+      amount: "10.00",
+      currency: "usdc",
+      sign: "debit",
+      date: "2024-02-02T15:01:09.091Z",
+    };
+
+    it("reads one wallet's history with the bearer token and the client key", async () => {
+      provider.get(HISTORY_PATH, () => jsonResponse([entry]));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getWalletHistory.initiate({
+          walletId: "w-usdc",
+          walletType: "INTERNAL",
+          walletCurrency: "usdc",
+        }),
+      );
+
+      const sent = provider.sent();
+      expect(new URL(sent.url).pathname).toBe(HISTORY_PATH);
+      expect(sent.method).toBe("GET");
+      expect(sent.headers.get("authorization")).toBe("Bearer session-token");
+      expect(sent.headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual([entry]);
+    });
+
+    it("names the wallet, its type and its currency in the query", async () => {
+      provider.get(HISTORY_PATH, () => jsonResponse([]));
+
+      const store = makeStore("session-token");
+      await store.dispatch(
+        cardManagementApi.endpoints.getWalletHistory.initiate({
+          walletId: "w-usdc",
+          walletType: "INTERNAL",
+          walletCurrency: "usdc",
+          page: 2,
+        }),
+      );
+
+      const { searchParams } = new URL(provider.sent().url);
+      expect(searchParams.get("walletId")).toBe("w-usdc");
+      expect(searchParams.get("walletType")).toBe("INTERNAL");
+      expect(searchParams.get("walletCurrency")).toBe("usdc");
+      expect(searchParams.get("page")).toBe("2");
+    });
+
+    it("refuses an internal wallet with no currency before the request goes out", async () => {
+      provider.get(HISTORY_PATH, () => jsonResponse([]));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        // The requirement is part of the request type, so this also asserts the type refuses it.
+        // @ts-expect-error an internal wallet without its currency is not a request
+        cardManagementApi.endpoints.getWalletHistory.initiate({
+          walletId: "w-usdc",
+          walletType: "INTERNAL",
+        }),
+      );
+
+      expect(result.error).toBeDefined();
+      // The provider errors on this one, and the request never leaves the app.
+      expect(provider.requests()).toEqual([]);
+    });
+
+    it("caches each wallet separately, so one does not answer for another", async () => {
+      provider.get(HISTORY_PATH, () => jsonResponse([entry]));
+
+      const store = makeStore("session-token");
+      await store.dispatch(
+        cardManagementApi.endpoints.getWalletHistory.initiate({
+          walletId: "w-usdc",
+          walletType: "INTERNAL",
+          walletCurrency: "usdc",
+        }),
+      );
+      await store.dispatch(
+        cardManagementApi.endpoints.getWalletHistory.initiate({
+          walletId: "w-usdt",
+          walletType: "INTERNAL",
+          walletCurrency: "usdt",
+        }),
+      );
+
+      // Two wallets, two reads: a card has several linked and each has its own history.
+      expect(provider.sentTo(HISTORY_PATH)).toHaveLength(2);
+    });
+
+    it("reads an empty history as an empty list, not as a failure", async () => {
+      provider.get(HISTORY_PATH, () => jsonResponse([]));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getWalletHistory.initiate({
+          walletId: "w-credit",
+          walletType: "CREDIT",
+        }),
       );
 
       expect(result.data).toEqual([]);

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -14,6 +14,8 @@ import {
   PayCardStatusResponseSchema,
   PayCardTransactionsRequestSchema,
   PayCardTransactionsResponseSchema,
+  PayCardWalletHistoryRequestSchema,
+  PayCardWalletHistoryResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 import { transformPayCardSessionResponse } from "./transforms";
@@ -32,6 +34,8 @@ import type {
   PayCardStatus,
   PayCardTransaction,
   PayCardTransactionsRequest,
+  PayCardWalletHistoryEntry,
+  PayCardWalletHistoryRequest,
   PayCardUser,
 } from "./types";
 
@@ -139,6 +143,23 @@ export const cardManagementApi = cardApi
       }),
 
       /**
+       * One wallet's own history, newest first, ten to a page.
+       *
+       * Asked for a single wallet: a card has several linked, so a caller that wants them all asks
+       * once per wallet.
+       */
+      getWalletHistory: build.query<PayCardWalletHistoryEntry[], PayCardWalletHistoryRequest>({
+        query: filters => ({
+          url: "/v1/wallet/history",
+          method: "GET",
+          params: filters,
+        }),
+        argSchema: PayCardWalletHistoryRequestSchema,
+        responseSchema: PayCardWalletHistoryResponseSchema,
+        providesTags: ["WalletHistory"],
+      }),
+
+      /**
        * A mutation, though it reads: the provider spends the token on first use, so the answer must
        * never be served from a cache, and a mutation is never cached.
        *
@@ -223,6 +244,8 @@ export const {
   useGetCardStatusQuery,
   useGetCardTransactionsQuery,
   useLazyGetCardTransactionsQuery,
+  useGetWalletHistoryQuery,
+  useLazyGetWalletHistoryQuery,
   useCreateCardDetailsTokenMutation,
   useLazyGetCardStatusQuery,
   useFreezeCardMutation,

--- a/domain/api/card-management/src/constants.ts
+++ b/domain/api/card-management/src/constants.ts
@@ -6,6 +6,7 @@ export const CARD_MANAGEMENT_TAGS = [
   "CardStatus",
   "CardOnboardingStatus",
   "CardTransactions",
+  "WalletHistory",
 ] as const;
 
 export const OAUTH2_TOKEN_PATH = "/v1/auth/oauth2/token";

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -12,6 +12,8 @@ import {
   PayCardStatusResponseSchema,
   PayCardTransactionSchema,
   PayCardTransactionsRequestSchema,
+  PayCardWalletHistoryEntrySchema,
+  PayCardWalletHistoryRequestSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 
@@ -457,5 +459,79 @@ describe("PayCardTransactionsRequestSchema", () => {
 
   it("rejects a negative page", () => {
     expect(() => PayCardTransactionsRequestSchema.parse({ page: -1 })).toThrow();
+  });
+});
+
+describe("PayCardWalletHistoryEntrySchema", () => {
+  // The provider's own documented example.
+  const withdrawal = {
+    name: "Credit withdrawal",
+    amount: "10.00",
+    currency: "usdc",
+    sign: "debit",
+    date: "2024-02-02T15:01:09.091Z",
+  };
+
+  it("reads the entry the provider documents", () => {
+    expect(PayCardWalletHistoryEntrySchema.parse(withdrawal)).toEqual(withdrawal);
+  });
+
+  it.each(["debit", "credit"])("reads a %s movement", sign => {
+    expect(PayCardWalletHistoryEntrySchema.parse({ ...withdrawal, sign }).sign).toBe(sign);
+  });
+
+  it("rejects the uppercase sign a card transaction uses", () => {
+    // The two endpoints disagree on case. Accepting both here would hide that from the caller
+    // that has to reconcile them.
+    expect(() => PayCardWalletHistoryEntrySchema.parse({ ...withdrawal, sign: "DEBIT" })).toThrow();
+  });
+
+  it("keeps the amount as the string the provider sent", () => {
+    expect(
+      PayCardWalletHistoryEntrySchema.parse({ ...withdrawal, amount: "0.104201" }).amount,
+    ).toBe("0.104201");
+  });
+
+  it("keeps the provider's own description, which is all it says about the movement", () => {
+    const purchase = { ...withdrawal, name: "Card purchase - Starbucks" };
+
+    expect(PayCardWalletHistoryEntrySchema.parse(purchase).name).toBe("Card purchase - Starbucks");
+  });
+});
+
+describe("PayCardWalletHistoryRequestSchema", () => {
+  it("reads a credit wallet without a currency", () => {
+    const request = { walletId: "w-1", walletType: "CREDIT" as const };
+
+    expect(PayCardWalletHistoryRequestSchema.parse(request)).toEqual(request);
+  });
+
+  it("requires the currency for an internal wallet", () => {
+    // The provider errors on an internal wallet asked for without one.
+    expect(() =>
+      PayCardWalletHistoryRequestSchema.parse({ walletId: "w-1", walletType: "INTERNAL" }),
+    ).toThrow();
+  });
+
+  it("reads an internal wallet with its currency", () => {
+    const request = { walletId: "w-1", walletType: "INTERNAL" as const, walletCurrency: "usdc" };
+
+    expect(PayCardWalletHistoryRequestSchema.parse(request)).toEqual(request);
+  });
+
+  it("takes a page", () => {
+    const request = { walletId: "w-1", walletType: "REWARD" as const, page: 3 };
+
+    expect(PayCardWalletHistoryRequestSchema.parse(request).page).toBe(3);
+  });
+
+  it("rejects a wallet type the provider does not serve", () => {
+    expect(() =>
+      PayCardWalletHistoryRequestSchema.parse({ walletId: "w-1", walletType: "SAVINGS" }),
+    ).toThrow();
+  });
+
+  it("rejects a request with no wallet to read", () => {
+    expect(() => PayCardWalletHistoryRequestSchema.parse({ walletType: "CREDIT" })).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -135,6 +135,54 @@ export const PayCardTransactionsRequestSchema = z
   )
   .optional();
 
+/**
+ * One entry of a wallet's own history.
+ *
+ * Narrower than a card transaction: the movement arrives as one `name`, so whatever a card
+ * transaction carries in its own fields has to be read out of that string here.
+ *
+ * `sign` is lowercase on this endpoint and uppercase on card transactions. Each schema keeps the
+ * case its own endpoint answers with and rejects the other, so the difference stays visible to a
+ * caller that reads both rather than being smoothed over here.
+ */
+export const PayCardWalletHistoryEntrySchema = z.object({
+  /** The provider's own description, e.g. `Credit withdrawal` or `Card purchase - Starbucks`. */
+  name: z.string().min(1),
+  amount: z.string().min(1),
+  currency: z.string().min(1),
+  sign: z.enum(["debit", "credit"]),
+  /** ISO 8601, as the provider formats it. */
+  date: z.string().min(1),
+});
+
+export const PayCardWalletHistoryResponseSchema = z.array(PayCardWalletHistoryEntrySchema);
+
+/**
+ * A wallet's history is asked for one wallet at a time.
+ *
+ * `walletCurrency` is required for an internal wallet and meaningless for the others, so the pair
+ * is checked here rather than left to a 400.
+ */
+const PayCardWalletHistoryBaseSchema = z.object({
+  walletId: z.string().min(1),
+  page: z.number().int().nonnegative().optional(),
+});
+
+/**
+ * Keyed on the wallet type, so the currency requirement is in the inferred type as well: asking for
+ * an internal wallet without naming its currency does not compile, let alone reach the provider.
+ */
+export const PayCardWalletHistoryRequestSchema = z.discriminatedUnion("walletType", [
+  PayCardWalletHistoryBaseSchema.extend({
+    walletType: z.literal("INTERNAL"),
+    walletCurrency: z.string().min(1),
+  }),
+  PayCardWalletHistoryBaseSchema.extend({
+    walletType: z.enum(["CREDIT", "REWARD"]),
+    walletCurrency: z.string().min(1).optional(),
+  }),
+]);
+
 export const PayCardInternalWalletSchema = z.object({
   id: z.string().min(1),
   balance: z.string().min(1),

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -15,6 +15,8 @@ import {
   PayCardStatusResponseSchema,
   PayCardTransactionSchema,
   PayCardTransactionsRequestSchema,
+  PayCardWalletHistoryEntrySchema,
+  PayCardWalletHistoryRequestSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 
@@ -41,6 +43,11 @@ export type PayCardTransaction = z.infer<typeof PayCardTransactionSchema>;
 
 /** Every filter the provider takes. The dates go together; the rest stand alone. */
 export type PayCardTransactionsRequest = z.infer<typeof PayCardTransactionsRequestSchema>;
+
+export type PayCardWalletHistoryEntry = z.infer<typeof PayCardWalletHistoryEntrySchema>;
+
+/** Which wallet's history to read, and which page of it. */
+export type PayCardWalletHistoryRequest = z.infer<typeof PayCardWalletHistoryRequestSchema>;
 
 /**
  * Single use, and short-lived: the provider invalidates the token once the image has been read.


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #21627 feat/LIVE-34780-card-transactions
- **#21635 feat/LIVE-34780-wallet-history ← this PR**
<!-- stac-man:stack-end -->

The second of the two lists the ticket asks for. One wallet at a time, newest
first, ten to a page: a card has several wallets linked, so reading them all
means one call per wallet rather than one call for the card.

- `walletCurrency` is required for an internal wallet and meaningless for the
  others, so the pair is checked before the request goes out. The provider
  errors on an internal wallet asked for without it.
- `sign` is lowercase here and uppercase on a card transaction. The schema
  keeps each endpoint's own case and rejects the other, so the inconsistency
  stays visible to whatever has to reconcile the two lists.
- An empty history is an empty list, not a failure.