### PR TITLE
ci(pay-card): expose the Baanx card vars to app builds

### DIFF
--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -24,6 +24,14 @@ on:
         required: true
       AWS_CACHE_ROLE_NAME:
         required: true
+      CARD_BAANX_API_URL:
+        required: false
+      CARD_BAANX_CLIENT_KEY:
+        required: false
+      CARD_BAANX_HOSTED_UI:
+        required: false
+      CARD_OAUTH_REDIRECT_URI:
+        required: false
       GH_BOT_CLIENT_ID:
         required: true
       GH_BOT_PRIVATE_KEY:
@@ -112,6 +120,10 @@ jobs:
         id: build-app
         env:
           GENERATE_METAFILES: "lite"
+          CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+          CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+          CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+          CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
         run: pnpm exec nx run ledger-live-desktop:build
 
       - name: Upload ${{ matrix.config.name }} app

--- a/.github/workflows/build-mobile-reusable.yml
+++ b/.github/workflows/build-mobile-reusable.yml
@@ -13,6 +13,14 @@ on:
         required: false
       AWS_CACHE_ROLE_NAME:
         required: false
+      CARD_BAANX_API_URL:
+        required: false
+      CARD_BAANX_CLIENT_KEY:
+        required: false
+      CARD_BAANX_HOSTED_UI:
+        required: false
+      CARD_OAUTH_REDIRECT_URI:
+        required: false
       NX_KEY:
         required: false
   workflow_dispatch:
@@ -91,6 +99,10 @@ jobs:
           ANDROID_KEY_PASS: staging
           NODE_OPTIONS: "--max-old-space-size=7168"
           ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/apps/ledger-live-mobile/android/app/staging.kstr
+          CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+          CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+          CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+          CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
         run: pnpm build-ci:llm:android
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: post-version

--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -53,6 +53,14 @@ on:
         required: true
       AWS_CACHE_ROLE_NAME:
         required: true
+      CARD_BAANX_API_URL:
+        required: false
+      CARD_BAANX_CLIENT_KEY:
+        required: false
+      CARD_BAANX_HOSTED_UI:
+        required: false
+      CARD_OAUTH_REDIRECT_URI:
+        required: false
       NX_KEY:
         required: true
   workflow_dispatch:
@@ -163,6 +171,10 @@ jobs:
         env:
           PRODUCTION: ${{ inputs.production_firebase }}
           SKIP_JS_BUNDLING: true
+          CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+          CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+          CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+          CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
         with:
           command: pnpm exec nx run live-mobile:e2e:ci -- -p android -b $([[ "$PRODUCTION" == "true" ]] && printf %s '--production')
           disable_cache: ${{ inputs.disable-nx-cache || false }}
@@ -235,6 +247,11 @@ jobs:
 
       - name: Build JS bundle and minify for size analysis
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
+        env:
+          CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+          CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+          CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+          CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
         with:
           command: pnpm exec nx run live-mobile:e2e:ci -- -p android --bundle --bundle-size
           disable_cache: ${{ inputs.disable-nx-cache || false }}

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -58,6 +58,14 @@ on:
         required: true
       AWS_CACHE_ROLE_NAME:
         required: true
+      CARD_BAANX_API_URL:
+        required: false
+      CARD_BAANX_CLIENT_KEY:
+        required: false
+      CARD_BAANX_HOSTED_UI:
+        required: false
+      CARD_OAUTH_REDIRECT_URI:
+        required: false
       NX_KEY:
         required: true
       S3_DIRECTCONNECT_ENDPOINT:
@@ -172,6 +180,10 @@ jobs:
         env:
           SKIP_JS_BUNDLING: "true"
           PRODUCTION: ${{ inputs.production_firebase }}
+          CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+          CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+          CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+          CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
         with:
           command: pnpm exec nx run live-mobile:e2e:ci -- -p ios -b $([[ "$PRODUCTION" == "true" ]] && printf %s '--production')
           disable_cache: ${{ inputs.disable-nx-cache || false }}
@@ -248,6 +260,11 @@ jobs:
 
       - name: Build JS bundle and minify for size analysis
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
+        env:
+          CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+          CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+          CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+          CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
         with:
           command: pnpm exec nx run live-mobile:e2e:ci -- -p ios --bundle --bundle-size
           disable_cache: ${{ inputs.disable-nx-cache || false }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -185,6 +185,14 @@ on:
         required: false
       AWS_CACHE_ROLE_NAME:
         required: false
+      CARD_BAANX_API_URL:
+        required: false
+      CARD_BAANX_CLIENT_KEY:
+        required: false
+      CARD_BAANX_HOSTED_UI:
+        required: false
+      CARD_OAUTH_REDIRECT_URI:
+        required: false
       GH_BOT_CLIENT_ID:
         required: false
       GH_BOT_PRIVATE_KEY:
@@ -562,6 +570,10 @@ jobs:
       AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
       AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+      CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+      CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+      CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
       NX_KEY: ${{ secrets.NX_KEY }}
       S3_DIRECTCONNECT_ENDPOINT: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
 
@@ -587,6 +599,10 @@ jobs:
       AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
       AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+      CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+      CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+      CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
       NX_KEY: ${{ secrets.NX_KEY }}
 
   setup-android-avd:

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -50,6 +50,14 @@ on:
         required: true
       AWS_CACHE_ROLE_NAME:
         required: true
+      CARD_BAANX_API_URL:
+        required: false
+      CARD_BAANX_CLIENT_KEY:
+        required: false
+      CARD_BAANX_HOSTED_UI:
+        required: false
+      CARD_OAUTH_REDIRECT_URI:
+        required: false
       GH_BOT_APP_ID:
         required: true
       GH_BOT_CLIENT_ID:
@@ -320,6 +328,10 @@ jobs:
       AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
       AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+      CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+      CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+      CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
       NX_KEY: ${{ secrets.NX_KEY }}
       S3_DIRECTCONNECT_ENDPOINT: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
 
@@ -343,6 +355,10 @@ jobs:
       AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
       AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      CARD_BAANX_API_URL: ${{ secrets.CARD_BAANX_API_URL }}
+      CARD_BAANX_CLIENT_KEY: ${{ secrets.CARD_BAANX_CLIENT_KEY }}
+      CARD_BAANX_HOSTED_UI: ${{ secrets.CARD_BAANX_HOSTED_UI }}
+      CARD_OAUTH_REDIRECT_URI: ${{ secrets.CARD_OAUTH_REDIRECT_URI }}
       NX_KEY: ${{ secrets.NX_KEY }}
 
   report-bundle-sizes:

--- a/nx.workspace.json
+++ b/nx.workspace.json
@@ -198,6 +198,18 @@
         "env": "ANALYTICS_TOKEN"
       },
       {
+        "env": "CARD_BAANX_API_URL"
+      },
+      {
+        "env": "CARD_BAANX_CLIENT_KEY"
+      },
+      {
+        "env": "CARD_BAANX_HOSTED_UI"
+      },
+      {
+        "env": "CARD_OAUTH_REDIRECT_URI"
+      },
+      {
         "env": "DISABLE_TRANSACTION_BROADCAST"
       },
       {


### PR DESCRIPTION
Declare CARD_BAANX_API_URL, CARD_BAANX_CLIENT_KEY, CARD_BAANX_HOSTED_UI and CARD_OAUTH_REDIRECT_URI on the reusable desktop and mobile build workflows, and set them on the build steps so the value reaches the build process.

All four are declared `required: false` so the callers, which are updated separately, keep validating against develop's copy of these workflows until they are.

They also join the `sharedEnv` nx named input: the desktop and mobile build targets are cached, and without the declaration nx would serve a bundle built against another tenant.

Pr 1 of 2

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-37074