### PR TITLE
[LWDM] fix(contacts): add ENS disclaimer banner title (LIVE-37004)

### DIFF
--- a/.changeset/ens-disclaimer-banner-title.md
+++ b/.changeset/ens-disclaimer-banner-title.md
@@ -1,0 +1,9 @@
+---
+"@features/flow-contacts-add-address": minor
+"@features/flow-contacts-edit-address": minor
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add a title to the contacts ENS disclaimer banner

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -307,6 +307,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
       sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
       validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+      ensDisclaimerTitle: t("contacts.addAddressEntry.ensDisclaimerTitle"),
       ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
     }),
     [t],

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -298,6 +298,7 @@ export function useSendPrefillAddAddressFlow({
       domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
       sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
       validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+      ensDisclaimerTitle: t("contacts.addAddressEntry.ensDisclaimerTitle"),
       ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
     }),
     [t],

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9681,7 +9681,8 @@
         "learnMore": "Learn more"
       },
       "validationUnavailable": "Address validation is temporarily unavailable.",
-      "ensDisclaimer": "This ENS name resolves to the address shown above."
+      "ensDisclaimerTitle": "ENS names can change",
+      "ensDisclaimer": "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify."
     },
     "addAddressName": {
       "inputLabel": "Address name",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10602,7 +10602,8 @@
       "domainNotFound": "No address found for this domain",
       "sanctionedAddress": "This address is sanctioned and cannot be used.",
       "validationUnavailable": "Address validation is temporarily unavailable",
-      "ensDisclaimer": "ENS names resolve to wallet addresses. Always verify the resolved address before continuing.",
+      "ensDisclaimerTitle": "ENS names can change",
+      "ensDisclaimer": "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
       "sanctioned": {
         "description": "This address has been flagged and Ledger doesn't allow sending to it",
         "learnMore": "Learn more"

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -77,6 +77,7 @@ export function useContactsAddAddressFlowDrawerViewModel({
               domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
               sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
               validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+              ensDisclaimerTitle: t("contacts.addAddressEntry.ensDisclaimerTitle"),
               ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
             },
             sanctionedAddressBanner: {

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
@@ -46,6 +46,7 @@ export function resolveContactAddressDetailActionsLabels({
         domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
         sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
         validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+        ensDisclaimerTitle: t("contacts.addAddressEntry.ensDisclaimerTitle"),
         ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
       },
     },

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
@@ -14,6 +14,7 @@ const labels: AddAddressEntryLabels = {
   domainNotFound: "No address found for this domain",
   sanctionedAddress: "This address is sanctioned and cannot be used.",
   validationUnavailable: "Address validation is unavailable",
+  ensDisclaimerTitle: "ENS names can change",
   ensDisclaimer: "ENS names resolve to wallet addresses.",
 };
 

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntryView/ContactsAddAddressEntryView.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntryView/ContactsAddAddressEntryView.native.tsx
@@ -66,6 +66,7 @@ export function ContactsAddAddressEntryView({
             <Banner
               testID="contacts-add-address-ens-disclaimer"
               appearance="info"
+              title={labels.ensDisclaimerTitle}
               description={labels.ensDisclaimer}
             />
           ) : null}

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntryView/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntryView/ContactsAddAddressEntryView.web.tsx
@@ -65,6 +65,7 @@ export function ContactsAddAddressEntryView({
           appearance="info"
           data-testid="contacts-add-address-ens-disclaimer"
           description={labels.ensDisclaimer}
+          title={labels.ensDisclaimerTitle}
         />
       ) : null}
       {sanctionedAddressBanner ? <SanctionedAddressBanner {...sanctionedAddressBanner} /> : null}

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
@@ -19,6 +19,7 @@ const labels: AddAddressEntryLabels = {
   domainNotFound: "Domain not found",
   sanctionedAddress: "This address is sanctioned and cannot be used.",
   validationUnavailable: "Address validation is temporarily unavailable.",
+  ensDisclaimerTitle: "ENS disclaimer title",
   ensDisclaimer: "ENS disclaimer",
 };
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
@@ -24,6 +24,7 @@ const entryLabels: AddAddressEntryLabels = {
   domainNotFound: "Domain not found",
   sanctionedAddress: "Address is sanctioned",
   validationUnavailable: "Address validation is unavailable",
+  ensDisclaimerTitle: "ENS disclaimer title",
   ensDisclaimer: "ENS disclaimer",
 };
 const nameLabels: AddAddressNameLabels = {

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -34,6 +34,7 @@ const entryLabels: AddAddressEntryLabels = {
   domainNotFound: "Domain not found",
   sanctionedAddress: "Address is sanctioned",
   validationUnavailable: "Address validation is unavailable",
+  ensDisclaimerTitle: "ENS disclaimer title",
   ensDisclaimer: "ENS disclaimer",
 };
 const nameLabels: ContactsAddAddressNameLabels = {

--- a/features/flow/flow-contacts-add-address/src/state/types.ts
+++ b/features/flow/flow-contacts-add-address/src/state/types.ts
@@ -148,6 +148,7 @@ export type AddAddressEntryLabels = Readonly<{
   domainNotFound: string;
   sanctionedAddress: string;
   validationUnavailable: string;
+  ensDisclaimerTitle: string;
   ensDisclaimer: string;
 }>;
 

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
@@ -44,6 +44,7 @@ function createViewModel(
         domainNotFound: "Domain not found",
         sanctionedAddress: "Sanctioned address",
         validationUnavailable: "Validation unavailable",
+        ensDisclaimerTitle: "ENS names can change",
         ensDisclaimer: "ENS addresses are supported.",
       },
     },

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.tsx
@@ -68,6 +68,7 @@ export function ContactsRenameAddressDialog({
               appearance="info"
               data-testid="contacts-edit-address-ens-disclaimer"
               description={labels.addressValidation.ensDisclaimer}
+              title={labels.addressValidation.ensDisclaimerTitle}
             />
           ) : null}
           <TextInput

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
@@ -44,6 +44,7 @@ function createViewModel(
         domainNotFound: "Domain not found",
         sanctionedAddress: "Sanctioned address",
         validationUnavailable: "Validation unavailable",
+        ensDisclaimerTitle: "ENS names can change",
         ensDisclaimer: "ENS addresses are supported.",
       },
     },

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
@@ -55,6 +55,7 @@ export function ContactsRenameAddressDialog({
               <Banner
                 testID="contacts-edit-address-ens-disclaimer"
                 appearance="info"
+                title={labels.addressValidation.ensDisclaimerTitle}
                 description={labels.addressValidation.ensDisclaimer}
               />
             ) : null}

--- a/features/flow/flow-contacts-edit-address/src/types.ts
+++ b/features/flow/flow-contacts-edit-address/src/types.ts
@@ -71,6 +71,7 @@ export type ContactsEditAddressValidationLabels = Readonly<{
   domainNotFound: string;
   sanctionedAddress: string;
   validationUnavailable: string;
+  ensDisclaimerTitle: string;
   ensDisclaimer: string;
 }>;
 

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
@@ -11,6 +11,7 @@ const labels = {
   domainNotFound: "Domain not found",
   sanctionedAddress: "Sanctioned",
   validationUnavailable: "Unavailable",
+  ensDisclaimerTitle: "ENS disclaimer title",
   ensDisclaimer: "ENS disclaimer",
 };
 

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
@@ -12,6 +12,7 @@ const labels = {
   domainNotFound: "Domain not found",
   sanctionedAddress: "Sanctioned",
   validationUnavailable: "Unavailable",
+  ensDisclaimerTitle: "ENS disclaimer title",
   ensDisclaimer: "ENS disclaimer",
 };
 


### PR DESCRIPTION
### 📝 Description

The ENS disclaimer in Add Address (and Edit Address) only showed body copy. Design calls for a titled info banner so users understand that ENS names can change over time, and that we persist the resolved address.

This PR adds `ensDisclaimerTitle` to the shared add/edit address labels, renders it as the Lumen `Banner` title on mobile and desktop, and aligns desktop `ensDisclaimer` with the mobile copy.

add address

<img width="433" height="546" alt="Screenshot 2026-09-08 at 10 25 50 AM" src="https://github.com/user-attachments/assets/f0b75785-1328-47ab-9c60-fd97034de3bf" />

<img width="377" height="805" alt="Screenshot 2026-09-08 at 10 19 20 AM" src="https://github.com/user-attachments/assets/3ff16457-e2db-4b5a-8344-97752c90fc15" />

edit address 

<img width="454" height="554" alt="Screenshot 2026-09-08 at 10 26 04 AM" src="https://github.com/user-attachments/assets/78d09522-c9c2-4d29-b902-37c574e409c2" />

<img width="368" height="812" alt="Screenshot 2026-09-08 at 10 20 34 AM" src="https://github.com/user-attachments/assets/bc008792-9cb3-4f56-83a6-154851d1726b" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37004](https://ledgerhq.atlassian.net/browse/LIVE-37004)
- **ADR** (if any): n/a

### Test plan

- [ ] Add an Ethereum address using an ENS name (e.g. `vitalik.eth`) on **mobile** and confirm the info banner shows **ENS names can change** plus the new body copy
- [ ] Repeat on **desktop** add-address and confirm the same title and body
- [ ] Edit/rename an existing address to an ENS name and confirm the same banner
- [ ] Confirm a non-ENS address does **not** show the banner

[LIVE-37004]: https://ledgerhq.atlassian.net/browse/LIVE-37004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ