### PR TITLE
[LWDM] fix(lkrp): validate command block issuer membership (LIVE-37072)

### DIFF
--- a/.changeset/lkrp-fix-trustchain-membership-check.md
+++ b/.changeset/lkrp-fix-trustchain-membership-check.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-ledger-key-ring-protocol": patch
+---
+
+Fix the trustchain membership check, which accepted any public key of the right length and therefore let a block issued by a non-member be replayed. Seed and Derive, which grant ownership to their issuer, now also require an existing owner when the stream is already created, and two unreachable conditions were removed from the key publication check.

--- a/libs/hw-ledger-key-ring-protocol/src/CommandStreamResolver.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/CommandStreamResolver.ts
@@ -117,18 +117,7 @@ export class ResolvedCommandStream {
 }
 
 function exists(list: Uint8Array[], obj: Uint8Array): boolean {
-  for (const item of list) {
-    if (obj.length !== item.length) {
-      continue;
-    }
-    for (let i = 0; i < item.length; i++) {
-      if (item[i] !== obj[i]) {
-        continue;
-      }
-    }
-    return true;
-  }
-  return false;
+  return list.some(item => item.length === obj.length && item.every((byte, i) => byte === obj[i]));
 }
 
 export default class CommandStreamResolver {
@@ -139,25 +128,12 @@ export default class CommandStreamResolver {
     if (!exists(internals.members, issuer)) {
       throw new Error("Issuer is not a member of the group at height " + internals.height);
     }
-    if ((internals.permission.get(crypto.to_hex(issuer))! & 0x02) === Permissions.KEY_READER) {
-      throw new Error(
-        "Issuer does not have permission to publish keys at height " + internals.height,
-      );
-    }
     if (
       internals.keys.get(crypto.to_hex(issuer)) === undefined &&
       (internals.permission.get(crypto.to_hex(issuer))! & Permissions.KEY_CREATOR) !=
         Permissions.KEY_CREATOR
     ) {
       throw new Error("Issuer does not have a key to publish at height " + internals.height);
-    }
-    if (
-      !internals.keys.has(crypto.to_hex(issuer)) &&
-      (internals.permission.get(crypto.to_hex(issuer))! & Permissions.KEY_CREATOR) !==
-        Permissions.KEY_CREATOR &&
-      internals.keys.keys.length > 0
-    ) {
-      throw new Error("Issuer is trying to publish a new key at height " + internals.height);
     }
   }
 
@@ -178,6 +154,19 @@ export default class CommandStreamResolver {
     }
   }
 
+  private static assertIssuerCanCreateStream(
+    issuer: Uint8Array,
+    internals: ResolvedCommandStreamInternals,
+    action: "seed" | "derive",
+  ): void {
+    if (!internals.isCreated) return;
+    if (internals.permission.get(crypto.to_hex(issuer)) !== Permissions.OWNER) {
+      throw new Error(
+        `Issuer is not allowed to ${action} an existing stream at height ${internals.height}`,
+      );
+    }
+  }
+
   private static assertStreamIsCreated(internals: ResolvedCommandStreamInternals): void {
     if (internals.isCreated === false) {
       throw new Error("The stream is not created at height " + internals.height);
@@ -193,6 +182,7 @@ export default class CommandStreamResolver {
   ): ResolvedCommandStreamInternals {
     switch (command.getType()) {
       case CommandType.Seed:
+        this.assertIssuerCanCreateStream(block.issuer, internals, "seed");
         internals.isCreated = true;
         internals.topic = (command as Seed).topic;
         internals.members.push(block.issuer);
@@ -207,6 +197,7 @@ export default class CommandStreamResolver {
         internals.groupPublicKey = (command as Seed).groupKey;
         break;
       case CommandType.Derive:
+        this.assertIssuerCanCreateStream(block.issuer, internals, "derive");
         internals.isCreated = true;
         internals.members.push(block.issuer);
         internals.permission.set(crypto.to_hex(block.issuer), Permissions.OWNER);

--- a/libs/hw-ledger-key-ring-protocol/src/__tests__/units/CommandStreamResolver.test.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/__tests__/units/CommandStreamResolver.test.ts
@@ -1,0 +1,224 @@
+// Blocks are forged rather than produced by CommandStream.edit(): an attacker controlling the
+// backend is not bound to the SDK helpers, only to producing a signed and correctly chained block.
+
+import { SoftwareDevice } from "../..";
+import {
+  AddMember,
+  CloseStream,
+  Command,
+  CommandBlock,
+  createCommandBlock,
+  Derive,
+  hashCommandBlock,
+  Permissions,
+  PublishKey,
+  Seed,
+  signCommandBlock,
+} from "../../CommandBlock";
+import CommandStream from "../../CommandStream";
+import { crypto, DerivationPath, KeyPair } from "../../Crypto";
+import { StreamTree } from "../../StreamTree";
+
+const APPLICATION_ID = 16;
+
+function member() {
+  const keyPair = crypto.randomKeypair();
+  return { keyPair, device: new SoftwareDevice(keyPair), publicKey: keyPair.publicKey };
+}
+
+function forgeBlock(issuer: KeyPair, commands: Command[], parent: Uint8Array): CommandBlock {
+  const block = createCommandBlock(issuer.publicKey, commands, new Uint8Array(), parent);
+  return signCommandBlock(block, issuer.publicKey, issuer.privateKey);
+}
+
+function appendForgedBlock(stream: CommandStream, issuer: KeyPair, commands: Command[]) {
+  const parent = hashCommandBlock(stream.blocks[stream.blocks.length - 1]);
+  return new CommandStream(stream.blocks.concat([forgeBlock(issuer, commands, parent)]));
+}
+
+function forgedDerive(path: string): Derive {
+  return new Derive(
+    DerivationPath.toIndexArray(path),
+    crypto.randomKeypair().publicKey,
+    crypto.randomBytes(16),
+    crypto.randomBytes(64),
+    crypto.randomKeypair().publicKey,
+  );
+}
+
+function forgedSeed(): Seed {
+  return new Seed(
+    null,
+    0,
+    crypto.randomKeypair().publicKey,
+    crypto.randomBytes(16),
+    crypto.randomBytes(64),
+    crypto.randomKeypair().publicKey,
+  );
+}
+
+async function createApplicationTree(owner: SoftwareDevice) {
+  const tree = await StreamTree.createNewTree(owner);
+  return { tree, path: tree.getApplicationRootPath(APPLICATION_ID) };
+}
+
+describe("CommandStreamResolver membership gate", () => {
+  it("rejects a block issued by a valid public key that is not a member", async () => {
+    const alice = member();
+    const attacker = member();
+    const tree = await StreamTree.createNewTree(alice.device);
+
+    // 33 bytes compressed point, indistinguishable from a member key by length alone
+    expect(attacker.publicKey.length).toBe(alice.publicKey.length);
+
+    const tampered = appendForgedBlock(tree.getRoot(), attacker.keyPair, [new CloseStream()]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not part of the group/);
+  });
+
+  it("does not let a non member take ownership through a Derive block and add itself", async () => {
+    const alice = member();
+    const attacker = member();
+    const tree = await StreamTree.createNewTree(alice.device);
+
+    const tampered = appendForgedBlock(tree.getRoot(), attacker.keyPair, [
+      forgedDerive(`m/0'/${APPLICATION_ID}'/0'`),
+      new AddMember("Attacker", attacker.publicKey, Permissions.OWNER),
+    ]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not part of the group/);
+  });
+
+  it("does not let a non member re-seed the stream", async () => {
+    const alice = member();
+    const attacker = member();
+    const tree = await StreamTree.createNewTree(alice.device);
+
+    const tampered = appendForgedBlock(tree.getRoot(), attacker.keyPair, [forgedSeed()]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not part of the group/);
+  });
+
+  it("does not let a non member publish the group key to itself", async () => {
+    const alice = member();
+    const attacker = member();
+    const tree = await StreamTree.createNewTree(alice.device);
+
+    const tampered = appendForgedBlock(tree.getRoot(), attacker.keyPair, [
+      new PublishKey(
+        crypto.randomBytes(16),
+        crypto.randomBytes(64),
+        attacker.publicKey,
+        crypto.randomKeypair().publicKey,
+      ),
+    ]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not part of the group/);
+  });
+
+  it("rejects a non member on a derived application stream", async () => {
+    const alice = member();
+    const bob = member();
+    const attacker = member();
+
+    let { tree, path } = await createApplicationTree(alice.device);
+    tree = await tree.share(path, alice.device, bob.publicKey, "Bob", Permissions.OWNER);
+
+    const tampered = appendForgedBlock(tree.getChild(path)!, attacker.keyPair, [
+      new AddMember("Attacker", attacker.publicKey, Permissions.OWNER),
+    ]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not part of the group/);
+  });
+});
+
+describe("CommandStreamResolver stream creation gate", () => {
+  it("does not let a member without ownership escalate through a Derive block", async () => {
+    const alice = member();
+    const bob = member();
+    const attacker = member();
+
+    let { tree, path } = await createApplicationTree(alice.device);
+    tree = await tree.share(path, alice.device, bob.publicKey, "Bob", Permissions.MEMBER);
+
+    const tampered = appendForgedBlock(tree.getChild(path)!, bob.keyPair, [
+      forgedDerive(`m/0'/${APPLICATION_ID}'/0'`),
+      new AddMember("Attacker", attacker.publicKey, Permissions.OWNER),
+    ]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not allowed to derive/);
+  });
+
+  it("does not let a member without ownership escalate through a Seed block", async () => {
+    const alice = member();
+    const bob = member();
+
+    let { tree, path } = await createApplicationTree(alice.device);
+    tree = await tree.share(path, alice.device, bob.publicKey, "Bob", Permissions.MEMBER);
+
+    const tampered = appendForgedBlock(tree.getChild(path)!, bob.keyPair, [forgedSeed()]);
+
+    await expect(tampered.resolve()).rejects.toThrow(/not allowed to seed/);
+  });
+
+  it("still allows an owner to derive, which the signing path relies on", async () => {
+    const alice = member();
+    const tree = await StreamTree.createNewTree(alice.device);
+
+    // CommandStream.push prepends the root block, so SoftwareDevice.sign resolves [seed, derive, ...]
+    const prepended = appendForgedBlock(tree.getRoot(), alice.keyPair, [
+      forgedDerive(`m/0'/${APPLICATION_ID}'/0'`),
+    ]);
+
+    await expect(prepended.resolve()).resolves.toBeDefined();
+  });
+});
+
+describe("CommandStreamResolver legitimate flows", () => {
+  it("resolves a tree shared with two members", async () => {
+    const alice = member();
+    const bob = member();
+    const carol = member();
+
+    let { tree, path } = await createApplicationTree(alice.device);
+    tree = await tree.share(path, alice.device, bob.publicKey, "Bob", Permissions.OWNER);
+    tree = await tree.share(path, bob.device, carol.publicKey, "Carol", Permissions.OWNER);
+
+    const resolved = await tree.getChild(path)!.resolve();
+    expect(resolved.isCreated()).toBe(true);
+    expect(resolved.getMembersData().map(m => m.name)).toEqual(["Bob", "Carol"]);
+    expect(resolved.getMembers().map(k => crypto.to_hex(k))).toEqual([
+      crypto.to_hex(alice.publicKey),
+      crypto.to_hex(bob.publicKey),
+      crypto.to_hex(carol.publicKey),
+    ]);
+    expect(resolved.isOwner(carol.publicKey)).toBe(true);
+  });
+
+  it("lets a member close the stream it belongs to", async () => {
+    const alice = member();
+    const bob = member();
+
+    let { tree, path } = await createApplicationTree(alice.device);
+    tree = await tree.share(path, alice.device, bob.publicKey, "Bob", Permissions.OWNER);
+    tree = await tree.close(path, bob.device);
+
+    expect((await tree.getChild(path)!.resolve()).isClosed()).toBe(true);
+  });
+
+  it("supports rotating the application stream to a new derivation index", async () => {
+    const alice = member();
+    const bob = member();
+
+    let { tree, path } = await createApplicationTree(alice.device);
+    tree = await tree.share(path, alice.device, bob.publicKey, "Bob", Permissions.OWNER);
+    tree = await tree.close(path, alice.device);
+
+    const nextPath = tree.getApplicationRootPath(APPLICATION_ID, 1);
+    tree = await tree.share(nextPath, alice.device, bob.publicKey, "Bob", Permissions.OWNER);
+
+    const resolved = await tree.getChild(nextPath)!.resolve();
+    expect(resolved.getMembersData().map(m => m.name)).toEqual(["Bob"]);
+    expect(await bob.device.readKey(tree, DerivationPath.toIndexArray(nextPath))).toBeDefined();
+  });
+});

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
@@ -2,13 +2,22 @@ import { DefaultBodyType, http, HttpResponse, PathParams, StrictRequest } from "
 import { setupServer } from "msw/node";
 import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import {
+  AddMember,
   CommandBlock,
+  CommandStreamEncoder,
   crypto,
+  DerivationPath,
+  Derive,
   Device,
   Permissions,
   SoftwareDevice,
   StreamTree,
 } from "@ledgerhq/hw-ledger-key-ring-protocol";
+import {
+  createCommandBlock,
+  hashCommandBlock,
+  signCommandBlock,
+} from "@ledgerhq/hw-ledger-key-ring-protocol/CommandBlock";
 import { getEnv } from "@shared/env";
 import { PutCommandsRequest } from "../../api";
 import { HWDeviceProvider } from "../../HWDeviceProvider";
@@ -198,6 +207,67 @@ describe("Trustchain SDK", () => {
 
     expect(onTrustchainRotation).toHaveBeenCalledWith(sdk, trustchain, alice);
     expect(afterRotation).toHaveBeenCalledWith(newTrustchain);
+  });
+
+  it("rejects an application stream in which the backend injected a member", async () => {
+    const { alice } = MOCK_DATA.members;
+
+    // Mock trustchain states:
+    const device = new SoftwareDevice(convertLiveCredentialsToKeyPair(alice));
+    const tree = await createTrustChain(device).then(addMember(device, "m/0'/16'/0'", "alice"));
+
+    // Derive first: it grants OWNER to its issuer, which is what lets the AddMember through
+    const attacker = crypto.randomKeypair();
+    const applicationStream = tree.getChild("m/0'/16'/0'")!;
+    const forgedBlock = signCommandBlock(
+      createCommandBlock(
+        attacker.publicKey,
+        [
+          new Derive(
+            DerivationPath.toIndexArray("m/0'/16'/0'"),
+            crypto.randomKeypair().publicKey,
+            crypto.randomBytes(16),
+            crypto.randomBytes(64),
+            crypto.randomKeypair().publicKey,
+          ),
+          new AddMember("mallory", attacker.publicKey, Permissions.OWNER),
+        ],
+        new Uint8Array(),
+        hashCommandBlock(applicationStream.blocks[applicationStream.blocks.length - 1]),
+      ),
+      attacker.publicKey,
+      attacker.privateKey,
+    );
+    const tamperedTrustchain = {
+      ...tree.serialize(),
+      "m/0'/16'/0'": crypto.to_hex(
+        CommandStreamEncoder.encode(applicationStream.blocks.concat([forgedBlock])),
+      ),
+    };
+
+    // Mock API calls:
+    apiMocks.getChalenge.mockReturnValue({ json: {}, tlv: MOCK_DATA.challengeTlv });
+    apiMocks.postAuthenticate.mockReturnValue({
+      accessToken: "BACKEND JWT",
+      permissions: { ROOTID: { "m/0'/16'/0'": ["owner"] } },
+    });
+    HWDeviceProviderMethodsMocks.withJwt.mockImplementation(async (_deviceId, job) =>
+      job({ accessToken: "ACCESS TOKEN" }),
+    );
+
+    // Run the test:
+    const sdk = new SDK(sdkContext, hwDeviceProviderMock);
+    const trustchain = {
+      applicationPath: "m/0'/16'/0'",
+      rootId: "ROOTID",
+      walletSyncEncryptionKey: "",
+    };
+
+    apiMocks.getTrustchainByIdMock.mockReturnValueOnce(tree.serialize());
+    expect((await sdk.getMembers(trustchain, alice)).map(m => m.id)).toEqual([alice.pubkey]);
+
+    apiMocks.getTrustchainByIdMock.mockReturnValueOnce(tamperedTrustchain);
+    await expect(sdk.getMembers(trustchain, alice)).rejects.toThrow(/not part of the group/);
   });
 
   it("should recover from any 4xx indirectly caused by wrong JWT", async () => {


### PR DESCRIPTION
### 📝 Description

`exists()` in the trustchain command stream resolver had a misplaced `continue` in its inner byte loop, so it returned `true` for any entry matching only on length — making the issuer validation it backs ineffective. Rewrote the comparison, and tightened `Seed` / `Derive` (which grant ownership to their issuer) to require an existing owner once a stream is already created. Two unreachable conditions in `assertIssuerCanPublish` were also removed: an unsatisfiable bitmask compare and a comparison against a `Map` method's arity.

Covered by new resolver tests and one SDK-level test, all verified to fail before the fix. Existing suites, including the recorded device + backend replay scenarios, pass unchanged.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37072](https://ledgerhq.atlassian.net/browse/LIVE-37072)
- **ADR** (if any):


[LIVE-37072]: https://ledgerhq.atlassian.net/browse/LIVE-37072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ