### PR TITLE
[LWM] revert(lwm): disable R8 on Android release builds (LIVE-37086)

### DIFF
--- a/.changeset/eighty-pugs-shave.md
+++ b/.changeset/eighty-pugs-shave.md
@@ -1,5 +1,0 @@
----
-"live-mobile": patch
----
-
-Enable R8 code shrinking, optimization and obfuscation on Android release builds (LIVE-28531)

--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -84,7 +84,8 @@ def enableSeparateBuildPerCPUArchitecture = true
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = true
+// off while R8 is being stabilised: LIVE-37085
+def enableProguardInReleaseBuilds = false
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)


### PR DESCRIPTION
### 📝 Description

R8 keeps producing regressions that exist only in shipped builds (LIVE-37010, now LIVE-37084), so it goes off for a stabilisation period.

Deliberately not a `git revert` of #21296: two follow-ups landed on the same files since, and the `.pro` rules are worth keeping in tree for when we re-enable — they are inert while `minifyEnabled` is false. The flag is the only `minifyEnabled` in the Android tree and `stagingRelease` / `detox` / `detoxPreRelease` all `initWith` `release`, so it covers every variant.

The pending changeset is dropped rather than paired with a "disabled" one: no `release/*` branch contains 5edf6a4, so R8 never shipped to users.

> [!NOTE]
> Google's unoptimized-bundle deadline is Feb 2027. Re-enabling is tracked by LIVE-28531 under epic LIVE-37085, gated on a green LIVE-37023 smoke pass.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37086](https://ledgerhq.atlassian.net/browse/LIVE-37086) (epic [LIVE-37085](https://ledgerhq.atlassian.net/browse/LIVE-37085))
- **ADR** (if any): —

[LIVE-37086]: https://ledgerhq.atlassian.net/browse/LIVE-37086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37085]: https://ledgerhq.atlassian.net/browse/LIVE-37085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ