### PR TITLE
[LWM] fix(lwm): drop R8 optimization to fix custom lock screen (LIVE-37084)

### DIFF
--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -180,7 +180,7 @@ android {
         release {
             // no shrinkResources: one shrunk-resources per splits.abi ABI breaks bundleRelease https://issuetracker.google.com/402800800
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             matchingFallbacks = ['debug']
         }
         stagingRelease {


### PR DESCRIPTION
### 📝 Description

The custom lock screen flow fails in minified builds with expo-modules-core's `Call to function 'Context.resize' has been rejected`. R8's **optimizer** is the culprit — not shrinking, not obfuscation — so this switches to AGP's non-optimize default proguard file. The two default files differ by exactly two flags: this swaps `-allowaccessmodification` for `-dontoptimize`.

Bisected on a physical device (Android 15, arm64), five signed `stagingRelease` builds, reproducing the real flow each time:

| build | R8 config | result |
|---|---|---|
| A | R8 off entirely | works |
| B | `-keep class expo.modules.imagemanipulator.** { *; }` | fails |
| C | `-keep class kotlin.**` + `kotlinx.coroutines.**` | fails |
| D | `-dontoptimize` | works |
| E | this diff (`proguard-android.txt`) | works |

Shrinking and obfuscation stay on, so most of the win survives — dex is 47.7MB/6 files unminified, 18.3MB/3 files here, 12.9MB/2 files with the optimizer.

> [!IMPORTANT]
> Neither CI nor the nightlies can validate this while R8 is off (#21643), because `proguardFiles` is inert when `minifyEnabled` is false. The manual bisection above is the only evidence, which is why it is recorded here — re-run E when R8 is switched back on.

Two caveats worth knowing: which optimization pass breaks Expo is not isolated (worth an upstream report), and whether LIVE-37010 shares this mechanism is untested — if it does, re-enabling R8 with the optimizer off may be enough on its own.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37084](https://ledgerhq.atlassian.net/browse/LIVE-37084), epic [LIVE-37085](https://ledgerhq.atlassian.net/browse/LIVE-37085). Re-enabling is [LIVE-28531](https://ledgerhq.atlassian.net/browse/LIVE-28531).
- Independent of #21643 (different lines), but lands best after it — merged first and alone, it would leave R8 on with the optimizer off.
- **ADR** (if any): —

[LIVE-37084]: https://ledgerhq.atlassian.net/browse/LIVE-37084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ