### PR TITLE
[LWDM] fix(tezos): add UnexpectedGetBalanceError message (LIVE-36768)

### DIFF
--- a/.changeset/tezos-unexpected-getbalance-i18n.md
+++ b/.changeset/tezos-unexpected-getbalance-i18n.md
@@ -1,0 +1,10 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add an error message for `UnexpectedGetBalanceError`
+
+`@ledgerhq/coin-tezos` reports this error when a token balance cannot be retrieved, so Send Max
+no longer claims the account has insufficient funds during an indexer outage. Without a
+translation the send flow fell back to rendering the raw error name.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7226,6 +7226,10 @@
       "title": "Sorry, insufficient funds",
       "description": "Please make sure the account has enough funds."
     },
+    "UnexpectedGetBalanceError": {
+      "title": "Your balance could not be retrieved",
+      "description": "Please check your internet connection and try again."
+    },
     "NotEnoughTransferAmount": {
       "title": "A minimum of 1 ICP is required to stake into a neuron."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -705,6 +705,10 @@
       "title": "Sorry, insufficient funds",
       "description": "Please make sure the account has enough funds."
     },
+    "UnexpectedGetBalanceError": {
+      "title": "Your balance could not be retrieved",
+      "description": "Please check your internet connection and try again."
+    },
     "UnstakeNotEnoughStakedBalanceLeft": {
       "title": "If you unstake more than {{maxAmount}}, your total stake of {{totalAmount}} will be unstaked",
       "description": "If you unstake more than {{maxAmount}}, your total stake of {{totalAmount}} will be unstaked"


### PR DESCRIPTION
### 📝 Description

`@ledgerhq/coin-tezos@10.2.2` (catalog-bumped in #21647) reports a new `UnexpectedGetBalanceError` when a token balance cannot be retrieved, so Send Max no longer tells a holder of the token that they have insufficient funds during a TzKT outage.

Neither app had a translation for that error name. `TranslatedError` builds the key `errors.<error.name>.<field>`, and with no match it falls back to `errors.generic.<field>`, whose title is `"{{message}}"` — so the send flow rendered the raw error name to the user.

**Previous behaviour:** the send flow showed the bare string `UnexpectedGetBalanceError`.

**The fix:** adds the missing `errors.UnexpectedGetBalanceError` entry to both apps, next to its sibling `NotEnoughBalance`:

| | |
| --- | --- |
| title | Your balance could not be retrieved |
| description | Please check your internet connection and try again. |

Only `en` is edited — `static/i18n/README.md` states translations arrive via an automated incoming PR.

The error class lives in `@ledgerhq/coin-module-framework`, so this entry also covers any other coin module that reports it.

**Verification:** the error reaches the UI as a live instance with its `name` intact — `generic-coin-framework/getTransactionStatus.ts` passes the `errors` record straight through `addAccountToBuyLinks`, which only ever rewrites a `links` property. Both files parse, each key appears exactly once, and `prettier --check` is clean.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36768](https://ledgerhq.atlassian.net/browse/LIVE-36768) — follows LedgerHQ/coin-modules#846 and #21647
- **ADR** (if any): N/A


[LIVE-36768]: https://ledgerhq.atlassian.net/browse/LIVE-36768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ