### PR TITLE
[LWDM] fix(analytics): improve contacts and modular dialog tracking

### DIFF
--- a/.changeset/calm-contacts-tracking.md
+++ b/.changeset/calm-contacts-tracking.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@features/flow-contacts": minor
+"@features/flow-contacts-introduction": minor
+"@features/platform-contacts": minor
+---
+
+Align Contacts analytics events and properties with the tracking plan on desktop and mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -342,7 +342,10 @@ describe("Contacts integration", () => {
 
     await user.click(screen.getByRole("button", { name: "Sync my wallet" }));
 
-    expect(mockOpenActivationDrawer).toHaveBeenCalledWith({ startOnSyncMethod: true });
+    expect(mockOpenActivationDrawer).toHaveBeenCalledWith({
+      startOnSyncMethod: true,
+      analyticsFlow: "contacts",
+    });
     expect(
       screen.queryByTestId("contacts-ledger-sync-introduction-dialog"),
     ).not.toBeInTheDocument();

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/analytics/useContactsAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/analytics/useContactsAnalytics.ts
@@ -1,24 +1,18 @@
 import { createContactsAnalyticsHelper } from "@features/flow-contacts";
-import {
-  buildContactsGlobalProperties,
-  useContacts,
-  useContactsFeature,
-} from "@features/platform-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
 import { useMemo } from "react";
 import { createContactsAnalyticsAdapter } from "./createContactsAnalyticsAdapter";
 
 export function useContactsAnalytics() {
-  const { isEnabled } = useContactsFeature("desktop");
   const contacts = useContacts();
 
   return useMemo(
     () =>
       createContactsAnalyticsHelper(createContactsAnalyticsAdapter(), () =>
         buildContactsGlobalProperties({
-          ffAddressBookEnabled: isEnabled,
           contacts,
         }),
       ),
-    [contacts, isEnabled],
+    [contacts],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -34,7 +34,9 @@ describe("useContactsCurrencySelectionAdapter", () => {
         assets: { leftElement: "undefined", rightElement: "undefined" },
         networks: { leftElement: "undefined", rightElement: "undefined" },
       },
+      flow: "contacts",
       presentation: "embedded",
+      source: "contacts",
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -36,7 +36,9 @@ function createCurrencySelectionPort(
       resolveContactCurrencySelection(
         await openCurrencyFlow(networkIds, {
           dialogConfiguration: CONTACTS_CURRENCY_SELECTION_CONFIGURATION,
+          flow: "contacts",
           presentation: "embedded",
+          source: "contacts",
         }),
       ),
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
@@ -6,6 +6,7 @@ import {
   resolveContactDetailEditDeleteLabels,
   useContactDetailEditDeleteAnalytics,
   useContactDetailEditDeleteFlowBindings,
+  useContactsMeContact,
   useContactsEditDeletePorts,
 } from "@features/flow-contacts";
 import type { ContactsDeleteContactDialogProps } from "@features/flow-contacts-delete-contact";
@@ -34,6 +35,7 @@ export function useContactDetailEditDeleteAdapter(
 ): ContactDetailEditDeleteDialogProps {
   const { t } = useTranslation();
   const analytics = useContactsAnalytics();
+  const meContact = useContactsMeContact();
   const ports = useContactsEditDeletePorts(deviceIntents);
   const resolvedContactId = contactId ?? ContactIdSchema.parse("contact-me");
   const { flow, renameViewModel } = useContactDetailEditDeleteFlowBindings({
@@ -46,10 +48,11 @@ export function useContactDetailEditDeleteAdapter(
     () => createContactDetailEditDeleteUiState(flow, renameViewModel, labels),
     [flow, labels, renameViewModel],
   );
-  const { onEdit, onDelete } = useContactDetailEditDeleteAnalytics(
+  const { onEdit, onDelete, onConfirmDelete, onValidateEdit } = useContactDetailEditDeleteAnalytics(
     analytics,
     flow,
     uiState.signerMismatch.isOpen,
+    resolvedContactId === meContact.id,
   );
 
   return {
@@ -61,8 +64,14 @@ export function useContactDetailEditDeleteAdapter(
           onDelete,
         }
       : undefined,
-    renameDialog: uiState.rename,
-    deleteDialog: uiState.delete,
+    renameDialog: {
+      ...uiState.rename,
+      onConfirm: async () => {
+        onValidateEdit();
+        await uiState.rename.onConfirm();
+      },
+    },
+    deleteDialog: { ...uiState.delete, onConfirm: onConfirmDelete },
     signerMismatchDialog: uiState.signerMismatch,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -443,7 +443,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     trackContactsLedgerSyncActivate(analytics);
     dismissPendingIntent();
     setIsLedgerSyncIntroductionRequested(false);
-    openDrawer({ startOnSyncMethod: true });
+    openDrawer({ startOnSyncMethod: true, analyticsFlow: CONTACTS_FLOW.CONTACTS });
   }, [analytics, dismissPendingIntent, openDrawer]);
   const onRequestAddContact = useCallback(
     (onAllowed: () => void) => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useActivationDrawer.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useActivationDrawer.ts
@@ -1,27 +1,24 @@
 import { resetWalletSync, setDrawerVisibility } from "~/renderer/actions/walletSync";
 import {
-  AnalyticsFlow,
-  StepsOutsideFlow,
-  useLedgerSyncAnalytics,
+  setWalletSyncEntryFlow,
+  type WalletSyncFlow,
 } from "../../WalletSync/hooks/useLedgerSyncAnalytics";
-import { useMemo } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { walletSyncFakedSelector, walletSyncStepSelector } from "~/renderer/reducers/walletSync";
+import { walletSyncFakedSelector } from "~/renderer/reducers/walletSync";
 import { useFlows } from "../../WalletSync/hooks/useFlows";
 
 export type OpenActivationDrawerOptions = Readonly<{
   startOnSyncMethod?: boolean;
+  analyticsFlow?: WalletSyncFlow;
 }>;
 
 export function useActivationDrawer(onboardingNewDevice?: boolean) {
   const dispatch = useDispatch();
   const { goToWelcomeScreenWalletSync, goToSyncMethodScreenWalletSync } = useFlows();
   const hasBeenFaked = useSelector(walletSyncFakedSelector);
-  const currentStep = useSelector(walletSyncStepSelector);
-  const hasFlowEvent = useMemo(() => !StepsOutsideFlow.includes(currentStep), [currentStep]);
-  const { onActionTrack } = useLedgerSyncAnalytics();
 
   const openDrawer = (options?: OpenActivationDrawerOptions) => {
+    setWalletSyncEntryFlow(options?.analyticsFlow);
     if (!hasBeenFaked) {
       if (options?.startOnSyncMethod) {
         goToSyncMethodScreenWalletSync();
@@ -35,13 +32,8 @@ export function useActivationDrawer(onboardingNewDevice?: boolean) {
   const closeDrawer = () => {
     if (hasBeenFaked) {
       dispatch(resetWalletSync());
-    } else {
-      onActionTrack({
-        button: "Close",
-        step: currentStep,
-        flow: hasFlowEvent ? AnalyticsFlow : undefined,
-      });
     }
+    setWalletSyncEntryFlow(undefined);
     dispatch(setDrawerVisibility(false));
   };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogFlow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogFlow.tsx
@@ -150,6 +150,7 @@ export function ModularDialogFlow({
             networksConfiguration={networkConfiguration}
             onNetworkSelected={handleNetworkSelected}
             selectedAssetId={selectedAsset?.id}
+            selectedAssetName={selectedAsset?.name}
             selectableNetworkIds={selectableNetworkIds}
           />
         );

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
@@ -118,7 +118,7 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     bitcoinAsset.parentElement?.focus();
 
     expect(bitcoinAsset.parentElement).toHaveFocus();
-    expect(bitcoinAsset.parentElement).toHaveAttribute("role", "button");
+    expect(bitcoinAsset.parentElement?.tagName).toBe("BUTTON");
     expect(bitcoinAsset.parentElement).toHaveAttribute("aria-disabled", "true");
   });
 
@@ -148,7 +148,7 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     arbitrumNetwork.parentElement?.focus();
 
     expect(arbitrumNetwork.parentElement).toHaveFocus();
-    expect(arbitrumNetwork.parentElement).toHaveAttribute("role", "button");
+    expect(arbitrumNetwork.parentElement?.tagName).toBe("BUTTON");
     expect(arbitrumNetwork.parentElement).toHaveAttribute("aria-disabled", "true");
 
     await user.click(ethereumNetwork);

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/analytics/modularDialog.types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/analytics/modularDialog.types.ts
@@ -59,6 +59,8 @@ export type ModularDialogEventParams = {
   [EVENTS_NAME.BUTTON_CLICKED]: {
     page: string;
     button: string;
+    asset?: string;
+    network?: string;
   };
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { setFlowValue, setSourceValue } from "~/renderer/reducers/modularDialog";
 import { useOpenCurrencyFlow } from "../useOpenCurrencyFlow";
 
 describe("useOpenCurrencyFlow", () => {
@@ -93,6 +94,28 @@ describe("useOpenCurrencyFlow", () => {
 
     await expect(selection).resolves.toBeNull();
     expect(store.getState().modularDialog.isOpen).toBe(false);
+  });
+
+  it("should set MAD flow and source only when the caller provides them", () => {
+    const { result, store } = renderHook(() => useOpenCurrencyFlow());
+
+    act(() => {
+      store.dispatch(setFlowValue("send"));
+      store.dispatch(setSourceValue("portfolio"));
+    });
+
+    void result.current.openCurrencyFlow([ethereum.id]);
+
+    expect(store.getState().modularDialog.flow).toBe("send");
+    expect(store.getState().modularDialog.source).toBe("portfolio");
+
+    void result.current.openCurrencyFlow([ethereum.id], {
+      flow: "contacts",
+      source: "contacts",
+    });
+
+    expect(store.getState().modularDialog.flow).toBe("contacts");
+    expect(store.getState().modularDialog.source).toBe("contacts");
   });
 
   it("should cancel its pending selection before opening another one", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
@@ -6,6 +6,8 @@ import { useDispatch, useStore } from "LLD/hooks/redux";
 import {
   closeDialog,
   openDialog,
+  setFlowValue,
+  setSourceValue,
   type ModularDialogPresentation,
 } from "~/renderer/reducers/modularDialog";
 
@@ -22,6 +24,8 @@ export type OpenCurrencyFlow = (
   options?: Readonly<{
     dialogConfiguration?: EnhancedModularDrawerConfiguration;
     presentation?: ModularDialogPresentation;
+    flow?: string;
+    source?: string;
   }>,
 ) => Promise<CryptoOrTokenCurrency | null>;
 
@@ -65,6 +69,12 @@ export function useOpenCurrencyFlow(): Readonly<{
 
         pendingSelectionRef.current = { requestId, onAssetSelected, settle };
 
+        if (options?.flow !== undefined) {
+          dispatch(setFlowValue(options.flow));
+        }
+        if (options?.source !== undefined) {
+          dispatch(setSourceValue(options.source));
+        }
         dispatch(
           openDialog({
             dialogConfiguration: options?.dialogConfiguration,

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, type KeyboardEvent } from "react";
+import React, { useCallback, useState } from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import {
   ListItem,
@@ -22,6 +22,7 @@ const copyToClipboard = async (text: string) => {
 
 type AssetListItemProps = AssetType & {
   onClick: (asset: AssetType) => void;
+  onDisabledClick?: (asset: AssetType) => void;
 };
 
 const renderDescriptionTag = ({
@@ -57,6 +58,7 @@ export const AssetListItem = ({
   ticker,
   id,
   onClick,
+  onDisabledClick,
   leftElement,
   rightElement,
   numberOfNetworks,
@@ -68,17 +70,9 @@ export const AssetListItem = ({
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   const handleDisabledItemClick = useCallback(() => {
+    onDisabledClick?.({ name, ticker, id });
     setIsTooltipOpen(true);
-  }, []);
-
-  const handleDisabledItemKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
-    if (event.key !== "Enter" && event.key !== " ") {
-      return;
-    }
-
-    event.preventDefault();
-    setIsTooltipOpen(true);
-  }, []);
+  }, [id, name, onDisabledClick, ticker]);
 
   const handleClick = () => {
     if (disabled) return;
@@ -119,16 +113,14 @@ export const AssetListItem = ({
   return (
     <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
       <TooltipTrigger asChild>
-        <span
-          className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
-          tabIndex={0}
-          role="button"
+        <button
+          type="button"
+          className="block w-full border-0 bg-transparent p-0 text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
           aria-disabled
           onClick={handleDisabledItemClick}
-          onKeyDown={handleDisabledItemKeyDown}
         >
           {listItem}
-        </span>
+        </button>
       </TooltipTrigger>
       <TooltipContent>
         {t("modularAssetDrawer.unsupportedAssetTooltip", { asset: name })}

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetSelectorContent/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetSelectorContent/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { AssetType } from "../../../../types";
 import { useModularDialogAnalytics } from "../../../../analytics/useModularDialogAnalytics";
+import { MODULAR_DIALOG_PAGE_NAME } from "../../../../analytics/modularDialog.types";
 import SkeletonList from "../../../../components/SkeletonList";
 import { MarketPriceIndicator, MarketPercentIndicator } from "../../../../components/Market";
 import { useAssetConfiguration } from "@ledgerhq/live-common/modularDrawer/modules/createAssetConfiguration";
@@ -29,8 +30,6 @@ export type AssetSelectorContentProps = {
   assetsSorted?: AssetData[];
   disabledAssetIds?: ReadonlySet<string>;
 };
-
-const CURRENT_PAGE = "Modular Asset Selection";
 
 export const AssetSelectorContent = ({
   assetsToDisplay,
@@ -85,7 +84,7 @@ export const AssetSelectorContent = ({
         "asset_clicked",
         {
           asset: selectedAsset.name,
-          page: CURRENT_PAGE,
+          page: MODULAR_DIALOG_PAGE_NAME.MODULAR_ASSET_SELECTION,
         },
         {
           formatAssetConfig: true,
@@ -96,6 +95,16 @@ export const AssetSelectorContent = ({
       onAssetSelected(selectedAsset);
     },
     [assetsToDisplay, trackModularDialogEvent, assetsConfiguration, onAssetSelected],
+  );
+  const onDisabledClick = useCallback(
+    (asset: AssetType) => {
+      trackModularDialogEvent("button_clicked", {
+        asset: asset.name,
+        button: "disabled network tooltip",
+        page: MODULAR_DIALOG_PAGE_NAME.MODULAR_ASSET_SELECTION,
+      });
+    },
+    [trackModularDialogEvent],
   );
 
   useEffect(() => {
@@ -117,6 +126,7 @@ export const AssetSelectorContent = ({
       scrollToTop={scrollToTop}
       assets={formattedAssets}
       onClick={onClick}
+      onDisabledClick={onDisabledClick}
       onVisibleItemsScrollEnd={loadNext}
       hasNextPage={!!loadNext}
       isDebuggingDuplicates={isDebuggingDuplicates}

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetVirtualList/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetVirtualList/index.tsx
@@ -12,6 +12,7 @@ import {
 type AssetVirtualListProps = {
   assets: AssetType[];
   onClick: (asset: AssetType) => void;
+  onDisabledClick?: (asset: AssetType) => void;
   onVisibleItemsScrollEnd?: () => void;
   scrollToTop?: boolean;
   hasNextPage?: boolean;
@@ -24,6 +25,7 @@ const isUnavailableAsset = (asset: AssetType) => !!asset.disabled;
 export const AssetVirtualList = ({
   assets,
   onClick,
+  onDisabledClick,
   onVisibleItemsScrollEnd,
   scrollToTop,
   hasNextPage,
@@ -37,9 +39,14 @@ export const AssetVirtualList = ({
       row.kind === "unavailableSectionHeader" ? (
         <UnavailableSectionHeader testId="asset-selector-unavailable-assets-header" />
       ) : (
-        <AssetListItem {...row.item} shouldDisplayId={isDebuggingDuplicates} onClick={onClick} />
+        <AssetListItem
+          {...row.item}
+          shouldDisplayId={isDebuggingDuplicates}
+          onClick={onClick}
+          onDisabledClick={onDisabledClick}
+        />
       ),
-    [onClick, isDebuggingDuplicates],
+    [isDebuggingDuplicates, onClick, onDisabledClick],
   );
 
   const getItemHeight = useCallback(

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useState,
-  type KeyboardEvent,
-  type ReactElement,
-  type ReactNode,
-} from "react";
+import React, { useCallback, useState, type ReactElement, type ReactNode } from "react";
 import {
   ListItem,
   ListItemTitle,
@@ -29,6 +23,7 @@ export type NetworkListItemData = {
 
 type NetworkListItemProps = NetworkListItemData & {
   onClick: () => void;
+  onDisabledClick?: () => void;
   disabled?: boolean;
 };
 
@@ -38,23 +33,16 @@ export const NetworkListItem = ({
   rightElement,
   apy,
   onClick,
+  onDisabledClick,
   disabled,
 }: NetworkListItemProps) => {
   const { t } = useTranslation();
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   const handleDisabledItemClick = useCallback(() => {
+    onDisabledClick?.();
     setIsTooltipOpen(true);
-  }, []);
-
-  const handleDisabledItemKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
-    if (event.key !== "Enter" && event.key !== " ") {
-      return;
-    }
-
-    event.preventDefault();
-    setIsTooltipOpen(true);
-  }, []);
+  }, [onDisabledClick]);
 
   const listItem = (
     <ListItem
@@ -85,19 +73,19 @@ export const NetworkListItem = ({
   return (
     <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
       <TooltipTrigger asChild>
-        <span
-          className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
-          tabIndex={0}
-          role="button"
+        <button
+          type="button"
+          className="block w-full border-0 bg-transparent p-0 text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
           aria-disabled
           onClick={handleDisabledItemClick}
-          onKeyDown={handleDisabledItemKeyDown}
         >
           {listItem}
-        </span>
+        </button>
       </TooltipTrigger>
       <TooltipContent>
-        {t("modularAssetDrawer.unsupportedNetworkTooltip", { network: currency.name })}
+        {t("modularAssetDrawer.unsupportedNetworkTooltip", {
+          network: currency.name,
+        })}
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkSelectorContent/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkSelectorContent/index.tsx
@@ -17,6 +17,7 @@ type NetworkSelectorContentProps = {
   onNetworkSelected: (network: CryptoOrTokenCurrency) => void;
   networksConfig: EnhancedModularDrawerConfiguration["networks"];
   selectedAssetId?: string;
+  selectedAssetName?: string;
   selectableNetworkIds?: readonly string[];
 };
 
@@ -25,6 +26,7 @@ export const NetworkSelectorContent = ({
   onNetworkSelected,
   networksConfig,
   selectedAssetId,
+  selectedAssetName,
   selectableNetworkIds,
 }: NetworkSelectorContentProps) => {
   const { trackModularDialogEvent } = useModularDialogAnalytics();
@@ -71,11 +73,20 @@ export const NetworkSelectorContent = ({
 
     onNetworkSelected(network);
   };
+  const onDisabledClick = (network: CryptoOrTokenCurrency) => {
+    trackModularDialogEvent("button_clicked", {
+      button: "disabled network tooltip",
+      network: network.name,
+      ...(selectedAssetName ? { asset: selectedAssetName } : {}),
+      page: MODULAR_DIALOG_PAGE_NAME.MODULAR_NETWORK_SELECTION,
+    });
+  };
 
   return (
     <NetworkVirtualList
       networks={formattedNetworks}
       onClick={onClick}
+      onDisabledClick={onDisabledClick}
       selectableNetworkIdSet={selectableNetworkIdSet}
     />
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkVirtualList/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkVirtualList/index.tsx
@@ -19,6 +19,7 @@ type NetworkWithUI = CryptoOrTokenCurrency & {
 type NetworkVirtualListProps = {
   networks: NetworkWithUI[];
   onClick: (networkId: string) => void;
+  onDisabledClick?: (network: NetworkWithUI) => void;
   selectableNetworkIdSet?: ReadonlySet<string>;
 };
 
@@ -28,6 +29,7 @@ const getNetworkId = (network: NetworkWithUI) =>
 export const NetworkVirtualList = ({
   networks,
   onClick,
+  onDisabledClick,
   selectableNetworkIdSet,
 }: NetworkVirtualListProps) => {
   const isUnavailableNetwork = useCallback(
@@ -55,10 +57,11 @@ export const NetworkVirtualList = ({
           apy={network.apy}
           disabled={selectableNetworkIdSet ? !selectableNetworkIdSet.has(networkId) : undefined}
           onClick={() => onClick(networkId)}
+          onDisabledClick={() => onDisabledClick?.(network)}
         />
       );
     },
-    [onClick, selectableNetworkIdSet],
+    [onClick, onDisabledClick, selectableNetworkIdSet],
   );
 
   const getItemHeight = useCallback(

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/index.tsx
@@ -10,6 +10,7 @@ export type NetworkSelectorProps = {
   networksConfiguration: EnhancedModularDrawerConfiguration["networks"];
   onNetworkSelected: (network: CryptoOrTokenCurrency) => void;
   selectedAssetId?: string;
+  selectedAssetName?: string;
   selectableNetworkIds?: readonly string[];
 };
 
@@ -18,6 +19,7 @@ export function NetworkSelector({
   onNetworkSelected,
   networksConfiguration,
   selectedAssetId,
+  selectedAssetName,
   selectableNetworkIds,
 }: Readonly<NetworkSelectorProps>) {
   return (
@@ -32,6 +34,7 @@ export function NetworkSelector({
         onNetworkSelected={onNetworkSelected}
         networksConfig={networksConfiguration}
         selectedAssetId={selectedAssetId}
+        selectedAssetName={selectedAssetName}
         selectableNetworkIds={selectableNetworkIds}
       />
     </>

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -13,6 +13,7 @@ import {
   useContactsLedgerSyncMutationGuard,
   trackContactsLedgerSyncActivate,
   trackContactsLedgerSyncDismiss,
+  CONTACTS_FLOW,
 } from "@features/flow-contacts";
 import {
   isContactsLedgerSyncActivationRequired,
@@ -115,7 +116,7 @@ export function usePayTabContacts(): UsePayTabContactsResult {
     trackContactsLedgerSyncActivate(analytics);
     dismissPendingIntent();
     setIsLedgerSyncIntroductionRequested(false);
-    openDrawer({ startOnSyncMethod: true });
+    openDrawer({ startOnSyncMethod: true, analyticsFlow: CONTACTS_FLOW.CONTACTS });
   }, [analytics, dismissPendingIntent, openDrawer]);
   const onDismissLedgerSyncIntroduction = useCallback(() => {
     trackContactsLedgerSyncDismiss(analytics);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -16,12 +16,11 @@ import {
   useContactsIntentsOrchestrator,
   type ContactsDeviceIntentExecutorProps,
 } from "@features/platform-contacts/device";
-import { CONTACTS_EVENT_SOURCE } from "@features/flow-contacts";
 import {
-  buildContactsGlobalProperties,
-  useContacts,
-  useContactsFeature,
-} from "@features/platform-contacts";
+  buildContactsSaveAddressClickProperties,
+  CONTACTS_EVENT_SOURCE,
+} from "@features/flow-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
 import {
   isPrefillAddAddressFlowOpen,
   useAddAddressFlowViewModel,
@@ -80,7 +79,6 @@ export function useSendPrefillAddAddressFlow({
   const { navigation } = useFlowWizard<SendFlowStep>();
   const { state, recipientSearch } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
   const { inputMethod, markContactSaved } = useSendFlowTracking();
   const { setState: setHeaderState } = useAddNewContactHeaderController();
   const [isOpeningAddressFlow, setIsOpeningAddressFlow] = useState(false);
@@ -105,11 +103,10 @@ export function useSendPrefillAddAddressFlow({
     () => ({
       ...getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),
       ...buildContactsGlobalProperties({
-        ffAddressBookEnabled: isContactsFeatureEnabled,
         contacts,
       }),
     }),
-    [contacts, isContactsFeatureEnabled, state.account.account, state.account.parentAccount],
+    [contacts, state.account.account, state.account.parentAccount],
   );
 
   const trackedAddressPhaseRef = useRef("");
@@ -357,6 +354,15 @@ export function useSendPrefillAddAddressFlow({
           if (!addressFlowState.displayContext) {
             return;
           }
+          track(
+            "button_clicked",
+            buildContactsSaveAddressClickProperties(trackingProperties, {
+              page: "address review",
+              network: addressFlowState.displayContext.network.networkId,
+              asset: addressFlowState.selectedCurrencyId,
+              inputMethod,
+            }),
+          );
           trackPage("Modal send - address signing device", null, {
             ...trackingProperties,
             network: addressFlowState.displayContext.network.networkId,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
@@ -9,11 +9,7 @@ import {
   type AddContactDialogViewModel,
 } from "@features/flow-contacts-add-contact";
 import { CONTACTS_EVENT_SOURCE } from "@features/flow-contacts";
-import {
-  buildContactsGlobalProperties,
-  useContacts,
-  useContactsFeature,
-} from "@features/platform-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { v4 as uuid } from "uuid";
@@ -40,7 +36,6 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   const dispatch = useDispatch();
   const { state } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
   const { addressPhase, isOpeningAddressFlow, startForContact } = useSendPrefillAddAddressFlow({
     idleHeaderState: DEFAULT_ADD_NEW_CONTACT_HEADER_STATE,
     contactType: "new",
@@ -49,11 +44,10 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
     () => ({
       ...getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),
       ...buildContactsGlobalProperties({
-        ffAddressBookEnabled: isContactsFeatureEnabled,
         contacts,
       }),
     }),
-    [contacts, isContactsFeatureEnabled, state.account.account, state.account.parentAccount],
+    [contacts, state.account.account, state.account.parentAccount],
   );
   const contactCreation = useMemo(
     () => createContactCreationPort({ dispatch, generateId: uuid }),
@@ -87,11 +81,12 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   const callbacks = useMemo(
     () => ({
       onOpen: () => {
-        trackPage("Modal send - add contact", null, trackingProperties);
+        trackPage("Add Contact", null, trackingProperties);
       },
       onConfirm: () => {
         track("button_clicked", {
-          button: "confirm name",
+          button: "save contact",
+          hasPicture: false,
           page: "add contact",
           ...trackingProperties,
         });

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useAddMember.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useAddMember.test.ts
@@ -5,6 +5,7 @@ import { renderHook, waitFor } from "tests/testSetup";
 import { TrustchainResultType } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
+import { AnalyticsFlow } from "../hooks/useLedgerSyncAnalytics";
 import { useAddMember } from "../hooks/useAddMember";
 import {
   TrustchainAlreadyInitialized,
@@ -56,7 +57,7 @@ describe("useAddMember", () => {
       hasTrustchainBeenCreated: true,
     });
     expect(Mocks.track).toHaveBeenCalledTimes(1);
-    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_activated");
+    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_activated", { flow: AnalyticsFlow });
   });
 
   it("should get an existing trustchain", async () => {
@@ -81,7 +82,7 @@ describe("useAddMember", () => {
       hasTrustchainBeenCreated: false,
     });
     expect(Mocks.track).toHaveBeenCalledTimes(1);
-    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_activated");
+    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_activated", { flow: AnalyticsFlow });
   });
 
   it("should handle missing device", async () => {
@@ -200,7 +201,7 @@ jest.mock("~/renderer/actions/walletSync", () => ({
 }));
 
 jest.mock("~/renderer/analytics/segment", () => ({
-  track: (event: string) => Mocks.track(event),
+  track: (event: string, props?: Record<string, unknown>) => Mocks.track(event, props),
   setAnalyticsFeatureFlagMethod: jest.fn(),
 }));
 

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useLedgerSyncAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useLedgerSyncAnalytics.test.ts
@@ -4,6 +4,10 @@ import {
   StepMappedToAnalytics,
   AnalyticsPage,
   StepsOutsideFlow,
+  setWalletSyncEntryFlow,
+  resolveWalletSyncEntryFlow,
+  walletSyncEntryFlowProperties,
+  AnalyticsFlow,
 } from "../hooks/useLedgerSyncAnalytics";
 import { Step } from "~/renderer/reducers/walletSync";
 
@@ -48,6 +52,24 @@ describe("useLedgerSyncAnalytics", () => {
       page: StepMappedToAnalytics[Step.DeleteBackup],
       flow: "Ledger Sync",
     });
+  });
+});
+
+describe("walletSyncEntryFlow", () => {
+  afterEach(() => {
+    setWalletSyncEntryFlow(undefined);
+  });
+
+  it("should resolve contacts flow when set from the contacts entry", () => {
+    setWalletSyncEntryFlow("contacts");
+
+    expect(resolveWalletSyncEntryFlow(AnalyticsFlow)).toBe("contacts");
+    expect(walletSyncEntryFlowProperties(AnalyticsFlow)).toEqual({ flow: "contacts" });
+  });
+
+  it("should fall back to Ledger Sync when no contacts entry is set", () => {
+    expect(resolveWalletSyncEntryFlow(AnalyticsFlow)).toBe(AnalyticsFlow);
+    expect(walletSyncEntryFlowProperties()).toEqual({});
   });
 });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/components/Drawer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/components/Drawer.tsx
@@ -11,6 +11,7 @@ import {
   AnalyticsFlow,
   StepsOutsideFlow,
   AnalyticsPage,
+  resolveWalletSyncEntryFlow,
 } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
 import { BackRef, WalletSyncRouter } from "LLD/features/WalletSync/screens/router";
 import { STEPS_WITH_BACK } from "LLD/features/WalletSync/hooks/useFlows";
@@ -49,7 +50,7 @@ const WalletSyncDrawer: React.FC<WalletSyncDrawerProps> = ({ currentPage, onClos
       onActionTrack({
         button: "Back",
         step: currentStep,
-        flow: hasFlowEvent ? AnalyticsFlow : undefined,
+        flow: hasFlowEvent ? resolveWalletSyncEntryFlow(AnalyticsFlow) : undefined,
       });
       if (onBack) onBack();
     }
@@ -59,7 +60,7 @@ const WalletSyncDrawer: React.FC<WalletSyncDrawerProps> = ({ currentPage, onClos
     onActionTrack({
       button: "Close",
       step: currentStep,
-      flow: hasFlowEvent ? AnalyticsFlow : undefined,
+      flow: hasFlowEvent ? resolveWalletSyncEntryFlow(AnalyticsFlow) : undefined,
     });
     dispatch(setDrawerVisibility(false));
     onClose();

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/components/GenericStatusDisplay.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/components/GenericStatusDisplay.tsx
@@ -2,7 +2,11 @@ import { Box, Flex, Icons, Text } from "@ledgerhq/react-ui";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
-import { AnalyticsFlow, AnalyticsPage } from "../hooks/useLedgerSyncAnalytics";
+import {
+  AnalyticsFlow,
+  AnalyticsPage,
+  walletSyncEntryFlowProperties,
+} from "../hooks/useLedgerSyncAnalytics";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import ButtonV3 from "~/renderer/components/ButtonV3";
 
@@ -71,6 +75,10 @@ export const GenericStatusDisplay = ({
     </>
   );
 
+  const trackPage = (
+    <TrackPage category={String(analyticsPage)} {...walletSyncEntryFlowProperties(AnalyticsFlow)} />
+  );
+
   const buttons = (withClose || withCta) && (
     <BottomContainer
       mb={fullHeight ? undefined : 3}
@@ -96,7 +104,7 @@ export const GenericStatusDisplay = ({
   if (fullHeight) {
     return (
       <Flex flexDirection="column" alignItems="center" height="80%">
-        <TrackPage category={String(analyticsPage)} flow={AnalyticsFlow} />
+        {trackPage}
         <Flex
           flexDirection="column"
           alignItems="center"
@@ -113,7 +121,7 @@ export const GenericStatusDisplay = ({
 
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="center" rowGap="24px">
-      <TrackPage category={String(analyticsPage)} flow={AnalyticsFlow} />
+      {trackPage}
       {content}
       {buttons}
     </Flex>

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -10,7 +10,11 @@ import { useTrustchainSdk } from "./useTrustchainSdk";
 import { TrustchainResult, TrustchainResultType } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { track } from "~/renderer/analytics/segment";
-import { AnalyticsPage } from "./useLedgerSyncAnalytics";
+import {
+  AnalyticsFlow,
+  AnalyticsPage,
+  walletSyncEntryFlowProperties,
+} from "./useLedgerSyncAnalytics";
 import { saveSettings, setLastOnboardedDevice } from "~/renderer/actions/settings";
 import { useNavigate } from "react-router";
 
@@ -40,7 +44,7 @@ export function useAddMember({
   const transitionToNextScreen = useCallback(
     (trustchainResult: TrustchainResult) => {
       dispatch(setTrustchain(trustchainResult.trustchain));
-      track("ledgersync_activated");
+      track("ledgersync_activated", walletSyncEntryFlowProperties(AnalyticsFlow));
       if (sourcePage === AnalyticsPage.Onboarding) {
         if (!isOnboardingNewDeviceInitial.current) {
           dispatch(saveSettings({ hasCompletedOnboarding: true }));

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useLedgerSyncAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useLedgerSyncAnalytics.ts
@@ -1,3 +1,4 @@
+import type { ContactsFlow } from "@features/flow-contacts";
 import { track } from "~/renderer/analytics/segment";
 import { Step } from "~/renderer/reducers/walletSync";
 
@@ -47,16 +48,35 @@ export enum AnalyticsPage {
 export type AnalyticsFlow = "Ledger Sync";
 export const AnalyticsFlow = "Ledger Sync";
 
+export type WalletSyncFlow = AnalyticsFlow | ContactsFlow;
+
+let walletSyncEntryFlow: WalletSyncFlow | undefined;
+
+export function setWalletSyncEntryFlow(flow?: WalletSyncFlow): void {
+  walletSyncEntryFlow = flow;
+}
+
+export function resolveWalletSyncEntryFlow(fallback?: WalletSyncFlow): WalletSyncFlow | undefined {
+  return walletSyncEntryFlow ?? fallback;
+}
+
+export function walletSyncEntryFlowProperties(
+  fallback?: WalletSyncFlow,
+): Readonly<{ flow: WalletSyncFlow }> | Record<string, never> {
+  const flow = resolveWalletSyncEntryFlow(fallback);
+  return flow ? { flow } : {};
+}
+
 type OnClickTrack = {
   button: string;
   page: string;
-  flow?: AnalyticsFlow;
+  flow?: WalletSyncFlow;
 };
 
 type onActionTrack = {
   button: string;
   step: Step;
-  flow?: AnalyticsFlow;
+  flow?: WalletSyncFlow;
 };
 
 export const StepMappedToAnalytics: Record<Step, string> = {

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useQRCode.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useQRCode.ts
@@ -17,7 +17,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { track } from "~/renderer/analytics/segment";
 import { QueryKey } from "./type.hooks";
 import { useInstanceName } from "./useInstanceName";
-import { AnalyticsPage } from "./useLedgerSyncAnalytics";
+import {
+  AnalyticsFlow,
+  AnalyticsPage,
+  walletSyncEntryFlowProperties,
+} from "./useLedgerSyncAnalytics";
 import { saveSettings } from "~/renderer/actions/settings";
 import { useNavigate } from "react-router";
 
@@ -84,7 +88,9 @@ export function useQRCode({ sourcePage }: { sourcePage?: AnalyticsPage }) {
     onSuccess(newTrustchain) {
       if (newTrustchain) {
         dispatch(setTrustchain(newTrustchain));
-        if (!trustchain) track("ledgersync_activated");
+        if (!trustchain) {
+          track("ledgersync_activated", walletSyncEntryFlowProperties(AnalyticsFlow));
+        }
       }
       if (sourcePage === AnalyticsPage.Onboarding) {
         dispatch(saveSettings({ hasCompletedOnboarding: true }));

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/Activation/04-LoadingStep.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/Activation/04-LoadingStep.tsx
@@ -4,7 +4,11 @@ import { useSelector } from "LLD/hooks/redux";
 import { themeSelector } from "~/renderer/actions/general";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Loading from "../../components/LoadingStep";
-import { AnalyticsFlow, AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
+import {
+  AnalyticsFlow,
+  AnalyticsPage,
+  walletSyncEntryFlowProperties,
+} from "../../hooks/useLedgerSyncAnalytics";
 import { useLoadingStep } from "../../hooks/useLoadingStep";
 
 export default function ActivationLoadingStep() {
@@ -15,7 +19,10 @@ export default function ActivationLoadingStep() {
 
   return (
     <>
-      <TrackPage category={String(AnalyticsPage.Loading)} flow={AnalyticsFlow} />
+      <TrackPage
+        category={String(AnalyticsPage.Loading)}
+        {...walletSyncEntryFlowProperties(AnalyticsFlow)}
+      />
       <Loading
         title={t(title)}
         subtitle={t("walletSync.loading.activation")}

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/Synchronize/01-SyncModeStep.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/Synchronize/01-SyncModeStep.tsx
@@ -4,7 +4,11 @@ import { useTranslation } from "react-i18next";
 import { Card } from "../../components/Card";
 import styled, { useTheme } from "styled-components";
 import TrackPage from "~/renderer/analytics/TrackPage";
-import { AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
+import {
+  AnalyticsFlow,
+  AnalyticsPage,
+  walletSyncEntryFlowProperties,
+} from "../../hooks/useLedgerSyncAnalytics";
 
 type Props = {
   goToQRCode: () => void;
@@ -16,7 +20,10 @@ export default function SynchronizeModeStep({ goToQRCode, goToSyncWithDevice }: 
   const { colors } = useTheme();
   return (
     <Flex flexDirection="column" rowGap="16px">
-      <TrackPage category={AnalyticsPage.SyncMethod} />
+      <TrackPage
+        category={AnalyticsPage.SyncMethod}
+        {...walletSyncEntryFlowProperties(AnalyticsFlow)}
+      />
       <Text fontSize={23} variant="large" color="neutral.c100">
         {t("walletSync.synchronize.chooseMethod.title")}
       </Text>

--- a/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.test.tsx
@@ -87,6 +87,23 @@ describe("TrackPage", () => {
           optInPersonalRecommendations: false,
         }),
       );
+
+      rerender(
+        <TrackPage category="Analytics Consent" name="Mandatory" flow="test-flow" mandatory />,
+      );
+      await waitFor(() => expect(events).toHaveLength(1));
+
+      rerender(<TrackPage category="Analytics Consent" name="Mandatory" flow="send" mandatory />);
+
+      await waitFor(() => expect(events).toHaveLength(2));
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          eventName: "Page Analytics Consent Mandatory",
+          eventPropertiesWithoutExtra: expect.objectContaining({
+            flow: "send",
+          }),
+        }),
+      );
     } finally {
       subscription.unsubscribe();
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.ts
@@ -35,6 +35,14 @@ type Props = {
   [key: string]: unknown;
 };
 
+function getPagePropertiesKey(properties: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(properties);
+  } catch {
+    return "";
+  }
+}
+
 /**
  * On mount, this component will track an event which will have the name
  * `Page ${category}${name ? " " + name : ""}`.
@@ -46,9 +54,18 @@ const TrackPage: React.FC<Props> = ({
   mandatory = false,
   ...properties
 }) => {
+  const propertiesKey = getPagePropertiesKey(properties);
+
   useEffect(() => {
-    trackPage(category, name, properties, true, refreshSource, mandatory);
-  }, [category, name, properties, refreshSource, mandatory]);
+    trackPage(
+      category,
+      name,
+      propertiesKey ? JSON.parse(propertiesKey) : undefined,
+      true,
+      refreshSource,
+      mandatory,
+    );
+  }, [category, name, propertiesKey, refreshSource, mandatory]);
   return null;
 };
 

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -9,6 +9,8 @@ import { runOnceWhen } from "@ledgerhq/live-common/utils/runOnceWhen";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { getEnv } from "@shared/env";
 import { getDefaultAccountName } from "@domain/entity-account-name";
+import { selectContacts } from "@domain/entity-contact";
+import { buildContactsGlobalProperties } from "@features/platform-contacts";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { idsToLanguage } from "@ledgerhq/types-live";
 import type { Feature, FeatureId, Features } from "@shared/feature-flags";
@@ -269,6 +271,10 @@ const extraProperties = (store: ReduxStore) => {
   const device = lastSeenDeviceSelector(state);
   const devices = devicesModelListSelector(state);
   const accounts = accountsSelector(state);
+  const contactsAttributes = buildContactsGlobalProperties({
+    contacts: selectContacts(state),
+  });
+  const contactsFeature = analyticsFeatureFlagMethod?.("lwdContacts") ?? { enabled: false };
   const { postOnboardingInProgress } = hubStateSelector(state);
 
   const isOnboardingReceiveFlow = onboardingReceiveFlowSelector(state);
@@ -364,6 +370,8 @@ const extraProperties = (store: ReduxStore) => {
     sessionId,
     sidebarCollapsed,
     accountsWithFunds,
+    ContactsAttributes: contactsFeature,
+    ...contactsAttributes,
     tokenWithFunds,
     modelIdList: devices,
     ...ptxAttributes,

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -28,6 +28,8 @@ import { getTokensWithFunds } from "@ledgerhq/live-common/domain/getTokensWithFu
 import { getEnv } from "@shared/env";
 import { getAndroidArchitecture, getAndroidVersionCode } from "../logic/cleanBuildVersion";
 import { userIdSelector, isDummyUserId } from "@domain/entity-client-identity";
+import { selectContacts } from "@domain/entity-contact";
+import { buildContactsGlobalProperties } from "@features/platform-contacts";
 import {
   analyticsEnabledSelector,
   trackingEnabledSelector,
@@ -331,10 +333,18 @@ const getPayTabAttributes = () => {
 };
 
 const getLdmkAndSyncFlags = () => ({
-  ldmkTransport: analyticsFeatureFlagMethod?.("ldmkTransport") ?? { enabled: false },
-  ldmkConnectApp: analyticsFeatureFlagMethod?.("ldmkConnectApp") ?? { enabled: false },
-  ldmkSolanaSigner: analyticsFeatureFlagMethod?.("ldmkSolanaSigner") ?? { enabled: false },
-  ldmkCosmosSigner: analyticsFeatureFlagMethod?.("ldmkCosmosSigner") ?? { enabled: false },
+  ldmkTransport: analyticsFeatureFlagMethod?.("ldmkTransport") ?? {
+    enabled: false,
+  },
+  ldmkConnectApp: analyticsFeatureFlagMethod?.("ldmkConnectApp") ?? {
+    enabled: false,
+  },
+  ldmkSolanaSigner: analyticsFeatureFlagMethod?.("ldmkSolanaSigner") ?? {
+    enabled: false,
+  },
+  ldmkCosmosSigner: analyticsFeatureFlagMethod?.("ldmkCosmosSigner") ?? {
+    enabled: false,
+  },
 });
 
 const getAccountsWithFunds = (accounts: ReturnType<typeof accountsSelector>) =>
@@ -356,7 +366,11 @@ const getStakingCurrenciesFromFlags = () => {
     stakePrograms?.enabled && stakePrograms?.params?.redirects
       ? Object.keys(stakePrograms.params.redirects)
       : [];
-  return { stakePrograms, stakingCurrenciesEnabled, partnerStakingCurrenciesEnabled };
+  return {
+    stakePrograms,
+    stakingCurrenciesEnabled,
+    partnerStakingCurrenciesEnabled,
+  };
 };
 
 const getFlowAndSatisfactionProps = (
@@ -382,6 +396,10 @@ const extraProperties = async (store: AppStore) => {
   const bleDevices = bleDevicesSelector(state);
   const satisfaction = satisfactionSelector(state);
   const accounts = accountsSelector(state);
+  const contactsAttributes = buildContactsGlobalProperties({
+    contacts: selectContacts(state),
+  });
+  const contactsFeature = analyticsFeatureFlagMethod?.("lwmContacts") ?? { enabled: false };
   const lastDevice = devices.at(-1) || bleDevices.at(-1);
   const { ldmkTransport, ldmkConnectApp, ldmkSolanaSigner, ldmkCosmosSigner } =
     getLdmkAndSyncFlags();
@@ -459,7 +477,10 @@ const extraProperties = async (store: AppStore) => {
   const seenBleModels = new Set(bleDevices.map(d => d.modelId));
   const usbDeviceModelSeen = devices.filter(d => !seenBleModels.has(d.modelId));
   const devicesCount = bleDevices.length + usbDeviceModelSeen.length;
-  const modelIdQtyList = { ...aggregateData(bleDevices), ...aggregateData(usbDeviceModelSeen) };
+  const modelIdQtyList = {
+    ...aggregateData(bleDevices),
+    ...aggregateData(usbDeviceModelSeen),
+  };
 
   const startupEvents = await resolveStartupEvents();
   const legacyStartupTime = startupEvents.find(
@@ -495,6 +516,8 @@ const extraProperties = async (store: AppStore) => {
     notificationsBlacklisted,
     ...notificationsOptedIn,
     accountsWithFunds,
+    ContactsAttributes: contactsFeature,
+    ...contactsAttributes,
     appTimeToInteractiveMilliseconds: legacyStartupTime, // WARNING: this is not accurate in practice the splash is still blocking the user at this point
     staxDeviceUser: knownDeviceModelIds.stax,
     staxLockscreen: customImageType || "none",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/useContactsAnalytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/useContactsAnalytics.ts
@@ -3,26 +3,20 @@ import {
   createContactsAnalyticsHelper,
   type ContactsAnalyticsHelper,
 } from "@features/flow-contacts";
-import {
-  buildContactsGlobalProperties,
-  useContacts,
-  useContactsFeature,
-} from "@features/platform-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
 import { createContactsAnalyticsAdapter } from "./createContactsAnalyticsAdapter";
 
 export function useContactsAnalytics(): ContactsAnalyticsHelper {
   const contacts = useContacts();
-  const { isEnabled } = useContactsFeature("mobile");
   const adapter = useMemo(() => createContactsAnalyticsAdapter(), []);
 
   return useMemo(
     () =>
       createContactsAnalyticsHelper(adapter, () =>
         buildContactsGlobalProperties({
-          ffAddressBookEnabled: isEnabled,
           contacts,
         }),
       ),
-    [adapter, contacts, isEnabled],
+    [adapter, contacts],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncActivationDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncActivationDrawer/index.tsx
@@ -5,11 +5,13 @@ import { Steps } from "LLM/features/WalletSync/types/Activation";
 export type ContactsLedgerSyncActivationDrawerProps = Readonly<{
   isOpen: boolean;
   onClose: () => void;
+  onNavigate: () => void;
 }>;
 
 export function ContactsLedgerSyncActivationDrawer({
   isOpen,
   onClose,
+  onNavigate,
 }: ContactsLedgerSyncActivationDrawerProps): React.JSX.Element | null {
   // Mounted on first open only, then kept mounted so that closing stays animated.
   const [isMounted, setIsMounted] = useState(isOpen);
@@ -22,6 +24,11 @@ export function ContactsLedgerSyncActivationDrawer({
   }
 
   return (
-    <ActivationDrawer startingStep={Steps.ChooseSyncMethod} isOpen={isOpen} handleClose={onClose} />
+    <ActivationDrawer
+      startingStep={Steps.ChooseSyncMethod}
+      isOpen={isOpen}
+      handleClose={onClose}
+      handleNavigate={onNavigate}
+    />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncIntroductionSheet/ContactsLedgerSyncIntroductionSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncIntroductionSheet/ContactsLedgerSyncIntroductionSheet.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@tests/test-renderer";
 import { ContactsLedgerSyncIntroductionSheet } from ".";
 
 describe("ContactsLedgerSyncIntroductionSheet", () => {
-  it("should call the activation and dismissal actions", async () => {
+  it("should call the activation action without dismissing when the sheet closes", async () => {
     const onActivate = jest.fn();
     const onDismiss = jest.fn();
     const { user } = render(
@@ -19,9 +19,29 @@ describe("ContactsLedgerSyncIntroductionSheet", () => {
     );
 
     await user.press(screen.getByRole("button", { name: "Sync my wallet" }));
-    await user.press(screen.getByRole("button", { name: "Not now" }));
+    await user.press(screen.getByRole("button", { name: "Close" }));
 
     expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("should call the dismissal action once when the dismissed sheet closes", async () => {
+    const onDismiss = jest.fn();
+    const { user } = render(
+      <ContactsLedgerSyncIntroductionSheet
+        isOpen
+        title="Sync your wallet to add a contact"
+        description="Your contacts are encrypted."
+        activateLabel="Sync my wallet"
+        dismissLabel="Not now"
+        onActivate={jest.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    await user.press(screen.getByRole("button", { name: "Not now" }));
+    await user.press(screen.getByRole("button", { name: "Close" }));
+
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncIntroductionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncIntroductionSheet/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import {
   ContactsLedgerSyncIntroductionContent,
   type ContactsLedgerSyncIntroductionContentProps,
@@ -21,11 +21,36 @@ export function ContactsLedgerSyncIntroductionSheet({
   onDismiss,
 }: ContactsLedgerSyncIntroductionSheetProps): React.JSX.Element {
   const { bottom: bottomInset } = useSafeAreaInsets();
+  const skipNextCloseTracking = useRef(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      skipNextCloseTracking.current = false;
+    }
+  }, [isOpen]);
+
+  const handleActivate = useCallback(() => {
+    skipNextCloseTracking.current = true;
+    onActivate();
+  }, [onActivate]);
+
+  const handleDismiss = useCallback(() => {
+    skipNextCloseTracking.current = true;
+    onDismiss();
+  }, [onDismiss]);
+
+  const handleClose = useCallback(() => {
+    if (skipNextCloseTracking.current) {
+      skipNextCloseTracking.current = false;
+      return;
+    }
+    onDismiss();
+  }, [onDismiss]);
 
   return (
     <QueuedBottomSheet
       isRequestingToBeOpened={isOpen}
-      onClose={onDismiss}
+      onClose={handleClose}
       testID="contacts-ledger-sync-introduction-drawer"
       enableDynamicSizing
     >
@@ -36,8 +61,8 @@ export function ContactsLedgerSyncIntroductionSheet({
         activateLabel={activateLabel}
         dismissLabel={dismissLabel}
         bottomInset={bottomInset}
-        onActivate={onActivate}
-        onDismiss={onDismiss}
+        onActivate={handleActivate}
+        onDismiss={handleDismiss}
       />
     </QueuedBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -3,13 +3,14 @@ import {
   mockBtcCryptoCurrency,
   mockEthCryptoCurrency,
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
-import { ScreenName } from "~/const";
+import { track } from "~/analytics/segment";
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
 import { useContactsCurrencySelectionAdapter } from "./useContactsCurrencySelectionAdapter";
 
 jest.mock("LLM/features/ModularDrawer", () => ({
   useModularDrawerController: jest.fn(),
 }));
+jest.mock("~/analytics/segment", () => ({ track: jest.fn() }));
 
 const openDrawer = jest.fn();
 const closeDrawer = jest.fn();
@@ -62,13 +63,19 @@ describe("useContactsCurrencySelectionAdapter", () => {
     );
 
     expect(openDrawer).toHaveBeenCalledWith({
-      assetsConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+      assetsConfiguration: {
+        leftElement: "undefined",
+        rightElement: "undefined",
+      },
       completionMode: "currency",
       enableAccountSelection: false,
-      flow: "contacts_add_address",
-      networksConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+      flow: "contacts",
+      networksConfiguration: {
+        leftElement: "undefined",
+        rightElement: "undefined",
+      },
       presentation: "embedded",
-      source: ScreenName.MyWalletContactDetail,
+      source: "contacts",
       selectableNetworkIds: networkIds,
       onCurrencySelected: expect.any(Function),
     });
@@ -126,14 +133,61 @@ describe("useContactsCurrencySelectionAdapter", () => {
 
     expect(result.current.flowProps).toMatchObject({
       areCurrenciesFiltered: undefined,
-      assetsConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+      assetsConfiguration: {
+        leftElement: "undefined",
+        rightElement: "undefined",
+      },
       currencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
       isOpen: true,
-      networksConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+      networksConfiguration: {
+        leftElement: "undefined",
+        rightElement: "undefined",
+      },
       onAccountSelected: handleAccountSelected,
       onClose: closeDrawer,
       onCurrencySelected: handleCurrencySelected,
       selectableNetworkIds: [mockEthCryptoCurrency.id],
+    });
+  });
+
+  it("should track clicks on disabled-item explanations", () => {
+    const { result } = renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: true,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
+      }),
+    );
+    const networkExplanation = result.current.flowProps.disabledItemsExplanation?.network(
+      "Bitcoin",
+      "BTC",
+    );
+    const assetExplanation = result.current.flowProps.disabledItemsExplanation?.asset("Bitcoin");
+
+    act(() => {
+      if (networkExplanation) {
+        result.current.flowProps.disabledItemsExplanation?.onPress(networkExplanation);
+      }
+      if (assetExplanation) {
+        result.current.flowProps.disabledItemsExplanation?.onPress(assetExplanation);
+      }
+    });
+
+    expect(track).toHaveBeenNthCalledWith(1, "button_clicked", {
+      button: "disabled network tooltip",
+      flow: "contacts",
+      asset: "BTC",
+      network: "Bitcoin",
+      page: "Network Selection",
+      source: "contacts",
+    });
+    expect(track).toHaveBeenNthCalledWith(2, "button_clicked", {
+      button: "disabled network tooltip",
+      flow: "contacts",
+      asset: "Bitcoin",
+      page: "Asset Selection",
+      source: "contacts",
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ContactCurrencyIdSchema } from "@domain/entity-contact";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { AddAddressCurrencySelection } from "@features/flow-contacts-add-address";
-import { ScreenName } from "~/const";
+import { track } from "~/analytics/segment";
 import { useTranslation } from "~/context/Locale";
+import { MODULAR_DRAWER_PAGE_NAME } from "LLM/features/ModularDrawer/analytics/modularDrawer.types";
 import {
   type DisabledItemsExplanation,
   type DisabledItemExplanation,
@@ -11,11 +12,20 @@ import {
   useModularDrawerController,
 } from "LLM/features/ModularDrawer";
 
-const FLOW = "contacts_add_address";
+const FLOW = "contacts";
+type ContactsDisabledItemExplanation = DisabledItemExplanation &
+  Readonly<{
+    asset?: string;
+    network?: string;
+    page: (typeof MODULAR_DRAWER_PAGE_NAME)[keyof typeof MODULAR_DRAWER_PAGE_NAME];
+  }>;
 
 const CONTACTS_CURRENCY_SELECTION_CONFIGURATION = {
   assetsConfiguration: { leftElement: "undefined", rightElement: "undefined" },
-  networksConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+  networksConfiguration: {
+    leftElement: "undefined",
+    rightElement: "undefined",
+  },
 } as const;
 
 type UseContactsCurrencySelectionAdapterOptions = Readonly<{
@@ -30,6 +40,18 @@ export type ContactsCurrencySelectionAdapter = Readonly<{
   unsupportedItemExplanation: DisabledItemExplanation | null;
   dismissUnsupportedItemExplanation: () => void;
 }>;
+
+function trackDisabledItemExplanation(explanation: DisabledItemExplanation) {
+  const { asset, network, page } = explanation as ContactsDisabledItemExplanation;
+  track("button_clicked", {
+    button: "disabled network tooltip",
+    flow: FLOW,
+    page,
+    source: "contacts",
+    ...(asset ? { asset } : {}),
+    ...(network ? { network } : {}),
+  });
+}
 
 function resolveContactCurrencySelection(
   currency: CryptoOrTokenCurrency | null,
@@ -65,22 +87,37 @@ export function useContactsCurrencySelectionAdapter({
     uiUseCase,
     useCase,
   } = useModularDrawerController();
+  const showUnsupportedItemExplanation = useCallback((explanation: DisabledItemExplanation) => {
+    trackDisabledItemExplanation(explanation);
+    setUnsupportedItemExplanation(explanation);
+  }, []);
   const disabledItemsExplanation = useMemo<DisabledItemsExplanation>(
     () => ({
       asset: assetName => ({
-        title: t("modularDrawer.unsupportedAssetExplanation.title", { asset: assetName }),
-        content: t("modularDrawer.unsupportedAssetExplanation.description", { asset: assetName }),
+        title: t("modularDrawer.unsupportedAssetExplanation.title", {
+          asset: assetName,
+        }),
+        content: t("modularDrawer.unsupportedAssetExplanation.description", {
+          asset: assetName,
+        }),
+        asset: assetName,
+        page: MODULAR_DRAWER_PAGE_NAME.MODULAR_ASSET_SELECTION,
       }),
       network: (networkName, assetName) => ({
-        title: t("modularDrawer.unsupportedNetworkExplanation.title", { network: networkName }),
+        title: t("modularDrawer.unsupportedNetworkExplanation.title", {
+          network: networkName,
+        }),
         content: t("modularDrawer.unsupportedNetworkExplanation.description", {
           network: networkName,
           asset: assetName,
         }),
+        network: networkName,
+        asset: assetName,
+        page: MODULAR_DRAWER_PAGE_NAME.MODULAR_NETWORK_SELECTION,
       }),
-      onPress: setUnsupportedItemExplanation,
+      onPress: showUnsupportedItemExplanation,
     }),
-    [t],
+    [t, showUnsupportedItemExplanation],
   );
   const completeSelection = useCallback(
     (currency: CryptoOrTokenCurrency | null) => {
@@ -125,7 +162,7 @@ export function useContactsCurrencySelectionAdapter({
       enableAccountSelection: false,
       flow: FLOW,
       presentation: "embedded",
-      source: ScreenName.MyWalletContactDetail,
+      source: "contacts",
       selectableNetworkIds: [...networkIds],
       onCurrencySelected: completeSelection,
     });
@@ -164,5 +201,9 @@ export function useContactsCurrencySelectionAdapter({
     [],
   );
 
-  return { flowProps, unsupportedItemExplanation, dismissUnsupportedItemExplanation };
+  return {
+    flowProps,
+    unsupportedItemExplanation,
+    dismissUnsupportedItemExplanation,
+  };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncActivationDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncActivationDrawer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { setLedgerSyncReturnsToEntryScreen } from "~/actions/walletSync";
 import { useDispatch } from "~/context/hooks";
 import type { ContactsLedgerSyncActivationDrawerProps } from "../components/ContactsLedgerSyncActivationDrawer";
@@ -9,16 +9,27 @@ export function useContactsLedgerSyncActivationDrawer(): Readonly<{
 }> {
   const dispatch = useDispatch();
   const [isOpen, setIsOpen] = useState(false);
+  const isNavigatingToWalletSync = useRef(false);
 
   const openLedgerSyncActivationDrawer = useCallback(() => {
+    isNavigatingToWalletSync.current = false;
     dispatch(setLedgerSyncReturnsToEntryScreen(true));
     setIsOpen(true);
   }, [dispatch]);
 
-  const onClose = useCallback(() => setIsOpen(false), []);
+  const onClose = useCallback(() => {
+    if (!isNavigatingToWalletSync.current) {
+      dispatch(setLedgerSyncReturnsToEntryScreen(false));
+    }
+    setIsOpen(false);
+  }, [dispatch]);
+  const onNavigate = useCallback(() => {
+    isNavigatingToWalletSync.current = true;
+    setIsOpen(false);
+  }, []);
 
   return {
-    ledgerSyncActivationDrawer: { isOpen, onClose },
+    ledgerSyncActivationDrawer: { isOpen, onClose, onNavigate },
     openLedgerSyncActivationDrawer,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -6,6 +6,7 @@ import {
   resolveContactDetailEditDeleteLabels,
   useContactDetailEditDeleteAnalytics,
   useContactDetailEditDeleteFlowBindings,
+  useContactsMeContact,
   useContactsEditDeletePorts,
 } from "@features/flow-contacts";
 import type { ContactsDeleteContactDrawerProps } from "@features/flow-contacts-delete-contact";
@@ -37,6 +38,7 @@ export function useContactDetailEditDeleteAdapter(
 ): ContactDetailEditDeleteFlowProps {
   const { t } = useTranslation();
   const analytics = useContactsAnalytics();
+  const meContact = useContactsMeContact();
   const ports = useContactsEditDeletePorts(deviceIntents);
   const { flow, renameViewModel } = useContactDetailEditDeleteFlowBindings({
     contactId,
@@ -56,14 +58,16 @@ export function useContactDetailEditDeleteAdapter(
     () => createContactDetailEditDeleteUiState(flow, renameViewModel, labels),
     [flow, labels, renameViewModel],
   );
-  const { onEdit, onDelete } = useContactDetailEditDeleteAnalytics(
+  const { onEdit, onDelete, onConfirmDelete, onValidateEdit } = useContactDetailEditDeleteAnalytics(
     analytics,
     {
       onEditPress: flow.onEditPress,
       onDeletePress: flow.onDeletePress,
       openDelete: flow.openDelete,
+      confirmDelete: flow.confirmDelete,
     },
     uiState.signerMismatch.isOpen,
+    contactId === meContact.id,
   );
 
   return {
@@ -76,8 +80,14 @@ export function useContactDetailEditDeleteAdapter(
       onDelete,
       onClose: flow.onCloseActionsMenu,
     },
-    renameDrawer: uiState.rename,
-    deleteDrawer: uiState.delete,
+    renameDrawer: {
+      ...uiState.rename,
+      onConfirm: async () => {
+        onValidateEdit();
+        await uiState.rename.onConfirm();
+      },
+    },
+    deleteDrawer: { ...uiState.delete, onConfirm: onConfirmDelete },
     signerMismatchSheet: uiState.signerMismatch,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -21,6 +21,8 @@ import {
   CONTACTS_TRACK_EVENTS,
   CONTACTS_TRACKING_BUTTON,
   trackContactsAddAddressClick,
+  trackContactsLedgerSyncActivate,
+  trackContactsLedgerSyncDismiss,
 } from "@features/flow-contacts";
 import {
   isContactsLedgerSyncActivationRequired,
@@ -233,14 +235,16 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     });
   }, [navigation]);
   const onActivateLedgerSync = useCallback(() => {
+    trackContactsLedgerSyncActivate(analytics);
     dismissPendingIntent();
     setIsLedgerSyncIntroductionOpen(false);
     openLedgerSyncActivationDrawer();
-  }, [dismissPendingIntent, openLedgerSyncActivationDrawer]);
+  }, [analytics, dismissPendingIntent, openLedgerSyncActivationDrawer]);
   const onDismissLedgerSyncIntroduction = useCallback(() => {
+    trackContactsLedgerSyncDismiss(analytics);
     dismissPendingIntent();
     setIsLedgerSyncIntroductionOpen(false);
-  }, [dismissPendingIntent]);
+  }, [analytics, dismissPendingIntent]);
   useEffect(() => {
     if (!isContactsLedgerSyncActivationRequired(ledgerSyncStatus)) {
       dismissPendingIntent();

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -88,6 +88,7 @@ function createViewModel({
     ledgerSyncActivationDrawer: {
       isOpen: false,
       onClose: jest.fn(),
+      onNavigate: jest.fn(),
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
@@ -150,7 +150,7 @@ describe("useContactsPageViewModel", () => {
 
   it("should close the activation drawer when it is dismissed", () => {
     mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
-    const { result } = renderViewModelWithFeatureIntroductionDismissed();
+    const { result, store } = renderViewModelWithFeatureIntroductionDismissed();
 
     act(() => {
       result.current.ledgerSyncIntroduction.onActivate();
@@ -160,6 +160,25 @@ describe("useContactsPageViewModel", () => {
     });
 
     expect(result.current.ledgerSyncActivationDrawer.isOpen).toBe(false);
+    expect(store.getState().walletSync.returnsToEntryScreen).toBe(false);
+  });
+
+  it("should preserve the Contacts entry flow when navigating to Wallet Sync", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { result, store } = renderViewModelWithFeatureIntroductionDismissed();
+
+    act(() => {
+      result.current.ledgerSyncIntroduction.onActivate();
+    });
+    act(() => {
+      result.current.ledgerSyncActivationDrawer.onNavigate();
+    });
+    act(() => {
+      result.current.ledgerSyncActivationDrawer.onClose();
+    });
+
+    expect(result.current.ledgerSyncActivationDrawer.isOpen).toBe(false);
+    expect(store.getState().walletSync.returnsToEntryScreen).toBe(true);
   });
 
   it("should close the Ledger Sync introduction when it is dismissed", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -2,12 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { addAddress, contactAddress, type Contact } from "@domain/entity-contact";
 import { resolvePrefillAddAddressParams } from "@ledgerhq/live-common/flows/send/recipient/utils/resolvePrefillAddAddressParams";
-import { CONTACTS_EVENT_SOURCE } from "@features/flow-contacts";
 import {
-  buildContactsGlobalProperties,
-  useContacts,
-  useContactsFeature,
-} from "@features/platform-contacts";
+  buildContactsSaveAddressClickProperties,
+  CONTACTS_EVENT_SOURCE,
+} from "@features/flow-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
 import {
   useContactsIntentsOrchestrator,
   type ContactsDeviceIntentExecutorProps,
@@ -52,7 +51,6 @@ export function useSendPrefillAddAddressFlow({
   const dispatch = useDispatch();
   const { state, recipientSearch } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
   const { inputMethod, markContactSaved } = useSendFlowTracking();
   const [isOpeningAddressFlow, setIsOpeningAddressFlow] = useState(false);
   const selectedContactRef = useRef<Contact | null>(null);
@@ -77,11 +75,10 @@ export function useSendPrefillAddAddressFlow({
     () => ({
       ...getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),
       ...buildContactsGlobalProperties({
-        ffAddressBookEnabled: isContactsFeatureEnabled,
         contacts,
       }),
     }),
-    [contacts, isContactsFeatureEnabled, state.account.account, state.account.parentAccount],
+    [contacts, state.account.account, state.account.parentAccount],
   );
 
   const trackedAddressPhaseRef = useRef("");
@@ -245,6 +242,27 @@ export function useSendPrefillAddAddressFlow({
     [recipientSearch.value, startWithPrefilled, state.account.currency],
   );
 
+  const continueFromReview = useCallback(() => {
+    if (addressFlowState.status !== "reviewingAddress" || !addressFlowState.displayContext) {
+      return;
+    }
+    track(
+      "button_clicked",
+      buildContactsSaveAddressClickProperties(trackingProperties, {
+        page: "address review",
+        network: addressFlowState.displayContext.network.networkId,
+        asset: addressFlowState.selectedCurrencyId,
+        inputMethod,
+      }),
+    );
+    void screen("Modal send - address signing device", undefined, {
+      ...trackingProperties,
+      network: addressFlowState.displayContext.network.networkId,
+      asset: addressFlowState.selectedCurrencyId,
+    });
+    void saveFromReview();
+  }, [addressFlowState, inputMethod, saveFromReview, trackingProperties]);
+
   const addressPhase = isAddressPhase
     ? {
         state: addressFlowState,
@@ -263,17 +281,7 @@ export function useSendPrefillAddAddressFlow({
           });
           continueFromName();
         },
-        onContinueFromReview: () => {
-          if (!addressFlowState.displayContext) {
-            return;
-          }
-          void screen("Modal send - address signing device", undefined, {
-            ...trackingProperties,
-            network: addressFlowState.displayContext.network.networkId,
-            asset: addressFlowState.selectedCurrencyId,
-          });
-          void saveFromReview();
-        },
+        onContinueFromReview: continueFromReview,
       }
     : null;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
@@ -13,11 +13,7 @@ import {
   type AddContactDialogViewModel,
 } from "@features/flow-contacts-add-contact";
 import type { AddAddressFlowState } from "@features/flow-contacts-add-address";
-import {
-  buildContactsGlobalProperties,
-  useContacts,
-  useContactsFeature,
-} from "@features/platform-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
 import type { ContactsDeviceIntentExecutorProps } from "@features/platform-contacts/device";
 import {
   useSendPrefillAddAddressFlow,
@@ -116,7 +112,6 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   const dispatch = useDispatch();
   const { state } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
   const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
@@ -131,11 +126,10 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
     () => ({
       ...getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),
       ...buildContactsGlobalProperties({
-        ffAddressBookEnabled: isContactsFeatureEnabled,
         contacts,
       }),
     }),
-    [contacts, isContactsFeatureEnabled, state.account.account, state.account.parentAccount],
+    [contacts, state.account.account, state.account.parentAccount],
   );
   const closeAfterSave = useCallback(() => {
     setDrawerOrigin(null);
@@ -180,11 +174,12 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   const callbacks = useMemo(
     () => ({
       onOpen: () => {
-        void screen("Modal send - add contact", undefined, trackingProperties);
+        void screen("Add Contact", undefined, trackingProperties);
       },
       onConfirm: () => {
         track("button_clicked", {
-          button: "confirm name",
+          button: "save contact",
+          hasPicture: false,
           page: "add contact",
           ...trackingProperties,
         });

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -15,7 +15,7 @@ import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import ChooseSyncMethod from "../../screens/Synchronize/ChooseMethod";
 import QrCodeMethod from "../../screens/Synchronize/QrCodeMethod";
 import { Options, Steps } from "../../types/Activation";
-import { AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
+import { AnalyticsPage, useWalletSyncTrackingFlow } from "../../hooks/useLedgerSyncAnalytics";
 import PinCodeDisplay from "../../screens/Synchronize/PinCodeDisplay";
 import PinCodeInput from "../../screens/Synchronize/PinCodeInput";
 import SyncError from "../../screens/Synchronize/SyncError";
@@ -74,6 +74,7 @@ const ActivationFlow = ({
   );
 
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const trackingFlow = useWalletSyncTrackingFlow();
   const { navigate } =
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
 
@@ -96,7 +97,7 @@ const ActivationFlow = ({
       case Steps.ChooseSyncMethod:
         return (
           <>
-            <TrackScreen category={AnalyticsPage.ChooseSyncMethod} />
+            <TrackScreen category={AnalyticsPage.ChooseSyncMethod} flow={trackingFlow} />
             <ChooseSyncMethod
               onScanMethodPress={navigateToQrCodeMethod}
               onConnectWithLedgerPress={navigateToWalletSyncActivationProcess}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/Success/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/Success/index.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
 import React from "react";
 import styled, { useTheme } from "styled-components/native";
 import { TrackScreen } from "~/analytics";
+import { useWalletSyncTrackingFlow } from "../../hooks/useLedgerSyncAnalytics";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useFeature } from "@features/platform-feature-flags";
@@ -33,10 +34,11 @@ export function Success({
 }: Props) {
   const { colors } = useTheme();
   const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
+  const trackingFlow = useWalletSyncTrackingFlow();
   return (
     <SafeAreaView edges={["top", "left", "right", "bottom"]} isFlex>
       <PreventNativeBack />
-      <TrackScreen name={analyticsPage} />
+      <TrackScreen name={analyticsPage} flow={trackingFlow} />
       <Flex
         flexDirection="column"
         alignItems="center"

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/__tests__/useLedgerSyncAnalytics.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/__tests__/useLedgerSyncAnalytics.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from "@tests/test-renderer";
+import { CONTACTS_FLOW } from "@features/flow-contacts";
+import { INITIAL_STATE as WALLET_SYNC_INITIAL_STATE } from "~/reducers/walletSync";
+import {
+  AnalyticsButton,
+  AnalyticsFlow,
+  AnalyticsPage,
+  useLedgerSyncAnalytics,
+  useWalletSyncTrackingFlow,
+} from "../useLedgerSyncAnalytics";
+
+const mockedTrack = jest.fn();
+
+jest.mock("~/analytics", () => ({
+  track: (...args: unknown[]) => mockedTrack(...args),
+}));
+
+function renderTrackingFlow(returnsToEntryScreen: boolean) {
+  return renderHook(() => useWalletSyncTrackingFlow(), {
+    overrideInitialState: state => ({
+      ...state,
+      walletSync: { ...WALLET_SYNC_INITIAL_STATE, returnsToEntryScreen },
+    }),
+  });
+}
+
+describe("useWalletSyncTrackingFlow", () => {
+  it("should use the Ledger Sync flow by default", () => {
+    const { result } = renderTrackingFlow(false);
+
+    expect(result.current).toBe(AnalyticsFlow.LedgerSync);
+  });
+
+  it("should use the contacts flow when opened from Contacts", () => {
+    const { result } = renderTrackingFlow(true);
+
+    expect(result.current).toBe(CONTACTS_FLOW.CONTACTS);
+  });
+});
+
+describe("useLedgerSyncAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should attach the derived Wallet Sync flow when hasFlow is true", () => {
+    mockedTrack.mockClear();
+    const { result } = renderHook(() => useLedgerSyncAnalytics(), {
+      overrideInitialState: state => ({
+        ...state,
+        walletSync: { ...WALLET_SYNC_INITIAL_STATE, returnsToEntryScreen: true },
+      }),
+    });
+
+    result.current.onClickTrack({
+      button: AnalyticsButton.SyncYourAccounts,
+      page: AnalyticsPage.ActivateLedgerSync,
+      hasFlow: true,
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "Turn on Ledger Sync",
+      page: "Activate Ledger Sync",
+      flow: CONTACTS_FLOW.CONTACTS,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -12,6 +12,7 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useNavigation } from "@react-navigation/native";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
 import { track } from "~/analytics";
+import { useWalletSyncTrackingFlow } from "./useLedgerSyncAnalytics";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
@@ -30,16 +31,17 @@ export function useAddMember({ device }: { device: Device | null }): DrawerProps
   const navigation = useNavigation<StackNavigatorNavigation<WalletSyncNavigatorStackParamList>>();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const onboardingType = useSelector(onboardingTypeSelector);
+  const trackingFlow = useWalletSyncTrackingFlow();
 
   const transitionToNextScreen = useCallback(
     (trustchainResult: TrustchainResult) => {
       dispatch(setTrustchain(trustchainResult.trustchain));
-      track(AnalyticsEvents.LedgerSyncActivated);
+      track(AnalyticsEvents.LedgerSyncActivated, { flow: trackingFlow });
       navigation.navigate(ScreenName.WalletSyncLoading, {
         created: trustchainResult.type === TrustchainResultType.created,
       });
     },
-    [dispatch, navigation],
+    [dispatch, navigation, trackingFlow],
   );
 
   return useFollowInstructionDrawer(

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useLedgerSyncAnalytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useLedgerSyncAnalytics.ts
@@ -1,4 +1,7 @@
+import { CONTACTS_FLOW, type ContactsFlow } from "@features/flow-contacts";
 import { track } from "~/analytics";
+import { useSelector } from "~/context/hooks";
+import { returnsToEntryScreenSelector } from "~/reducers/walletSync";
 
 export enum AnalyticsPage {
   ActivateLedgerSync = "Activate Ledger Sync",
@@ -68,9 +71,17 @@ type OnClickTrack = {
   hasFlow?: boolean;
 };
 
+export type WalletSyncFlow = AnalyticsFlow | ContactsFlow;
+
+export function useWalletSyncTrackingFlow(): WalletSyncFlow {
+  const returnsToEntryScreen = useSelector(returnsToEntryScreenSelector);
+  return returnsToEntryScreen ? CONTACTS_FLOW.CONTACTS : AnalyticsFlow.LedgerSync;
+}
+
 export function useLedgerSyncAnalytics() {
+  const trackingFlow = useWalletSyncTrackingFlow();
   const onClickTrack = ({ button, page, hasFlow = false }: OnClickTrack) => {
-    track("button_clicked", { button, page, flow: hasFlow ? AnalyticsFlow.LedgerSync : undefined });
+    track("button_clicked", { button, page, flow: hasFlow ? trackingFlow : undefined });
   };
 
   return { onClickTrack };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useQRCodeHost.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useQRCodeHost.ts
@@ -10,6 +10,7 @@ import {
 } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
 import { track } from "~/analytics";
+import { useWalletSyncTrackingFlow } from "./useLedgerSyncAnalytics";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { Options, Steps } from "../types/Activation";
 import { useNavigation } from "@react-navigation/native";
@@ -45,6 +46,7 @@ export function useQRCodeHost({ currentOption }: Props) {
   const [pinCode, setPinCode] = useState<string | null>(null);
 
   const navigation = useNavigation();
+  const trackingFlow = useWalletSyncTrackingFlow();
 
   const { mutate, isPending, error } = useMutation({
     mutationFn: (memberCredentials: MemberCredentials) =>
@@ -72,7 +74,7 @@ export function useQRCodeHost({ currentOption }: Props) {
     onSuccess: newTrustchain => {
       if (newTrustchain) {
         dispatch(setTrustchain(newTrustchain));
-        if (!trustchain) track(AnalyticsEvents.LedgerSyncActivated);
+        if (!trustchain) track(AnalyticsEvents.LedgerSyncActivated, { flow: trackingFlow });
       }
       queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
       navigation.navigate(NavigatorName.WalletSync, {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useSyncWithQrCode.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useSyncWithQrCode.ts
@@ -7,11 +7,35 @@ import { useSelector, useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/native";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
 import { track } from "~/analytics";
+import { useWalletSyncTrackingFlow } from "./useLedgerSyncAnalytics";
 import { Steps } from "../types/Activation";
 import { NavigatorName, ScreenName } from "~/const";
 import { useInstanceName } from "./useInstanceName";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { useCurrentStep } from "./useCurrentStep";
+
+function resolveSyncErrorStep(error: unknown, trustchainRootId?: string): Steps | undefined {
+  const errorName = (error as { name?: string })?.name;
+
+  switch (errorName) {
+    case "ScannedOldImportQrCode":
+      return Steps.ScannedOldImportQrCode;
+    case "ScannedInvalidQrCode":
+      return Steps.ScannedInvalidQrCode;
+    case "InvalidDigitsError":
+      return Steps.SyncError;
+    case "NoTrustchainInitialized":
+      return Steps.UnbackedError;
+    case "TrustchainAlreadyInitialized":
+      return (error as Error)?.message === trustchainRootId
+        ? Steps.AlreadyBacked
+        : Steps.BackedWithDifferentSeeds;
+    case "TrustchainAlreadyInitializedWithOtherSeed":
+      return Steps.BackedWithDifferentSeeds;
+    default:
+      return undefined;
+  }
+}
 
 export const useSyncWithQrCode = () => {
   const { setCurrentStep } = useCurrentStep();
@@ -25,6 +49,7 @@ export const useSyncWithQrCode = () => {
 
   const inputCallbackRef = useRef<((input: string) => void) | null>(null);
   const dispatch = useDispatch();
+  const trackingFlow = useWalletSyncTrackingFlow();
 
   const onRequestQRCodeInput = useCallback(
     (config: { digits: number }, callback: (input: string) => void) => {
@@ -65,39 +90,29 @@ export const useSyncWithQrCode = () => {
         });
         if (newTrustchain) {
           dispatch(setTrustchain(newTrustchain));
-          if (!trustchain) track(AnalyticsEvents.LedgerSyncActivated);
+          if (!trustchain) track(AnalyticsEvents.LedgerSyncActivated, { flow: trackingFlow });
         }
         onSyncFinished();
         return true;
       } catch (e) {
-        const eName = (e as { name?: string })?.name;
-        if (eName === "ScannedOldImportQrCode") {
-          setCurrentStep(Steps.ScannedOldImportQrCode);
-          return;
-        } else if (eName === "ScannedInvalidQrCode") {
-          setCurrentStep(Steps.ScannedInvalidQrCode);
-          return;
-        } else if (eName === "InvalidDigitsError") {
-          setCurrentStep(Steps.SyncError);
-          return;
-        } else if (eName === "NoTrustchainInitialized") {
-          setCurrentStep(Steps.UnbackedError);
-          return;
-        } else if (eName === "TrustchainAlreadyInitialized") {
-          if ((e as Error)?.message === trustchain?.rootId) {
-            setCurrentStep(Steps.AlreadyBacked);
-          } else {
-            setCurrentStep(Steps.BackedWithDifferentSeeds);
-          }
-          return;
-        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
-          setCurrentStep(Steps.BackedWithDifferentSeeds);
+        const errorStep = resolveSyncErrorStep(e, trustchain?.rootId);
+        if (errorStep) {
+          setCurrentStep(errorStep);
           return;
         }
         throw e;
       }
     },
-    [instanceName, onRequestQRCodeInput, trustchain, onSyncFinished, sdk, dispatch, setCurrentStep],
+    [
+      instanceName,
+      onRequestQRCodeInput,
+      trustchain,
+      onSyncFinished,
+      sdk,
+      dispatch,
+      setCurrentStep,
+      trackingFlow,
+    ],
   );
 
   const handleSendDigits = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationDrawer.tsx
@@ -13,6 +13,7 @@ type Props = {
   isOpen: boolean;
   startingStep: Steps;
   handleClose: () => void;
+  handleNavigate?: () => void;
 };
 
 function View({

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationLoading.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationLoading.tsx
@@ -4,7 +4,7 @@ import { ScreenName } from "~/const";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { useLoadingStep } from "../../hooks/useLoadingStep";
 import { TrackScreen } from "~/analytics";
-import { AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
+import { AnalyticsPage, useWalletSyncTrackingFlow } from "../../hooks/useLedgerSyncAnalytics";
 import GradientContainer from "~/components/GradientContainer";
 import Animation from "~/components/Animation";
 import { Flex, Text } from "@ledgerhq/native-ui";
@@ -33,6 +33,7 @@ export function ActivationLoading({ route }: Props) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
+  const trackingFlow = useWalletSyncTrackingFlow();
   const title = "walletSync.loading.title";
   const subtitle = created ? "walletSync.loading.activation" : "walletSync.loading.synch";
   useLoadingStep(created);
@@ -52,7 +53,7 @@ export function ActivationLoading({ route }: Props) {
   return (
     <>
       <PreventNativeBack />
-      <TrackScreen category={AnalyticsPage.Loading} />
+      <TrackScreen category={AnalyticsPage.Loading} flow={trackingFlow} />
       <GradientContainer
         color={colors.background.main}
         startOpacity={1}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationSuccess.tsx
@@ -4,7 +4,11 @@ import { useTranslation } from "~/context/Locale";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 import { ScreenName } from "~/const";
-import { AnalyticsButton, AnalyticsFlow, AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
+import {
+  AnalyticsButton,
+  AnalyticsPage,
+  useWalletSyncTrackingFlow,
+} from "../../hooks/useLedgerSyncAnalytics";
 import { track } from "~/analytics";
 import { useClose } from "../../hooks/useClose";
 import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
@@ -33,6 +37,7 @@ export function ActivationSuccess({ route }: Props) {
   const page = created ? AnalyticsPage.BackupCreationSuccess : AnalyticsPage.SyncSuccess;
 
   const close = useClose();
+  const trackingFlow = useWalletSyncTrackingFlow();
 
   const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
 
@@ -40,7 +45,7 @@ export function ActivationSuccess({ route }: Props) {
     track("button_clicked", {
       button: AnalyticsButton.Close,
       page,
-      flow: AnalyticsFlow.LedgerSync,
+      flow: trackingFlow,
     });
     close();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
@@ -23,13 +23,19 @@ type Props = {
   isOpen: boolean;
   startingStep: Steps;
   handleClose: () => void;
+  handleNavigate?: () => void;
 };
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncActivationProcess>
 >;
 
-const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) => {
+const useActivationDrawerModel = ({
+  isOpen,
+  startingStep,
+  handleClose,
+  handleNavigate = handleClose,
+}: Props) => {
   const { onClickTrack } = useLedgerSyncAnalytics();
   const { currentStep, setCurrentStep } = useCurrentStep();
   const { closeAllBottomSheets } = useQueuedBottomSheetContext();
@@ -79,20 +85,25 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
 
   const goBackToPreviousStep = () => setCurrentStep(getPreviousStep(currentStep));
 
-  const onCloseDrawer = () => {
+  const resetDrawer = () => {
     dispatch(blockPasswordLock(false));
     setCurrentStep(startingStep);
     setCurrentOption(Options.SCAN);
-    handleClose();
   };
 
   const navigateToWalletSyncActivationProcess = () => {
-    onCloseDrawer();
+    resetDrawer();
+    handleNavigate();
     closeAllBottomSheets();
     dispatch(closePostOnboardingHubDrawer());
     navigation.navigate(NavigatorName.WalletSync, {
       screen: ScreenName.WalletSyncActivationProcess,
     });
+  };
+
+  const onCloseDrawer = () => {
+    resetDrawer();
+    handleClose();
   };
 
   const onCreateKey = () => {

--- a/features/flow/contacts/src/analytics/contactsAnalytics.types.ts
+++ b/features/flow/contacts/src/analytics/contactsAnalytics.types.ts
@@ -4,8 +4,8 @@
  *
  * P2 secured account-name tracking is intentionally excluded from Contacts: payloads must never
  * include contact names, address labels, account names, raw blockchain addresses, or raw search
- * queries. For `search_query`, send `queryLength` and `hasResults` instead of the tracking plan's
- * `$query` placeholder to avoid leaking names or address fragments.
+ * queries. For `search_query`, send only whether the query has results, never the query itself or
+ * its length, to avoid leaking information about names or address fragments.
  */
 
 import type { ContactsGlobalProperties } from "@features/platform-contacts";
@@ -71,12 +71,13 @@ export type ContactsPageProperty =
 export const CONTACTS_TRACKING_BUTTON = {
   contacts: "contacts",
   addContact: "add contact",
-  contact: "contact",
+  contact: "contact_details",
   activateLedgerSync: "activate ledger sync",
   dismiss: "dismiss",
   contactPicture: "contact picture",
   saveContact: "save contact",
   editContact: "edit contact",
+  validateEditContact: "validate edit contact",
   deleteContact: "delete contact",
   addAddress: "add address",
   disabledNetworkTooltip: "disabled network tooltip",
@@ -101,8 +102,6 @@ export type ContactsPictureAction = "add" | "change" | "delete";
 
 export type ContactsAddressInputMethod = "paste" | "qr_code" | "manual" | "ens";
 
-export type ContactsAddAddressType = "me" | "other";
-
 export type ContactsAddContactErrorType = "invalid name" | "invalid picture";
 
 export type ContactsContactDetailErrorType = "signer_mismatch";
@@ -118,7 +117,7 @@ export type ContactsTrackEventInputParams = {
     action?: ContactsPictureAction;
     hasPicture?: boolean;
     myContact?: boolean;
-    type?: ContactsAddAddressType;
+    isSelf?: boolean;
     asset?: string;
     network?: string;
     inputMethod?: ContactsAddressInputMethod;
@@ -126,7 +125,6 @@ export type ContactsTrackEventInputParams = {
   [CONTACTS_TRACK_EVENTS.SEARCH_QUERY]: Readonly<{
     source: typeof CONTACTS_EVENT_SOURCE.SEARCH;
     page: typeof CONTACTS_PAGE_PROPERTY.CONTACTS;
-    queryLength: number;
     hasResults: boolean;
   }>;
   [CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED]: Readonly<{

--- a/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.web.test.ts
+++ b/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.web.test.ts
@@ -14,7 +14,6 @@ import {
 } from "./createContactsAnalyticsHelper";
 
 const globalProperties = {
-  ffAddressBookEnabled: true,
   contactsCount: 2,
   externalAddressesSavedCount: 1,
   myAddressesSavedCount: 1,
@@ -127,7 +126,6 @@ describe("Contacts analytics payload shapes", () => {
         ...globalProperties,
         source: CONTACTS_EVENT_SOURCE.SEARCH,
         page: CONTACTS_PAGE_PROPERTY.CONTACTS,
-        queryLength: 3,
         hasResults: true,
       },
     };
@@ -253,7 +251,7 @@ describe("Contacts analytics payload shapes", () => {
 
     for (const payload of payloads) {
       const properties = "properties" in payload ? payload.properties : undefined;
-      expect(properties?.ffAddressBookEnabled).toBe(true);
+      expect(properties?.contactsCount).toBe(2);
       expect(properties?.source).toBeDefined();
       expect(Object.keys(properties ?? {})).not.toContain("contact_name");
       expect(Object.keys(properties ?? {})).not.toContain("address_label");

--- a/features/flow/contacts/src/analytics/trackContactsEvents.ts
+++ b/features/flow/contacts/src/analytics/trackContactsEvents.ts
@@ -1,12 +1,36 @@
 import type { ContactId } from "@domain/entity-contact";
 import {
   CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
   CONTACTS_PAGE_PROPERTY,
   CONTACTS_TRACK_EVENTS,
   CONTACTS_TRACKING_BUTTON,
   type ContactsTrackingButton,
 } from "./contactsAnalytics.types";
 import type { ContactsAnalyticsHelper } from "./createContactsAnalyticsHelper";
+
+export function buildContactsSaveAddressClickProperties<T extends Record<string, unknown>>(
+  trackingProperties: T,
+  details: Readonly<{
+    page: string;
+    network: string;
+    asset: string;
+    inputMethod: string;
+  }>,
+): T &
+  Readonly<{
+    button: typeof CONTACTS_TRACKING_BUTTON.saveAddress;
+    page: string;
+    network: string;
+    asset: string;
+    inputMethod: string;
+  }> {
+  return {
+    ...trackingProperties,
+    button: CONTACTS_TRACKING_BUTTON.saveAddress,
+    ...details,
+  };
+}
 
 export function trackContactsListContactOpen(
   analytics: ContactsAnalyticsHelper,
@@ -26,6 +50,7 @@ export function trackContactsLedgerSyncDismiss(analytics: ContactsAnalyticsHelpe
     source: CONTACTS_EVENT_SOURCE.LEDGER_SYNC_GATE,
     button: CONTACTS_TRACKING_BUTTON.dismiss,
     page: CONTACTS_PAGE_PROPERTY.LEDGER_SYNC_GATE,
+    flow: CONTACTS_FLOW.CONTACTS,
   });
 }
 
@@ -34,6 +59,7 @@ export function trackContactsLedgerSyncActivate(analytics: ContactsAnalyticsHelp
     source: CONTACTS_EVENT_SOURCE.LEDGER_SYNC_GATE,
     button: CONTACTS_TRACKING_BUTTON.activateLedgerSync,
     page: CONTACTS_PAGE_PROPERTY.LEDGER_SYNC_GATE,
+    flow: CONTACTS_FLOW.CONTACTS,
   });
 }
 
@@ -46,7 +72,7 @@ export function trackContactsAddAddressClick(
     source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
     button: CONTACTS_TRACKING_BUTTON.addAddress,
     page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
-    type: contactId === meContactId ? "me" : "other",
+    isSelf: contactId === meContactId,
   });
 }
 
@@ -59,7 +85,7 @@ export function trackContactAddressDetailQuickAction(
   analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
     source: CONTACTS_EVENT_SOURCE.QUICK_ACTION,
     button,
-    page: CONTACTS_PAGE_PROPERTY.ADDRESS_DETAIL,
+    page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
     ...(asset ? { asset } : {}),
     ...(network ? { network } : {}),
   });

--- a/features/flow/contacts/src/analytics/trackContactsEvents.web.test.ts
+++ b/features/flow/contacts/src/analytics/trackContactsEvents.web.test.ts
@@ -1,12 +1,14 @@
 import { ContactIdSchema } from "@domain/entity-contact";
 import {
   CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
   CONTACTS_PAGE_PROPERTY,
   CONTACTS_TRACK_EVENTS,
   CONTACTS_TRACKING_BUTTON,
 } from "./contactsAnalytics.types";
 import type { ContactsAnalyticsHelper } from "./createContactsAnalyticsHelper";
 import {
+  buildContactsSaveAddressClickProperties,
   trackContactAddressDetailQuickAction,
   trackContactsAddAddressClick,
   trackContactsLedgerSyncActivate,
@@ -23,6 +25,28 @@ function createAnalytics(): ContactsAnalyticsHelper {
 }
 
 describe("trackContactsEvents", () => {
+  it("should build save-address click properties without changing flow context", () => {
+    expect(
+      buildContactsSaveAddressClickProperties(
+        { flow: "send", contactsCount: 2 },
+        {
+          page: "address review",
+          network: "ethereum",
+          asset: "ethereum",
+          inputMethod: "manual",
+        },
+      ),
+    ).toEqual({
+      flow: "send",
+      contactsCount: 2,
+      button: CONTACTS_TRACKING_BUTTON.saveAddress,
+      page: "address review",
+      network: "ethereum",
+      asset: "ethereum",
+      inputMethod: "manual",
+    });
+  });
+
   it("should track list contact opens", () => {
     const analytics = createAnalytics();
     const meContactId = ContactIdSchema.parse("contact-me");
@@ -55,11 +79,13 @@ describe("trackContactsEvents", () => {
       source: CONTACTS_EVENT_SOURCE.LEDGER_SYNC_GATE,
       button: CONTACTS_TRACKING_BUTTON.dismiss,
       page: CONTACTS_PAGE_PROPERTY.LEDGER_SYNC_GATE,
+      flow: CONTACTS_FLOW.CONTACTS,
     });
     expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
       source: CONTACTS_EVENT_SOURCE.LEDGER_SYNC_GATE,
       button: CONTACTS_TRACKING_BUTTON.activateLedgerSync,
       page: CONTACTS_PAGE_PROPERTY.LEDGER_SYNC_GATE,
+      flow: CONTACTS_FLOW.CONTACTS,
     });
   });
 
@@ -73,7 +99,7 @@ describe("trackContactsEvents", () => {
       source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
       button: CONTACTS_TRACKING_BUTTON.addAddress,
       page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
-      type: "me",
+      isSelf: true,
     });
   });
 
@@ -86,12 +112,12 @@ describe("trackContactsEvents", () => {
     expect(analytics.trackEvent).toHaveBeenNthCalledWith(1, CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
       source: CONTACTS_EVENT_SOURCE.QUICK_ACTION,
       button: CONTACTS_TRACKING_BUTTON.edit,
-      page: CONTACTS_PAGE_PROPERTY.ADDRESS_DETAIL,
+      page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
     });
     expect(analytics.trackEvent).toHaveBeenNthCalledWith(2, CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
       source: CONTACTS_EVENT_SOURCE.QUICK_ACTION,
       button: CONTACTS_TRACKING_BUTTON.send,
-      page: CONTACTS_PAGE_PROPERTY.ADDRESS_DETAIL,
+      page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
       asset: "ETH",
     });
   });

--- a/features/flow/contacts/src/hooks/useContactDetailEditDeleteAnalytics.ts
+++ b/features/flow/contacts/src/hooks/useContactDetailEditDeleteAnalytics.ts
@@ -12,9 +12,10 @@ export function useContactDetailEditDeleteAnalytics(
   analytics: ContactsAnalyticsHelper,
   flow: Pick<
     UseContactDetailEditDeleteFlowViewModelResult,
-    "onEditPress" | "onDeletePress" | "openDelete"
+    "onEditPress" | "onDeletePress" | "openDelete" | "confirmDelete"
   >,
   isSignerMismatchOpen: boolean,
+  isSelf: boolean,
 ) {
   const hasTrackedSignerMismatch = useRef(false);
   const onEdit = useCallback(() => {
@@ -22,18 +23,30 @@ export function useContactDetailEditDeleteAnalytics(
       source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
       button: CONTACTS_TRACKING_BUTTON.editContact,
       page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
+      isSelf,
     });
     flow.onEditPress();
-  }, [analytics, flow]);
+  }, [analytics, flow, isSelf]);
   const onDelete = useCallback(() => {
+    flow.onDeletePress();
+    flow.openDelete();
+  }, [flow]);
+  const onConfirmDelete = useCallback(async () => {
     analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
       source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
       button: CONTACTS_TRACKING_BUTTON.deleteContact,
       page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
     });
-    flow.onDeletePress();
-    flow.openDelete();
+    await flow.confirmDelete();
   }, [analytics, flow]);
+  const onValidateEdit = useCallback(() => {
+    analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+      button: CONTACTS_TRACKING_BUTTON.validateEditContact,
+      page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
+      isSelf,
+    });
+  }, [analytics, isSelf]);
 
   useEffect(() => {
     if (isSignerMismatchOpen && !hasTrackedSignerMismatch.current) {
@@ -51,5 +64,5 @@ export function useContactDetailEditDeleteAnalytics(
     }
   }, [analytics, isSignerMismatchOpen]);
 
-  return { onEdit, onDelete };
+  return { onEdit, onDelete, onConfirmDelete, onValidateEdit };
 }

--- a/features/flow/contacts/src/hooks/useContactDetailEditDeleteAnalytics.web.test.ts
+++ b/features/flow/contacts/src/hooks/useContactDetailEditDeleteAnalytics.web.test.ts
@@ -17,15 +17,17 @@ function createAnalytics(): ContactsAnalyticsHelper {
 }
 
 describe("useContactDetailEditDeleteAnalytics", () => {
-  it("should track edit and delete button clicks", () => {
+  it("should track edit and confirmed delete button clicks", async () => {
     const analytics = createAnalytics();
     const onEditPress = jest.fn();
     const onDeletePress = jest.fn();
     const openDelete = jest.fn();
+    const confirmDelete = jest.fn();
     const { result } = renderHook(() =>
       useContactDetailEditDeleteAnalytics(
         analytics,
-        { onEditPress, onDeletePress, openDelete },
+        { onEditPress, onDeletePress, openDelete, confirmDelete },
+        false,
         false,
       ),
     );
@@ -36,11 +38,24 @@ describe("useContactDetailEditDeleteAnalytics", () => {
     act(() => {
       result.current.onDelete();
     });
+    act(() => {
+      result.current.onValidateEdit();
+    });
+    await act(async () => {
+      await result.current.onConfirmDelete();
+    });
 
     expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
       source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
       button: CONTACTS_TRACKING_BUTTON.editContact,
       page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
+      isSelf: false,
+    });
+    expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+      button: CONTACTS_TRACKING_BUTTON.validateEditContact,
+      page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
+      isSelf: false,
     });
     expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
       source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
@@ -50,14 +65,20 @@ describe("useContactDetailEditDeleteAnalytics", () => {
     expect(onEditPress).toHaveBeenCalledTimes(1);
     expect(onDeletePress).toHaveBeenCalledTimes(1);
     expect(openDelete).toHaveBeenCalledTimes(1);
+    expect(confirmDelete).toHaveBeenCalledTimes(1);
   });
 
   it("should track signer mismatch errors once while the sheet is open", () => {
     const analytics = createAnalytics();
-    const flow = { onEditPress: jest.fn(), onDeletePress: jest.fn(), openDelete: jest.fn() };
+    const flow = {
+      onEditPress: jest.fn(),
+      onDeletePress: jest.fn(),
+      openDelete: jest.fn(),
+      confirmDelete: jest.fn(),
+    };
     const { rerender } = renderHook(
       ({ isSignerMismatchOpen }) =>
-        useContactDetailEditDeleteAnalytics(analytics, flow, isSignerMismatchOpen),
+        useContactDetailEditDeleteAnalytics(analytics, flow, isSignerMismatchOpen, false),
       { initialProps: { isSignerMismatchOpen: false } },
     );
 
@@ -76,10 +97,15 @@ describe("useContactDetailEditDeleteAnalytics", () => {
 
   it("should allow signer mismatch tracking again after the sheet closes", () => {
     const analytics = createAnalytics();
-    const flow = { onEditPress: jest.fn(), onDeletePress: jest.fn(), openDelete: jest.fn() };
+    const flow = {
+      onEditPress: jest.fn(),
+      onDeletePress: jest.fn(),
+      openDelete: jest.fn(),
+      confirmDelete: jest.fn(),
+    };
     const { rerender } = renderHook(
       ({ isSignerMismatchOpen }) =>
-        useContactDetailEditDeleteAnalytics(analytics, flow, isSignerMismatchOpen),
+        useContactDetailEditDeleteAnalytics(analytics, flow, isSignerMismatchOpen, false),
       { initialProps: { isSignerMismatchOpen: true } },
     );
 

--- a/features/flow/contacts/src/hooks/useContactsListPageAnalytics.ts
+++ b/features/flow/contacts/src/hooks/useContactsListPageAnalytics.ts
@@ -47,7 +47,6 @@ export function useContactsListPageAnalytics({
       analytics.trackEvent(CONTACTS_TRACK_EVENTS.SEARCH_QUERY, {
         source: CONTACTS_EVENT_SOURCE.SEARCH,
         page: CONTACTS_PAGE_PROPERTY.CONTACTS,
-        queryLength: trimmedQuery.length,
         hasResults: searchHasResults,
       });
     }, 500);

--- a/features/flow/contacts/src/hooks/useContactsListPageAnalytics.web.test.ts
+++ b/features/flow/contacts/src/hooks/useContactsListPageAnalytics.web.test.ts
@@ -69,7 +69,6 @@ describe("useContactsListPageAnalytics", () => {
     expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.SEARCH_QUERY, {
       source: CONTACTS_EVENT_SOURCE.SEARCH,
       page: CONTACTS_PAGE_PROPERTY.CONTACTS,
-      queryLength: 3,
       hasResults: true,
     });
   });

--- a/features/platform/contacts/src/analytics/buildContactsGlobalProperties.ts
+++ b/features/platform/contacts/src/analytics/buildContactsGlobalProperties.ts
@@ -2,7 +2,6 @@ import type { Contact } from "@domain/entity-contact";
 import type { ContactsGlobalProperties } from "./contactsGlobalProperties";
 
 export type BuildContactsGlobalPropertiesInput = Readonly<{
-  ffAddressBookEnabled: boolean;
   contacts: readonly Contact[];
 }>;
 
@@ -17,7 +16,6 @@ export function buildContactsGlobalProperties(
   );
 
   return {
-    ffAddressBookEnabled: input.ffAddressBookEnabled,
     contactsCount: savedContacts.length,
     externalAddressesSavedCount,
     myAddressesSavedCount: meContact?.addresses.length ?? 0,

--- a/features/platform/contacts/src/analytics/buildContactsGlobalProperties.web.test.ts
+++ b/features/platform/contacts/src/analytics/buildContactsGlobalProperties.web.test.ts
@@ -12,11 +12,9 @@ describe("buildContactsGlobalProperties", () => {
 
     expect(
       buildContactsGlobalProperties({
-        ffAddressBookEnabled: true,
         contacts,
       }),
     ).toEqual({
-      ffAddressBookEnabled: true,
       contactsCount: 5,
       externalAddressesSavedCount: 3,
       myAddressesSavedCount: 3,
@@ -26,11 +24,9 @@ describe("buildContactsGlobalProperties", () => {
   it("returns zero counts when only Me is present without addresses", () => {
     expect(
       buildContactsGlobalProperties({
-        ffAddressBookEnabled: false,
         contacts: [mockMeContact()],
       }),
     ).toEqual({
-      ffAddressBookEnabled: false,
       contactsCount: 0,
       externalAddressesSavedCount: 0,
       myAddressesSavedCount: 0,
@@ -45,7 +41,6 @@ describe("buildContactsGlobalProperties", () => {
 
     expect(
       buildContactsGlobalProperties({
-        ffAddressBookEnabled: true,
         contacts,
       }),
     ).toMatchObject({

--- a/features/platform/contacts/src/analytics/contactsGlobalProperties.ts
+++ b/features/platform/contacts/src/analytics/contactsGlobalProperties.ts
@@ -1,5 +1,4 @@
 export type ContactsGlobalProperties = Readonly<{
-  ffAddressBookEnabled: boolean;
   contactsCount: number;
   externalAddressesSavedCount: number;
   myAddressesSavedCount: number;


### PR DESCRIPTION
### 📝 Description

Fixes the Contacts tracking-plan mismatches raised during QA on both Ledger Wallet Desktop and Mobile. Each event below was either missing, fired at the wrong moment, or sent the wrong property values; the shared `@features/flow-contacts` analytics contract is the source of truth, so most fixes land there and both apps inherit them.

**Global properties**

- `ContactsAttributes` (the raw feature-flag value) and the contact counts (`contactsCount`, `externalAddressesSavedCount`, `myAddressesSavedCount`) are now pushed as user/event properties on every event, via each app's Segment `extraProperties`.
- Dropped the deprecated `ffAddressBookEnabled` property.

**Contact list**

- `search_query` no longer sends `queryLength` (privacy: only `hasResults` is reported).
- Contact click now sends `button: contact_details` instead of `contact`.

**Contact detail**

- Edit, validate-edit, and add-address clicks now send `isSelf` (replacing `type: me | other` on add address). The tracking plan lists only `button` and `page` for `delete contact`, so that event does not carry `isSelf`.
- `delete contact` now fires when the user confirms the deletion, not when the confirmation modal opens.
- Added the missing `validate edit contact` event on rename confirmation.
- Quick actions (send / edit / delete) now report `page: contact detail` instead of `address detail`.

**Ledger Sync**

- Activate and dismiss clicks on the gate now carry `flow: contacts`.
- Activating no longer also emits a `dismiss` event: the desktop dialog and the mobile sheet skip the close callback that follows the activation. The mobile sheet does the same on explicit dismissal, so `dismiss` is reported once instead of twice.
- Ledger Sync screens reached from Contacts now inherit `flow: contacts` (`Page Choose sync method`, `Page Loading Sync`, `Page Ledger Sync turned on`, `ledgersync_activated`). Desktop resolves it from the entry point that opened the drawer; mobile derives it from the entry screen it returns to. Everywhere else these events keep `flow: Ledger Sync`.

**Add address (Modular Asset Drawer)**

- Asset/network selection events from Contacts now carry `flow: contacts` and `source: contacts`. Desktop previously sent empty values because the currency flow never set them; mobile sent `contacts_add_address` and a screen name.
- Added the missing `disabled network tooltip` click event on both platforms. It reports `network` plus the selected `asset` on the network step, and `asset` on the asset step, using the shared Modular Drawer page names.
- Asset selection events now use the shared `Asset Selection` page constant instead of a local literal.

**Send flow**

- Add contact: page renamed to `Add Contact` and the confirm button now reports `save contact` with `hasPicture`.
- Add address: added the missing `save address` click before the review step saves.

**Desktop page views**

- `TrackPage` now compares property values instead of object identity, so a screen no longer re-fires its page event on every re-render. This fixes `Page Network Selection` firing twice on LWD.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36800](https://ledgerhq.atlassian.net/browse/LIVE-36800)
- **ADR**: [Contacts Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7271088138/Contacts+-+Tracking+Plan)

[LIVE-36800]: https://ledgerhq.atlassian.net/browse/LIVE-36800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ