### PR TITLE
[LWDM] feat(aleo): aleo bond flow (LIVE-32807)

### DIFF
--- a/.changeset/aleo-bond-public-flow.md
+++ b/.changeset/aleo-bond-public-flow.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+---
+
+feat(aleo): add the bond public staking flow

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.test.tsx
@@ -172,50 +172,61 @@ describe("AccountHeaderManageActions", () => {
       expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
     });
 
-    it("opens the manage modal from an empty token account whose main account has funds", () => {
+    it.each([
+      ["with balance", ALEO_TOKEN_ACCOUNT],
+      ["that is empty", { ...ALEO_TOKEN_ACCOUNT, balance: new BigNumber(0), operationsCount: 0 }],
+    ])("is absent on a token account %s", (_label, tokenAccount) => {
       mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
 
-      const emptyTokenAccount = {
-        ...ALEO_TOKEN_ACCOUNT,
-        balance: new BigNumber(0),
-        operationsCount: 0,
-      };
-      const { result, store } = renderHook(() =>
-        hook({ account: emptyTokenAccount, parentAccount: ALEO_MAIN_ACCOUNT }),
+      const { result } = renderHook(() =>
+        hook({ account: tokenAccount, parentAccount: ALEO_MAIN_ACCOUNT }),
       );
-      const action = result.current?.find(item => item.key === "AleoBond");
 
-      expect(result.current?.find(item => item.key === "Self transfer")?.disabled).toBe(true);
-      expect(action?.disabled).toBeFalsy();
-
-      act(() => {
-        action?.onClick();
-      });
-
-      expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBe(true);
-      expect(store.getState().modals.MODAL_NO_FUNDS_STAKE?.isOpened).toBeFalsy();
+      expect(result.current?.find(item => item.key === "AleoBond")).toBeUndefined();
+      expect(result.current?.find(item => item.key === "Self transfer")).toBeDefined();
     });
 
-    // The manage modal drives the bond flow off the main account, so a token account must
-    // not reach it as the `account` — the bond spends native ALEO. And once the account has
-    // been switched, no parent goes with it: forwarding the original would land the same
-    // account in both fields, which NoFundsStake passes on to its receive and buy flows.
-    it("opens the manage modal on the main account alone, even from a token account", () => {
+    it("opens the bond flow directly when nothing is bonded", () => {
       mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
 
       const { result, store } = renderHook(() =>
-        hook({ account: ALEO_TOKEN_ACCOUNT, parentAccount: ALEO_MAIN_ACCOUNT }),
+        hook({ account: ALEO_MAIN_ACCOUNT, parentAccount: null }),
       );
-      const action = result.current?.find(item => item.key === "AleoBond");
 
       act(() => {
-        action?.onClick();
+        result.current?.find(item => item.key === "AleoBond")?.onClick();
+      });
+
+      expect(store.getState().modals[AleoCustomModal.BOND_PUBLIC]).toEqual({
+        isOpened: true,
+        data: { account: ALEO_MAIN_ACCOUNT },
+      });
+      expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
+    });
+
+    it("opens the manage modal once the account is bonded to a validator", () => {
+      mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, enableStaking: true });
+
+      const bondedAccount = {
+        ...ALEO_MAIN_ACCOUNT,
+        aleoResources: {
+          ...ALEO_MAIN_ACCOUNT.aleoResources!,
+          bondedValidator: "aleo1validator",
+        },
+      };
+      const { result, store } = renderHook(() =>
+        hook({ account: bondedAccount, parentAccount: null }),
+      );
+
+      act(() => {
+        result.current?.find(item => item.key === "AleoBond")?.onClick();
       });
 
       expect(store.getState().modals[AleoCustomModal.MANAGE]).toEqual({
         isOpened: true,
-        data: { account: ALEO_MAIN_ACCOUNT },
+        data: { account: bondedAccount },
       });
+      expect(store.getState().modals[AleoCustomModal.BOND_PUBLIC]?.isOpened).toBeFalsy();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
@@ -2,6 +2,7 @@ import { useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { openModal } from "~/renderer/actions/modals";
 import IconTransfer from "~/renderer/icons/Transfer";
 import IconCoins from "~/renderer/icons/Coins";
@@ -19,17 +20,25 @@ const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
   const isSelfTransferDisabled = bridge.isAccountEmpty(account);
   const mainAccount = getMainAccount(account, parentAccount);
   const isStakingEnabled = !!getAleoCurrencyConfig(mainAccount.currency)?.enableStaking;
+  const showStakingAction = isStakingEnabled && account.type === "Account";
 
   const onClick = () => {
     dispatch(openModal(AleoCustomModal.SELF_TRANSFER, { account, parentAccount }));
   };
 
   const onManage = () => {
-    const modalKey = bridge.isAccountEmpty(mainAccount)
-      ? "MODAL_NO_FUNDS_STAKE"
-      : AleoCustomModal.MANAGE;
+    if (bridge.isAccountEmpty(mainAccount)) {
+      dispatch(openModal("MODAL_NO_FUNDS_STAKE", { account: mainAccount }));
+      return;
+    }
 
-    dispatch(openModal(modalKey, { account: mainAccount }));
+    const hasBondedPosition = !!(mainAccount as AleoAccount).aleoResources?.bondedValidator;
+
+    dispatch(
+      openModal(hasBondedPosition ? AleoCustomModal.MANAGE : AleoCustomModal.BOND_PUBLIC, {
+        account: mainAccount,
+      }),
+    );
   };
 
   return [
@@ -44,7 +53,7 @@ const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
       eventProperties: { button: "aleo-self-transfer" },
       accountActionsTestId: "self-transfer-button",
     },
-    ...(isStakingEnabled
+    ...(showStakingAction
       ? [
           {
             key: "AleoBond",

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/Body.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { StepId, StepProps, St } from "./types";
+import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
+import StepValidator, { StepValidatorFooter } from "./steps/StepValidator";
+import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
+import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
+import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
+import { createStakingFlowBody, StakingFlowData } from "../shared/createStakingFlowBody";
+import { DEFAULT_ALEO_VALIDATOR } from "../constants";
+import { getAleoCurrencyConfig } from "../shared/utils";
+
+export type Data = StakingFlowData;
+
+const steps: Array<St> = [
+  {
+    id: "validator",
+    label: <Trans i18nKey="aleo.bond.flow.steps.validator.title" />,
+    component: StepValidator,
+    noScroll: true,
+    footer: StepValidatorFooter,
+  },
+  {
+    id: "amount",
+    label: <Trans i18nKey="aleo.bond.flow.steps.amount.title" />,
+    component: StepAmount,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("validator"),
+    noScroll: true,
+    footer: StepAmountFooter,
+  },
+  {
+    id: "connectDevice",
+    label: <Trans i18nKey="aleo.bond.flow.steps.connectDevice.title" />,
+    component: GenericStepConnectDevice,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("amount"),
+  },
+  {
+    id: "confirmation",
+    label: <Trans i18nKey="aleo.bond.flow.steps.confirmation.title" />,
+    component: StepConfirmation,
+    footer: StepConfirmationFooter,
+  },
+];
+
+export default createStakingFlowBody<StepId>({
+  steps,
+  initialStepId: "validator",
+  title: "aleo.bond.flow.title",
+  trackCloseEvent: "CloseModalBondPublic",
+  mode: TRANSACTION_TYPE.BOND_PUBLIC,
+  // Aleo allows one validator per address and the chain rejects a bond to a second one, so an
+  // account with an open position can only ever top that validator up.
+  initialRecipient: account => {
+    const bonded = account.aleoResources?.bondedValidator;
+    if (bonded) return bonded;
+    const networkType = getAleoCurrencyConfig(account.currency)?.networkType;
+    return networkType ? DEFAULT_ALEO_VALIDATOR[networkType] : "";
+  },
+  withdrawalFromFresh: true,
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorPicker.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorPicker.test.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { render, screen, userEvent } from "tests/testSetup";
+import { mockDomMeasurements } from "LLD/features/__tests__/shared";
+import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";
+import type { AleoValidator } from "@ledgerhq/live-common/families/aleo/types";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_MAIN_ACCOUNT } from "../__mocks__/account.mock";
+import ValidatorPicker from "./ValidatorPicker";
+
+jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/families/aleo/react"),
+  useAleoValidators: jest.fn(),
+}));
+
+const mockUseAleoValidators = jest.mocked(useAleoValidators);
+
+const FIGMENT: AleoValidator = {
+  address: "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t",
+  name: "Figment",
+  stakeMicrocredits: 63_051_013_000_000,
+  isOpen: true,
+  isUnbonding: false,
+  commissionPercent: 10,
+  estimatedYearlyRewardsRate: 0.062,
+} as AleoValidator;
+
+const OTHER: AleoValidator = {
+  ...FIGMENT,
+  address: "aleo1vfukg8ky2mhfprw63000000000000000000000000000000000000000q",
+  name: "Other Validator",
+  stakeMicrocredits: 162_243_084_000_000,
+} as AleoValidator;
+
+const setValidators = (
+  validators: AleoValidator[],
+  extra: { loading?: boolean; error?: Error | null } = {},
+) =>
+  mockUseAleoValidators.mockReturnValue({
+    validators,
+    loading: false,
+    error: null,
+    ...extra,
+  });
+
+beforeEach(() => {
+  mockDomMeasurements();
+  setValidators([FIGMENT, OTHER]);
+});
+
+function setup(props: Partial<React.ComponentProps<typeof ValidatorPicker>> = {}) {
+  const onSelect = jest.fn();
+  const onRetry = jest.fn();
+  const utils = render(
+    <ValidatorPicker
+      currency={ALEO_MAIN_ACCOUNT.currency}
+      selected={FIGMENT.address}
+      lockedTo={null}
+      onSelect={onSelect}
+      onRetry={onRetry}
+      {...props}
+    />,
+    { initialState: { settings: AFTER_ONBOARDING_STATE } },
+  );
+
+  return { ...utils, onSelect, onRetry };
+}
+
+describe("ValidatorPicker — list states", () => {
+  it("spins while the first load is still in flight", () => {
+    setValidators([], { loading: true });
+
+    setup();
+
+    expect(screen.getByTestId("validator-list-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("validator-list")).not.toBeInTheDocument();
+  });
+
+  it("shows the list rather than the spinner once a stale list exists", () => {
+    setValidators([FIGMENT], { loading: true });
+
+    setup();
+
+    expect(screen.queryByTestId("validator-list-loading")).not.toBeInTheDocument();
+    expect(screen.getByTestId("validator-list")).toBeInTheDocument();
+  });
+
+  it("offers a retry when the fetch failed with nothing to show", async () => {
+    setValidators([], { error: new Error("boom") });
+
+    const { onRetry } = setup();
+
+    expect(screen.getByTestId("validator-fetch-error")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // A stale list is more useful than an error screen, so an error alongside one is ignored.
+  it("keeps showing a stale list when the refresh failed", () => {
+    setValidators([FIGMENT], { error: new Error("boom") });
+
+    setup();
+
+    expect(screen.queryByTestId("validator-fetch-error")).not.toBeInTheDocument();
+    expect(screen.getByText("Figment")).toBeInTheDocument();
+  });
+});
+
+describe("ValidatorPicker — search", () => {
+  it("filters by name, case-insensitively", async () => {
+    setup();
+
+    await userEvent.type(screen.getByPlaceholderText("Search by name or address..."), "other");
+
+    expect(screen.getByText("Other Validator")).toBeInTheDocument();
+    expect(screen.queryByText("Figment")).not.toBeInTheDocument();
+  });
+
+  it("filters by address", async () => {
+    setup();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Search by name or address..."),
+      OTHER.address,
+    );
+
+    expect(screen.getByText("Other Validator")).toBeInTheDocument();
+    expect(screen.queryByText("Figment")).not.toBeInTheDocument();
+  });
+
+  it("shows a no-result placeholder and hides the show-all toggle", async () => {
+    setup();
+
+    await userEvent.type(screen.getByPlaceholderText("Search by name or address..."), "zzzz");
+
+    expect(screen.queryByText("Figment")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show less")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show all")).not.toBeInTheDocument();
+  });
+});
+
+describe("ValidatorPicker — show all toggle", () => {
+  it("starts expanded and collapses to the selected row alone", async () => {
+    setup();
+
+    expect(screen.getByText("Other Validator")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Show less"));
+
+    expect(screen.getByText("Figment")).toBeInTheDocument();
+    expect(screen.queryByText("Other Validator")).not.toBeInTheDocument();
+  });
+
+  it("re-expands on a second click", async () => {
+    setup();
+
+    await userEvent.click(screen.getByText("Show less"));
+    await userEvent.click(screen.getByText("Show all"));
+
+    expect(screen.getByText("Other Validator")).toBeInTheDocument();
+  });
+});
+
+describe("ValidatorPicker — locked to a bonded validator", () => {
+  it("shows that validator alone, with no search and no toggle", () => {
+    setup({ lockedTo: OTHER.address });
+
+    expect(screen.getByTestId("bonded-validator")).toHaveTextContent("Other Validator");
+    expect(screen.queryByText("Figment")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search by name or address...")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show less")).not.toBeInTheDocument();
+  });
+
+  // The bonded validator can have left the committee, so it need not be in the list at all.
+  it("falls back to the shortened address when the list does not carry it", () => {
+    setup({ lockedTo: "aleo1notinthelist000000000000000000000000000000000000000000000" });
+
+    expect(screen.getByTestId("bonded-validator")).toHaveTextContent("aleo1not...00000000");
+  });
+
+  it("does not auto-move off a locked validator that is unpickable", () => {
+    setValidators([{ ...OTHER, isUnbonding: true }, FIGMENT]);
+
+    const { onSelect } = setup({ lockedTo: OTHER.address, selected: OTHER.address });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorPicker.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorPicker.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import { shortAddressPreview } from "@ledgerhq/live-common/account/index";
+import { AleoValidator } from "@ledgerhq/live-common/families/aleo/types";
+import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";
+import BigSpinner from "~/renderer/components/BigSpinner";
+import Alert from "~/renderer/components/Alert";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import ScrollLoadingList from "~/renderer/components/ScrollLoadingList";
+import ValidatorSearchInput, {
+  NoResultPlaceholder,
+} from "~/renderer/components/Delegation/ValidatorSearchInput";
+import Text from "~/renderer/components/Text";
+import IconAngleDown from "~/renderer/icons/AngleDown";
+import AleoValidatorRow, { isDisabled } from "./ValidatorRow";
+
+const LIST_HEIGHT = 256;
+
+type Props = Readonly<{
+  currency: CryptoCurrency;
+  selected: string;
+  lockedTo: string | null;
+  onSelect: (address: string) => void;
+  onRetry: () => void;
+}>;
+
+export default function ValidatorPicker({
+  currency,
+  selected,
+  lockedTo,
+  onSelect,
+  onRetry,
+}: Props) {
+  const [search, setSearch] = useState("");
+  const [showAll, setShowAll] = useState(true);
+  const { validators, loading, error } = useAleoValidators(currency);
+
+  useEffect(() => {
+    if (lockedTo) return;
+
+    const current = validators.find(({ address }) => address === selected);
+    if (!current || !isDisabled(current)) return;
+
+    const replacement = validators.find(validator => !isDisabled(validator));
+    if (replacement) onSelect(replacement.address);
+  }, [validators, selected, lockedTo, onSelect]);
+
+  const matches = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    const matched = needle
+      ? validators.filter(
+          ({ address, name }) =>
+            address.includes(needle) || (name?.toLowerCase() ?? "").includes(needle),
+        )
+      : validators;
+
+    return [...matched].sort((left, right) => Number(isDisabled(left)) - Number(isDisabled(right)));
+  }, [search, validators]);
+
+  const renderItem = useCallback(
+    (validator: AleoValidator) => (
+      <AleoValidatorRow
+        key={validator.address}
+        validator={validator}
+        currency={currency}
+        selected={selected === validator.address}
+        locked={false}
+        onSelect={onSelect}
+      />
+    ),
+    [currency, selected, onSelect],
+  );
+
+  if (lockedTo) {
+    const bonded = validators.find(({ address }) => address === lockedTo);
+    return (
+      <ValidatorsFieldContainer>
+        <Box p={1} data-testid="bonded-validator">
+          {bonded ? (
+            <AleoValidatorRow
+              validator={bonded}
+              currency={currency}
+              selected
+              locked
+              onSelect={onSelect}
+            />
+          ) : (
+            <Box p={2}>
+              <Text ff="Inter|SemiBold" fontSize={3} color="neutral.c100">
+                {shortAddressPreview(lockedTo)}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      </ValidatorsFieldContainer>
+    );
+  }
+
+  if (error && validators.length === 0) {
+    return (
+      <Box flow={3} alignItems="flex-start" data-testid="validator-fetch-error">
+        <Alert type="warning">
+          <Trans i18nKey="aleo.bond.flow.steps.validator.fetchError" />
+        </Alert>
+        <Button primary onClick={onRetry}>
+          <Trans i18nKey="common.retry" />
+        </Button>
+      </Box>
+    );
+  }
+
+  if (loading && validators.length === 0) {
+    return (
+      <ValidatorsFieldContainer>
+        <Box
+          p={1}
+          alignItems="center"
+          justifyContent="center"
+          style={{ minHeight: LIST_HEIGHT }}
+          data-testid="validator-list-loading"
+        >
+          <BigSpinner size={35} />
+        </Box>
+      </ValidatorsFieldContainer>
+    );
+  }
+
+  const shown = showAll
+    ? matches
+    : [matches.find(({ address }) => address === selected) ?? matches[0]].filter(Boolean);
+
+  const noResults = matches.length === 0 && search.length > 0;
+  const expanded = showAll || noResults;
+
+  return (
+    <>
+      <ValidatorSearchInput
+        noMargin
+        search={search}
+        onSearch={evt => setSearch(evt.target.value)}
+      />
+      <ValidatorsFieldContainer>
+        <Box p={1} data-testid="validator-list">
+          <ScrollLoadingList
+            data={shown}
+            style={{
+              flex: expanded ? `1 0 ${LIST_HEIGHT}px` : "1 0 64px",
+              marginBottom: 0,
+              paddingLeft: 0,
+              paddingRight: expanded ? 4 : 0,
+            }}
+            renderItem={renderItem}
+            noResultPlaceholder={noResults && <NoResultPlaceholder search={search} />}
+          />
+        </Box>
+        {!noResults && (
+          <SeeAllButton expanded={showAll} onClick={() => setShowAll(all => !all)}>
+            <Text color="wallet" ff="Inter|SemiBold" fontSize={4}>
+              <Trans i18nKey={showAll ? "distribution.showLess" : "distribution.showAll"} />
+            </Text>
+            <IconAngleDown size={16} />
+          </SeeAllButton>
+        )}
+      </ValidatorsFieldContainer>
+    </>
+  );
+}
+
+const ValidatorsFieldContainer = styled(Box)`
+  border: 1px solid ${p => p.theme.colors.neutral.c40};
+  border-radius: 4px;
+`;
+
+const SeeAllButton = styled.div<{ expanded: boolean }>`
+  display: flex;
+  color: ${p => p.theme.colors.wallet};
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid ${p => p.theme.colors.neutral.c40};
+  height: 40px;
+  cursor: pointer;
+
+  &:hover ${Text} {
+    text-decoration: underline;
+  }
+
+  > :nth-child(2) {
+    margin-left: 8px;
+    transform: rotate(${p => (p.expanded ? "180deg" : "0deg")});
+  }
+`;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorRow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorRow.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { render, screen, userEvent } from "tests/testSetup";
+import type { AleoValidator } from "@ledgerhq/live-common/families/aleo/types";
+import { openURL } from "~/renderer/linking";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_MAIN_ACCOUNT } from "../__mocks__/account.mock";
+import AleoValidatorRow, { isDisabled } from "./ValidatorRow";
+
+jest.mock("~/renderer/linking", () => ({
+  __esModule: true,
+  ...jest.requireActual("~/renderer/linking"),
+  openURL: jest.fn(),
+}));
+
+const mockOpenURL = jest.mocked(openURL);
+
+const VALIDATOR = {
+  address: "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t",
+  name: "Figment",
+  stakeMicrocredits: 63_051_013_000_000,
+  isOpen: true,
+  isUnbonding: false,
+  commissionPercent: 10,
+  estimatedYearlyRewardsRate: 0.062,
+} as AleoValidator;
+
+function setup(overrides: Partial<AleoValidator> = {}, props: { locked?: boolean } = {}) {
+  const onSelect = jest.fn();
+  const utils = render(
+    <AleoValidatorRow
+      validator={{ ...VALIDATOR, ...overrides } as AleoValidator}
+      currency={ALEO_MAIN_ACCOUNT.currency}
+      selected={false}
+      locked={props.locked ?? false}
+      onSelect={onSelect}
+    />,
+    { initialState: { settings: AFTER_ONBOARDING_STATE } },
+  );
+
+  return { ...utils, onSelect };
+}
+
+const row = () => screen.getByTestId("modal-provider-row");
+
+describe("isDisabled", () => {
+  it.each<[string, Partial<AleoValidator>]>([
+    ["closed to new stake", { isOpen: false }],
+    ["unbonding its own stake", { isUnbonding: true }],
+    ["over the concentration cap", { nonEarningReason: "overConcentrated" }],
+  ])("rejects a validator %s", (_label, overrides) => {
+    expect(isDisabled({ ...VALIDATOR, ...overrides } as AleoValidator)).toBe(true);
+  });
+
+  // A validator's commission is its own choice and can change, unlike the protocol-level
+  // concentration cap, so a full-commission validator stays selectable.
+  it("accepts a validator on full commission", () => {
+    expect(isDisabled({ ...VALIDATOR, nonEarningReason: "fullCommission" } as AleoValidator)).toBe(
+      false,
+    );
+  });
+
+  it("accepts an open, earning validator", () => {
+    expect(isDisabled(VALIDATOR)).toBe(false);
+  });
+});
+
+describe("AleoValidatorRow — subtitle", () => {
+  it("shows the yearly rate alongside the commission", () => {
+    setup();
+
+    expect(screen.getByText("6.2% est. · 10% commission")).toBeInTheDocument();
+  });
+
+  it("falls back to the commission alone when no rate is known", () => {
+    setup({ estimatedYearlyRewardsRate: undefined });
+
+    expect(screen.getByText("10% commission")).toBeInTheDocument();
+  });
+
+  // Unbonding outranks the others: the chain rejects the bond outright, so the reason the
+  // validator also earns nothing is beside the point.
+  it("reports unbonding ahead of any other warning", () => {
+    setup({ isUnbonding: true, isOpen: false, nonEarningReason: "overConcentrated" });
+
+    expect(screen.getByText("Validator is unbonding")).toBeInTheDocument();
+    expect(screen.queryByText("Validator is closed to new stake")).not.toBeInTheDocument();
+  });
+
+  it("reports a closed validator ahead of a non-earning reason", () => {
+    setup({ isOpen: false, nonEarningReason: "overConcentrated" });
+
+    expect(screen.getByText("Validator is closed to new stake")).toBeInTheDocument();
+    expect(screen.queryByText("Validator earns no rewards")).not.toBeInTheDocument();
+  });
+
+  it.each(["overConcentrated", "fullCommission"])("reports %s as earning nothing", reason => {
+    setup({ nonEarningReason: reason as AleoValidator["nonEarningReason"] });
+
+    expect(screen.getByText("Validator earns no rewards")).toBeInTheDocument();
+    expect(screen.queryByText(/commission$/)).not.toBeInTheDocument();
+  });
+});
+
+describe("AleoValidatorRow — selection", () => {
+  it("selects the validator when its row is clicked", async () => {
+    const { onSelect } = setup();
+
+    await userEvent.click(row());
+
+    expect(onSelect).toHaveBeenCalledWith(VALIDATOR.address);
+  });
+
+  it("does not select a validator that cannot take stake", async () => {
+    const { onSelect } = setup({ isUnbonding: true });
+
+    await userEvent.click(row());
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  // Locked means it is already the only legal target, so there is nothing to pick.
+  it("does not select a locked validator", async () => {
+    const { onSelect } = setup({}, { locked: true });
+
+    await userEvent.click(row());
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("opens the explorer from the validator name, even when unpickable", async () => {
+    setup({ isUnbonding: true });
+
+    await userEvent.click(screen.getByText("Figment"));
+
+    expect(mockOpenURL).toHaveBeenCalledWith(expect.stringContaining(VALIDATOR.address));
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorRow.tsx
@@ -1,0 +1,168 @@
+import { BigNumber } from "bignumber.js";
+import React, { useCallback } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import styled from "styled-components";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import { shortAddressPreview } from "@ledgerhq/live-common/account/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
+import { AleoValidator } from "@ledgerhq/live-common/families/aleo/types";
+import { Flex, Icons } from "@ledgerhq/react-ui";
+import Box from "~/renderer/components/Box";
+import ValidatorRow, {
+  IconContainer,
+  InfoContainer,
+  SideInfo,
+} from "~/renderer/components/Delegation/ValidatorRow";
+import FirstLetterIcon from "~/renderer/components/FirstLetterIcon";
+import Text from "~/renderer/components/Text";
+import ToolTip from "~/renderer/components/Tooltip";
+import Check from "~/renderer/icons/Check";
+import { openURL } from "~/renderer/linking";
+
+/** Still listed and explorer-linkable, but sorted below anything better and not selectable. */
+export const isDisabled = (validator: AleoValidator) =>
+  !validator.isOpen || validator.isUnbonding || validator.nonEarningReason === "overConcentrated";
+
+type Props = Readonly<{
+  validator: AleoValidator;
+  currency: CryptoCurrency;
+  selected: boolean;
+  locked: boolean;
+  onSelect: (address: string) => void;
+}>;
+
+export default function AleoValidatorRow({
+  validator,
+  currency,
+  selected,
+  locked,
+  onSelect,
+}: Props) {
+  const { t } = useTranslation();
+  const { address, name, nonEarningReason, isOpen, isUnbonding, commissionPercent } = validator;
+  const unit = currency.units[0];
+  const rate = validator.estimatedYearlyRewardsRate;
+  const label = name || shortAddressPreview(address);
+
+  const onExternalLink = useCallback(() => {
+    const explorerView = getDefaultExplorerView(currency);
+    const url = explorerView && getAddressExplorer(explorerView, address);
+    if (url) openURL(url);
+  }, [currency, address]);
+
+  const pickable = !locked && !isDisabled(validator);
+
+  let warning: React.ReactNode = null;
+  if (isUnbonding) {
+    warning = (
+      <ToolTip content={t("aleo.bond.flow.steps.validator.unbondingTooltip")}>
+        <Warning label={t("aleo.bond.flow.steps.validator.rowSubtitleUnbonding")} />
+      </ToolTip>
+    );
+  } else if (!isOpen) {
+    warning = <Warning label={t("aleo.bond.flow.steps.validator.rowSubtitleClosed")} />;
+  } else if (nonEarningReason) {
+    warning = (
+      <ToolTip content={t(`aleo.bond.flow.steps.validator.nonEarning.${nonEarningReason}`)}>
+        <Warning label={t("aleo.bond.flow.steps.validator.rowSubtitleEarnsNothing")} />
+      </ToolTip>
+    );
+  }
+
+  return (
+    <RowWrapper
+      dimmed={!locked && !pickable}
+      data-testid={selected ? "selected-validator" : undefined}
+    >
+      <StyledValidatorRow
+        disabled={!pickable}
+        validator={{ address }}
+        icon={
+          <IconContainer isSR>
+            <FirstLetterIcon label={label} />
+          </IconContainer>
+        }
+        title={label}
+        subtitle={
+          <Text ff="Inter|Medium" fontSize={2} color="neutral.c70">
+            {warning ?? (
+              <Text fontSize={2}>
+                {rate === undefined
+                  ? t("aleo.bond.flow.steps.validator.commissionOnly", {
+                      commission: commissionPercent,
+                    })
+                  : t("aleo.bond.flow.steps.validator.rateAndCommission", {
+                      rate: (rate * 100).toFixed(1),
+                      commission: commissionPercent,
+                    })}
+              </Text>
+            )}
+          </Text>
+        }
+        unit={unit}
+        onExternalLink={onExternalLink}
+        onClick={pickable ? () => onSelect(address) : undefined}
+        sideInfo={
+          <Flex flexDirection="row">
+            <Flex flexDirection="column" alignItems="flex-end">
+              <Text ff="Inter|SemiBold" color="neutral.c100" fontSize={4}>
+                {formatCurrencyUnit(unit, new BigNumber(validator.stakeMicrocredits), {
+                  showCode: true,
+                })}
+              </Text>
+              <Text fontSize={2} color="neutral.c70" textAlign="right">
+                <Trans i18nKey="aleo.bond.flow.steps.validator.totalStake" />
+              </Text>
+            </Flex>
+            {locked ? null : (
+              <Box ml={2} justifyContent="center">
+                <ChosenMark active={selected} />
+              </Box>
+            )}
+          </Flex>
+        }
+      />
+    </RowWrapper>
+  );
+}
+
+const Warning = ({ label }: Readonly<{ label: string }>) => (
+  <Flex alignItems="center" columnGap={1} color="warning.c70">
+    <Icons.Warning size="XS" style={{ width: "10px" }} />
+    <Text fontSize={2}>{label}</Text>
+  </Flex>
+);
+
+const StyledValidatorRow = styled(ValidatorRow)`
+  border-color: transparent;
+  margin-bottom: 0;
+
+  /* The shared row always hands its own handler down to the underlying div, so an absent
+     onSelect alone still leaves the hover affordance behind. Killing it off the forwarded
+     [disabled] attribute is what actually makes the row read as unpickable. */
+  &[disabled] {
+    cursor: default;
+  }
+  &[disabled]:hover {
+    border-color: transparent;
+  }
+
+  ${InfoContainer} {
+    flex: 1 1 80%;
+    min-width: 0;
+  }
+  ${SideInfo} {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+`;
+
+const ChosenMark = styled(Check).attrs<{ active?: boolean }>(p => ({
+  color: p.active ? p.theme.colors.primary.c80 : "transparent",
+  size: 14,
+}))<{ active?: boolean }>``;
+
+const RowWrapper = styled.div<{ dimmed: boolean }>`
+  opacity: ${p => (p.dimmed ? 0.5 : 1)};
+`;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/index.tsx
@@ -1,0 +1,9 @@
+import Body from "./Body";
+import { StepId } from "./types";
+import { createStakingFlowModal } from "../shared/createStakingFlowModal";
+
+export default createStakingFlowModal<"MODAL_ALEO_BOND_PUBLIC", StepId>({
+  name: "MODAL_ALEO_BOND_PUBLIC",
+  initialStepId: "validator",
+  Body,
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepAmount.test.tsx
@@ -1,0 +1,121 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
+import { render, screen, userEvent } from "tests/testSetup";
+import i18n from "~/renderer/i18n/init";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_MAIN_ACCOUNT } from "../../__mocks__/account.mock";
+import { makeAleoTransaction } from "../../__mocks__/transaction.mock";
+import { makeBondStepProps } from "../../__mocks__/stepProps.mock";
+import type { StepProps } from "../types";
+import StepAmount, { StepAmountFooter } from "./StepAmount";
+
+jest.mock("~/renderer/modals/Send/fields/AmountField", () => ({
+  __esModule: true,
+  default: () => <div data-testid="amount-field" />,
+}));
+jest.mock("~/renderer/components/SpendableBanner", () => ({
+  __esModule: true,
+  default: () => <div data-testid="spendable-banner" />,
+}));
+jest.mock("~/renderer/modals/Send/AccountFooter", () => ({
+  __esModule: true,
+  default: () => <div data-testid="account-footer" />,
+}));
+jest.mock("~/renderer/components/ErrorBanner", () => ({
+  __esModule: true,
+  default: ({ error }: { error: Error }) => <div data-testid="error-banner">{error.name}</div>,
+}));
+
+const VALIDATOR = "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t";
+
+const withStatusErrors = (errors: Record<string, Error>): Partial<StepProps> => ({
+  status: {
+    errors,
+    warnings: {},
+    estimatedFees: new BigNumber(0),
+    amount: new BigNumber(0),
+    totalSpent: new BigNumber(0),
+  },
+});
+
+const continueButton = () => screen.getByRole("button", { name: "Continue" });
+
+function setup(Component: React.ComponentType<StepProps>, overrides: Partial<StepProps> = {}) {
+  const props = makeBondStepProps({
+    t: i18n.t.bind(i18n),
+    account: ALEO_MAIN_ACCOUNT,
+    transaction: makeAleoTransaction({ mode: "bond_public", recipient: VALIDATOR }),
+    ...overrides,
+  });
+  const utils = render(<Component {...props} />, {
+    initialState: { settings: AFTER_ONBOARDING_STATE },
+  });
+
+  return { ...utils, props };
+}
+
+describe("Aleo bond StepAmount", () => {
+  it("renders the amount field with the minimum-stake hint", () => {
+    setup(StepAmount);
+
+    expect(screen.getByTestId("amount-field")).toBeInTheDocument();
+    expect(screen.getByText(/must reach at least 10,000 ALEO/)).toBeInTheDocument();
+  });
+
+  it("surfaces a step error above the fields", () => {
+    setup(StepAmount, { error: new NotEnoughBalance() });
+
+    expect(screen.getByTestId("error-banner")).toHaveTextContent("NotEnoughBalance");
+  });
+
+  // AmountField renders an amount error inline, so banning the fee banner alongside it
+  // keeps the same shortfall from being reported twice.
+  it("hides the fee error while the amount itself is also invalid", () => {
+    setup(StepAmount, withStatusErrors({ amount: new NotEnoughBalance(), fees: new Error("fee") }));
+
+    expect(screen.queryByTestId("error-banner")).not.toBeInTheDocument();
+  });
+
+  it("shows the fee error on its own once the amount is valid", () => {
+    setup(StepAmount, withStatusErrors({ fees: new NotEnoughBalance() }));
+
+    expect(screen.getByTestId("error-banner")).toHaveTextContent("NotEnoughBalance");
+  });
+
+  it("renders nothing without a status", () => {
+    const { container } = setup(StepAmount, {
+      status: undefined as unknown as StepProps["status"],
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("Aleo bond StepAmountFooter", () => {
+  it("moves on to the device step", async () => {
+    const { props } = setup(StepAmountFooter);
+
+    await userEvent.click(continueButton());
+
+    expect(props.transitionTo).toHaveBeenCalledWith("connectDevice");
+  });
+
+  it("blocks Continue while the bridge is still preparing", () => {
+    setup(StepAmountFooter, { bridgePending: true });
+
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it.each(["amount", "fees", "recipient"])("blocks Continue on a %s error", key => {
+    setup(StepAmountFooter, withStatusErrors({ [key]: new NotEnoughBalance() }));
+
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it("renders nothing without an account", () => {
+    const { container } = setup(StepAmountFooter, { account: null });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepAmount.tsx
@@ -1,0 +1,93 @@
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import React, { Fragment, PureComponent } from "react";
+import { Trans } from "react-i18next";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Alert from "~/renderer/components/Alert";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import SpendableBanner from "~/renderer/components/SpendableBanner";
+import AccountFooter from "~/renderer/modals/Send/AccountFooter";
+import AmountField from "~/renderer/modals/Send/fields/AmountField";
+import { StepProps } from "../types";
+
+const StepAmount = ({
+  t,
+  account,
+  parentAccount,
+  transaction,
+  onChangeTransaction,
+  error,
+  status,
+  bridgePending,
+}: StepProps) => {
+  if (!status) return null;
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  return (
+    <Box flow={4}>
+      <TrackPage
+        category="Delegation Flow"
+        name="Step Amount"
+        flow="bond"
+        action="bonding"
+        currency="aleo"
+      />
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
+      {error ? <ErrorBanner error={error} /> : null}
+      {!status.errors.amount && status.errors.fees ? (
+        <ErrorBanner error={status.errors.fees} />
+      ) : null}
+      {account && transaction && mainAccount && (
+        <Fragment key={account.id}>
+          <Alert type="hint" small>
+            <Trans i18nKey="aleo.bond.flow.steps.amount.minimum" />
+          </Alert>
+          <SpendableBanner
+            account={account}
+            parentAccount={parentAccount}
+            transaction={transaction}
+          />
+          <AmountField
+            status={status}
+            account={account}
+            parentAccount={parentAccount}
+            transaction={transaction}
+            onChangeTransaction={onChangeTransaction}
+            bridgePending={bridgePending}
+            t={t}
+          />
+        </Fragment>
+      )}
+    </Box>
+  );
+};
+
+export class StepAmountFooter extends PureComponent<StepProps> {
+  onNext = async () => {
+    const { transitionTo } = this.props;
+    transitionTo("connectDevice");
+  };
+
+  render() {
+    const { account, parentAccount, status, bridgePending } = this.props;
+    if (!account) return null;
+    const canNext = !bridgePending && Object.keys(status.errors).length === 0;
+    return (
+      <>
+        <AccountFooter parentAccount={parentAccount} account={account} status={status} />
+        <Button
+          id={"bond-amount-continue-button"}
+          isLoading={bridgePending}
+          primary
+          disabled={!canNext}
+          onClick={this.onNext}
+        >
+          <Trans i18nKey="common.continue" />
+        </Button>
+      </>
+    );
+  }
+}
+
+export default StepAmount;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepConfirmation.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, screen, userEvent } from "tests/testSetup";
+import i18n from "~/renderer/i18n/init";
+import { track } from "~/renderer/analytics/segment";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { makeBondStepProps } from "../../__mocks__/stepProps.mock";
+import { makeAleoTransaction } from "../../__mocks__/transaction.mock";
+import { mockBroadcastedOperation } from "../../__mocks__/signedOperation.mock";
+import { ALEO_MAIN_ACCOUNT } from "../../__mocks__/account.mock";
+import type { StepProps } from "../types";
+import StepConfirmation, { StepConfirmationFooter } from "./StepConfirmation";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  __esModule: true,
+  ...jest.requireActual("~/renderer/analytics/segment"),
+  track: jest.fn(),
+}));
+jest.mock("~/renderer/drawers/Provider", () => ({
+  __esModule: true,
+  ...jest.requireActual("~/renderer/drawers/Provider"),
+  setDrawer: jest.fn(),
+}));
+
+const mockTrack = jest.mocked(track);
+const mockSetDrawer = jest.mocked(setDrawer);
+
+const VALIDATOR = "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t";
+
+const bondProps = (overrides: Partial<StepProps> = {}) =>
+  makeBondStepProps({
+    t: i18n.t.bind(i18n),
+    transaction: makeAleoTransaction({ mode: "bond_public", recipient: VALIDATOR }),
+    ...overrides,
+  });
+
+function setup(Component: React.ComponentType<StepProps>, overrides: Partial<StepProps> = {}) {
+  const props = bondProps(overrides);
+  const utils = render(<Component {...props} />, {
+    initialState: { settings: AFTER_ONBOARDING_STATE },
+  });
+
+  return { ...utils, props };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Aleo bond StepConfirmation", () => {
+  it("shows the success state once the operation is broadcast", () => {
+    setup(StepConfirmation, { optimisticOperation: mockBroadcastedOperation });
+
+    expect(screen.getByText("Bond sent")).toBeInTheDocument();
+    expect(screen.getByText("Your bond is being processed.")).toBeInTheDocument();
+  });
+
+  it("tracks staking_completed with the validator that was bonded to", () => {
+    setup(StepConfirmation, { optimisticOperation: mockBroadcastedOperation });
+
+    expect(mockTrack).toHaveBeenCalledWith("staking_completed", {
+      currency: "ALEO",
+      validator: VALIDATOR,
+      source: undefined,
+      delegation: "bonding",
+      flow: "bond",
+    });
+  });
+
+  // Without an operation there is nothing completed to report.
+  it("does not track anything while the step is still pending", () => {
+    setup(StepConfirmation);
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing while neither an operation nor an error has arrived", () => {
+    const { container } = setup(StepConfirmation);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the error on its own when signing failed", () => {
+    setup(StepConfirmation, { error: new Error("nope"), signed: false });
+
+    expect(screen.queryByText("Your bond could not be sent.")).not.toBeInTheDocument();
+  });
+
+  // A signed-but-failed transaction may still land, so the user is warned rather than
+  // told it simply failed.
+  it("adds the broadcast disclaimer when the transaction was already signed", () => {
+    setup(StepConfirmation, { error: new Error("nope"), signed: true });
+
+    expect(screen.getByText("Your bond could not be sent.")).toBeInTheDocument();
+  });
+});
+
+describe("Aleo bond StepConfirmationFooter", () => {
+  it("closes the modal from the close button", async () => {
+    const { props } = setup(StepConfirmationFooter);
+
+    await userEvent.click(screen.getByTestId("modal-close-button"));
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers a retry instead of details when the step errored", async () => {
+    const { props } = setup(StepConfirmationFooter, { error: new Error("nope") });
+
+    expect(screen.queryByText("View details")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(props.onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the modal and opens the operation drawer from View details", async () => {
+    const { props } = setup(StepConfirmationFooter, {
+      account: ALEO_MAIN_ACCOUNT,
+      optimisticOperation: mockBroadcastedOperation,
+    });
+
+    await userEvent.click(screen.getByText("View details"));
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(mockSetDrawer).toHaveBeenCalledWith(expect.anything(), {
+      operationId: mockBroadcastedOperation.id,
+      accountId: ALEO_MAIN_ACCOUNT.id,
+    });
+  });
+
+  it("prefers the first sub-operation when the bond produced one", async () => {
+    setup(StepConfirmationFooter, {
+      account: ALEO_MAIN_ACCOUNT,
+      optimisticOperation: {
+        ...mockBroadcastedOperation,
+        subOperations: [{ ...mockBroadcastedOperation, id: "sub-op-1" }],
+      },
+    });
+
+    await userEvent.click(screen.getByText("View details"));
+
+    expect(mockSetDrawer).toHaveBeenCalledWith(expect.anything(), {
+      operationId: "sub-op-1",
+      accountId: ALEO_MAIN_ACCOUNT.id,
+    });
+  });
+
+  it("shows neither retry nor details while the step is still pending", () => {
+    setup(StepConfirmationFooter);
+
+    expect(screen.queryByText("View details")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepConfirmation.tsx
@@ -1,0 +1,10 @@
+import { createStepConfirmation } from "../../shared/StepConfirmation";
+
+const { StepConfirmation, StepConfirmationFooter } = createStepConfirmation({
+  flow: "bond",
+  action: "bonding",
+  trackField: "validator",
+});
+
+export { StepConfirmationFooter };
+export default StepConfirmation;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepValidator.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepValidator.test.tsx
@@ -1,0 +1,178 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { render, screen, userEvent } from "tests/testSetup";
+import { mockDomMeasurements } from "LLD/features/__tests__/shared";
+import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";
+import type { AleoAccount, AleoValidator } from "@ledgerhq/live-common/families/aleo/types";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_MAIN_ACCOUNT } from "../../__mocks__/account.mock";
+import { makeAleoTransaction } from "../../__mocks__/transaction.mock";
+import { makeBondStepProps } from "../../__mocks__/stepProps.mock";
+import type { StepProps } from "../types";
+import StepValidator, { StepValidatorFooter } from "./StepValidator";
+
+jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/families/aleo/react"),
+  useAleoValidators: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+jest.mock("~/renderer/components/ErrorBanner", () => ({
+  __esModule: true,
+  default: ({ error }: { error: Error }) => <div data-testid="error-banner">{error.name}</div>,
+}));
+
+const mockUseAleoValidators = jest.mocked(useAleoValidators);
+
+const FIGMENT = {
+  address: "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t",
+  name: "Figment",
+  stakeMicrocredits: 63_051_013_000_000,
+  isOpen: true,
+  isUnbonding: false,
+  commissionPercent: 10,
+  estimatedYearlyRewardsRate: 0.062,
+} as AleoValidator;
+
+const OTHER = {
+  ...FIGMENT,
+  address: "aleo1vfukg8ky2mhfprw63000000000000000000000000000000000000000q",
+  name: "Other Validator",
+} as AleoValidator;
+
+const bondedTo = (validator: string): AleoAccount =>
+  ({
+    ...ALEO_MAIN_ACCOUNT,
+    aleoResources: { ...ALEO_MAIN_ACCOUNT.aleoResources, bondedValidator: validator },
+  }) as AleoAccount;
+
+beforeEach(() => {
+  mockDomMeasurements();
+  mockUseAleoValidators.mockReturnValue({
+    validators: [FIGMENT, OTHER],
+    loading: false,
+    error: null,
+  });
+});
+
+function setup(Component: React.ComponentType<StepProps>, overrides: Partial<StepProps> = {}) {
+  const props = makeBondStepProps({
+    account: ALEO_MAIN_ACCOUNT,
+    transaction: makeAleoTransaction({ mode: "bond_public", recipient: FIGMENT.address }),
+    ...overrides,
+  });
+  const utils = render(<Component {...props} />, {
+    initialState: { settings: AFTER_ONBOARDING_STATE },
+  });
+
+  return { ...utils, props };
+}
+
+// Selection hangs off the row. The name is the explorer link and deliberately selects
+// nothing, so tests that mean to select must target the row.
+const validatorRow = (name: string) =>
+  screen.getByText(name).closest("[data-testid='modal-provider-row']") as HTMLElement;
+
+describe("Aleo bond StepValidator", () => {
+  it("lets the user pick a different validator", async () => {
+    const { props } = setup(StepValidator);
+
+    await userEvent.click(validatorRow("Other Validator"));
+
+    expect(props.onUpdateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the selection alone when the validator name is clicked", async () => {
+    const { props } = setup(StepValidator);
+
+    await userEvent.click(screen.getByText("Other Validator"));
+
+    expect(props.onUpdateTransaction).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a step error", () => {
+    setup(StepValidator, { error: new Error("boom") });
+
+    expect(screen.getByTestId("error-banner")).toBeInTheDocument();
+  });
+
+  it("surfaces a recipient error from the status", () => {
+    setup(StepValidator, {
+      status: {
+        errors: { recipient: new Error("InvalidAddress") },
+        warnings: {},
+        estimatedFees: new BigNumber(0),
+        amount: new BigNumber(0),
+        totalSpent: new BigNumber(0),
+      },
+    });
+
+    expect(screen.getByTestId("error-banner")).toBeInTheDocument();
+  });
+
+  it("shows no top-up notice when nothing is bonded yet", () => {
+    setup(StepValidator);
+
+    expect(screen.queryByText(/Aleo allows one validator per account/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bonded-validator")).not.toBeInTheDocument();
+  });
+
+  it("explains the single-validator rule once a position is open", () => {
+    setup(StepValidator, {
+      account: bondedTo(OTHER.address),
+      transaction: makeAleoTransaction({ mode: "bond_public", recipient: OTHER.address }),
+    });
+
+    expect(screen.getByText(/Aleo allows one validator per account/)).toBeInTheDocument();
+    expect(screen.getByTestId("bonded-validator")).toHaveTextContent("Other Validator");
+  });
+});
+
+describe("Aleo bond StepValidatorFooter", () => {
+  it("moves on to the amount step", async () => {
+    const { props } = setup(StepValidatorFooter);
+
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(props.transitionTo).toHaveBeenCalledWith("amount");
+  });
+
+  it("closes the modal from Cancel", async () => {
+    const { props } = setup(StepValidatorFooter);
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks Continue until a validator is chosen", () => {
+    setup(StepValidatorFooter, {
+      transaction: makeAleoTransaction({ mode: "bond_public", recipient: "" }),
+    });
+
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+  });
+
+  it("blocks Continue while the bridge is still preparing", () => {
+    setup(StepValidatorFooter, { bridgePending: true });
+
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+  });
+
+  it("blocks Continue on a recipient error", () => {
+    setup(StepValidatorFooter, {
+      status: {
+        errors: { recipient: new Error("InvalidAddress") },
+        warnings: {},
+        estimatedFees: new BigNumber(0),
+        amount: new BigNumber(0),
+        totalSpent: new BigNumber(0),
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/steps/StepValidator.tsx
@@ -1,0 +1,85 @@
+import invariant from "invariant";
+import React, { useCallback, useState } from "react";
+import { Trans } from "react-i18next";
+import { StepProps } from "../types";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction, AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Alert from "~/renderer/components/Alert";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import ValidatorPicker from "../ValidatorPicker";
+
+export default function StepValidator({
+  account,
+  parentAccount,
+  onUpdateTransaction,
+  transaction,
+  error,
+  status,
+}: StepProps) {
+  invariant(account && transaction, "account and transaction required");
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const [attempt, setAttempt] = useState(0);
+
+  // Body.tsx has already seeded `recipient` with the bonded validator.
+  const lockedTo = (account as AleoAccount).aleoResources?.bondedValidator ?? null;
+
+  const onSelect = useCallback(
+    (address: string) =>
+      onUpdateTransaction(() => bridge.updateTransaction(transaction, { recipient: address })),
+    [bridge, onUpdateTransaction, transaction],
+  );
+
+  return (
+    <Box flow={3}>
+      <TrackPage
+        category="Bond Flow"
+        name={lockedTo ? "Step Validator Locked" : "Step Validator"}
+        currency="aleo"
+        type="modal"
+      />
+      {error && <ErrorBanner error={error} />}
+      {status.errors.recipient && <ErrorBanner error={status.errors.recipient} />}
+      {lockedTo && (
+        <Alert type="primary" small>
+          <Trans i18nKey="aleo.bond.flow.steps.validator.topUpOnly" />
+        </Alert>
+      )}
+      <ValidatorPicker
+        key={attempt}
+        currency={account.currency}
+        selected={transaction.recipient || ""}
+        lockedTo={lockedTo}
+        onSelect={onSelect}
+        onRetry={() => setAttempt(n => n + 1)}
+      />
+    </Box>
+  );
+}
+
+export function StepValidatorFooter({
+  transitionTo,
+  status,
+  bridgePending,
+  transaction,
+  onClose,
+}: StepProps) {
+  const canNext = !bridgePending && !!transaction?.recipient && !status.errors.recipient;
+  return (
+    <Box horizontal>
+      <Button mr={1} onClick={onClose}>
+        <Trans i18nKey="common.cancel" />
+      </Button>
+      <Button
+        id="bond-continue-button"
+        disabled={!canNext}
+        primary
+        onClick={() => transitionTo("amount")}
+      >
+        <Trans i18nKey="common.continue" />
+      </Button>
+    </Box>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/types.ts
@@ -1,0 +1,33 @@
+import { TFunction } from "i18next";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { Step } from "~/renderer/components/Stepper";
+import { Account, Operation } from "@ledgerhq/types-live";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/aleo/types";
+import { OpenModal } from "~/renderer/actions/modals";
+
+export type StepId = "validator" | "amount" | "connectDevice" | "confirmation";
+
+export type StepProps = Readonly<{
+  t: TFunction;
+  transitionTo: (a: string) => void;
+  device: Device | undefined | null;
+  account: Account | undefined | null;
+  parentAccount: Account | undefined | null;
+  onRetry: (a: void) => void;
+  onClose: () => void;
+  openModal: OpenModal;
+  optimisticOperation: Operation | undefined;
+  error: Error | undefined;
+  signed: boolean;
+  transaction: Transaction | undefined | null;
+  status: TransactionStatus;
+  onChangeTransaction: (a: Transaction) => void;
+  onUpdateTransaction: (a: (a: Transaction) => Transaction) => void;
+  onTransactionError: (a: Error) => void;
+  onOperationBroadcasted: (a: Operation) => void;
+  setSigned: (a: boolean) => void;
+  bridgePending: boolean;
+  source?: string;
+}>;
+
+export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.test.tsx
@@ -30,21 +30,27 @@ afterEach(() => {
 });
 
 describe("Aleo ManageModal", () => {
-  // The rows are shown so the modal describes the whole staking lifecycle, but none of the
-  // flows are built. A row that looked clickable would open nothing at all.
-  it.each(["aleo-bond-button", "aleo-unbond-button", "aleo-claim-button"])(
-    "leaves %s disabled",
-    async testId => {
-      setup();
-
-      expect(await screen.findByTestId(testId)).toBeDisabled();
-    },
-  );
-
-  it("does not open any flow from the rows", async () => {
+  it("hands over to the bond flow when the bond row is clicked", async () => {
     const { store } = setup();
 
     await userEvent.click(await screen.findByTestId("aleo-bond-button"));
+
+    expect(store.getState().modals[AleoCustomModal.BOND_PUBLIC]).toEqual({
+      isOpened: true,
+      data: { account: ALEO_MAIN_ACCOUNT },
+    });
+    expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
+  });
+
+  it.each(["aleo-unbond-button", "aleo-claim-button"])("leaves %s disabled", async testId => {
+    setup();
+
+    expect(await screen.findByTestId(testId)).toBeDisabled();
+  });
+
+  it("opens no flow from the unbond or claim rows", async () => {
+    const { store } = setup();
+
     await userEvent.click(await screen.findByTestId("aleo-unbond-button"));
     await userEvent.click(await screen.findByTestId("aleo-claim-button"));
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { useDispatch } from "LLD/hooks/redux";
 import { Trans, useTranslation } from "react-i18next";
+import { openModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import ToolTip from "~/renderer/components/Tooltip";
@@ -8,6 +10,7 @@ import UnbondIcon from "~/renderer/icons/Undelegate";
 import ClaimRewardIcon from "~/renderer/icons/ClaimReward";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import type { Account } from "@ledgerhq/types-live";
+import { ModalData } from "~/renderer/modals/types";
 import * as S from "./ManageModal.styles";
 
 export type Data = {
@@ -16,14 +19,17 @@ export type Data = {
   source?: string;
 };
 
-const ManageModal = ({
-  account: _account,
-  parentAccount: _parentAccount,
-  source: _source,
-  ...rest
-}: Data) => {
+const ManageModal = ({ account, parentAccount, source, ...rest }: Data) => {
+  const dispatch = useDispatch();
   const { t } = useTranslation();
 
+  const onSelectAction = useCallback(
+    (onClose: () => void, name: keyof ModalData) => {
+      onClose();
+      dispatch(openModal(name, { account, parentAccount, source }));
+    },
+    [dispatch, account, parentAccount, source],
+  );
   return (
     <Modal
       {...rest}
@@ -36,24 +42,23 @@ const ManageModal = ({
           title={<Trans i18nKey="aleo.manage.title" />}
           render={() => (
             <Box>
-              <ToolTip
-                content={t("aleo.manage.comingSoonTooltip")}
-                containerStyle={{ width: "100%" }}
+              <S.ManageButton
+                data-testid="aleo-bond-button"
+                onClick={() => onSelectAction(onClose, "MODAL_ALEO_BOND_PUBLIC")}
               >
-                <S.ManageButton data-testid="aleo-bond-button" disabled>
-                  <S.IconWrapper>
-                    <IconCoins size={16} />
-                  </S.IconWrapper>
-                  <S.InfoWrapper>
-                    <S.Title>
-                      <Trans i18nKey="aleo.manage.bond.title" />
-                    </S.Title>
-                    <S.Description>
-                      <Trans i18nKey="aleo.manage.bond.description" />
-                    </S.Description>
-                  </S.InfoWrapper>
-                </S.ManageButton>
-              </ToolTip>
+                <S.IconWrapper>
+                  <IconCoins size={16} />
+                </S.IconWrapper>
+                <S.InfoWrapper>
+                  <S.Title>
+                    <Trans i18nKey="aleo.manage.bond.title" />
+                  </S.Title>
+                  <S.Description>
+                    <Trans i18nKey="aleo.manage.bond.description" />
+                  </S.Description>
+                </S.InfoWrapper>
+              </S.ManageButton>
+              {/* Listed so the modal shows the whole staking lifecycle; the flows are not built yet. */}
               <ToolTip
                 content={t("aleo.manage.comingSoonTooltip")}
                 containerStyle={{ width: "100%" }}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/TransactionConfirmFields.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/TransactionConfirmFields.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
+import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";
+import type { AleoValidator, Transaction } from "@ledgerhq/live-common/families/aleo/types";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_MAIN_ACCOUNT } from "./__mocks__/account.mock";
+import { makeAleoTransaction } from "./__mocks__/transaction.mock";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import type { AleoFieldComponentProps } from "./types";
+
+jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/families/aleo/react"),
+  useAleoValidators: jest.fn(),
+}));
+
+const mockUseAleoValidators = jest.mocked(useAleoValidators);
+
+const VALIDATOR_ADDRESS = "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t";
+
+const AddressField = transactionConfirmFields.fieldComponents.address;
+
+beforeEach(() => {
+  mockUseAleoValidators.mockReturnValue({
+    validators: [
+      { address: VALIDATOR_ADDRESS, name: "Figment", commissionPercent: 10 } as AleoValidator,
+    ],
+    loading: false,
+    error: null,
+  });
+});
+
+function setup(
+  field: AleoFieldComponentProps["field"],
+  mode: Transaction["mode"] = TRANSACTION_TYPE.BOND_PUBLIC,
+) {
+  return render(
+    <AddressField
+      field={field}
+      account={ALEO_MAIN_ACCOUNT}
+      parentAccount={undefined}
+      transaction={
+        { ...makeAleoTransaction({ recipient: VALIDATOR_ADDRESS }), mode } as Transaction
+      }
+      status={{ errors: {}, warnings: {} } as AleoFieldComponentProps["status"]}
+    />,
+    { initialState: { settings: AFTER_ONBOARDING_STATE } },
+  );
+}
+
+const addressField = (overrides: Record<string, unknown> = {}) =>
+  ({
+    type: "address",
+    label: "To",
+    address: VALIDATOR_ADDRESS,
+    ...overrides,
+  }) as AleoFieldComponentProps["field"];
+
+describe("Aleo TransactionConfirmFields — address field", () => {
+  it("always renders the raw address under its own label", () => {
+    setup(addressField());
+
+    expect(screen.getByText("To")).toBeInTheDocument();
+    expect(screen.getByText(VALIDATOR_ADDRESS)).toBeInTheDocument();
+  });
+
+  it("adds a Validator row naming the recipient when it is a known validator", () => {
+    setup(addressField());
+
+    expect(screen.getByText("Validator")).toBeInTheDocument();
+    expect(screen.getByText("Figment")).toBeInTheDocument();
+  });
+
+  // Any address can be a "To": only a validator the list knows gets the extra row.
+  it("omits the Validator row for an address the list does not carry", () => {
+    setup(addressField({ address: "aleo1someoneelse" }));
+
+    expect(screen.queryByText("Validator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Figment")).not.toBeInTheDocument();
+  });
+
+  it("omits the Validator row for a non-To address such as the sender", () => {
+    setup(addressField({ label: "From" }));
+
+    expect(screen.getByText(VALIDATOR_ADDRESS)).toBeInTheDocument();
+    expect(screen.queryByText("Validator")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a field that is not an address", () => {
+    const { container } = setup({
+      type: "amount",
+      label: "Amount",
+    } as AleoFieldComponentProps["field"]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe("validator lookup", () => {
+    it("does not fetch validators for a non-bond transaction", () => {
+      setup(addressField(), TRANSACTION_TYPE.TRANSFER_PUBLIC);
+
+      expect(mockUseAleoValidators).not.toHaveBeenCalled();
+      expect(screen.queryByText("Validator")).not.toBeInTheDocument();
+    });
+
+    it("does not fetch validators for the From row of a bond transaction", () => {
+      setup(addressField({ label: "From" }));
+
+      expect(mockUseAleoValidators).not.toHaveBeenCalled();
+    });
+
+    it("fetches validators only for the bond flow's To row", () => {
+      setup(addressField());
+
+      expect(mockUseAleoValidators).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/TransactionConfirmFields.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
+import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";
+import Text from "~/renderer/components/Text";
+import TransactionConfirmField from "~/renderer/components/TransactionConfirm/TransactionConfirmField";
+import type { AleoFieldComponentProps } from "./types";
+
+const FieldText = styled(Text).attrs(() => ({
+  ml: 1,
+  ff: "Inter|Medium",
+  color: "neutral.c80",
+  fontSize: 3,
+}))`
+  word-break: break-all;
+  text-align: right;
+  max-width: 50%;
+`;
+
+const ValidatorNameField = ({
+  address,
+  currency,
+}: {
+  address: string;
+  currency: CryptoCurrency;
+}) => {
+  const { validators } = useAleoValidators(currency);
+  const validatorName = validators.find(v => v.address === address)?.name;
+
+  if (!validatorName) return null;
+
+  return (
+    <TransactionConfirmField
+      label={<Trans i18nKey="aleo.bond.flow.steps.connectDevice.validatorLabel" />}
+    >
+      <FieldText>{validatorName}</FieldText>
+    </TransactionConfirmField>
+  );
+};
+
+const AddressField = ({ field, account, parentAccount, transaction }: AleoFieldComponentProps) => {
+  if (field.type !== "address") return null;
+
+  const isBondRecipient = field.label === "To" && transaction.mode === TRANSACTION_TYPE.BOND_PUBLIC;
+
+  return (
+    <>
+      <TransactionConfirmField label={field.label}>
+        <FieldText>{field.address}</FieldText>
+      </TransactionConfirmField>
+      {isBondRecipient && (
+        <ValidatorNameField
+          address={field.address}
+          currency={getMainAccount(account, parentAccount).currency}
+        />
+      )}
+    </>
+  );
+};
+
+export default {
+  fieldComponents: {
+    address: AddressField,
+  },
+};

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/bondFlow.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/bondFlow.integ.test.tsx
@@ -1,0 +1,321 @@
+import React from "react";
+import { act, render, screen, userEvent, waitFor } from "tests/testSetup";
+import { mockDomMeasurements } from "LLD/features/__tests__/shared";
+import { importLLDCoinFamily } from "~/renderer/families";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import BondPublicFlowModal from "../BondPublicFlowModal";
+import { DEFAULT_ALEO_VALIDATOR } from "../constants";
+import { ALEO_MAIN_ACCOUNT } from "../__mocks__/account.mock";
+import { mockAleoCoinConfig } from "../__mocks__/config.mock";
+import { mockSignedOperation } from "../__mocks__/signedOperation.mock";
+import { getAleoCurrencyConfig } from "../shared/utils";
+import { initSendSubjects, subjectRefs, prepareTransactionSpy } from "../__mocks__/bridge.mock";
+import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";
+import type { AleoValidator } from "@ledgerhq/live-common/families/aleo/types";
+
+jest.mock("../shared/utils", () => ({
+  ...jest.requireActual("../shared/utils"),
+  getAleoCurrencyConfig: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/families/aleo/react"),
+  useAleoValidators: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/crypto-icons", () => ({ CryptoIcon: jest.fn() }));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
+const mockUseAleoValidators = jest.mocked(useAleoValidators);
+
+// Open, not unbonding and earning: give any of a closed flag, an unbonding flag or a
+// non-earning reason and the rows below get demoted and re-sorted, silently changing what
+// the assertions mean.
+const FIGMENT = {
+  address: DEFAULT_ALEO_VALIDATOR.mainnet,
+  name: "Figment",
+  stakeMicrocredits: 63_051_013_000_000,
+  isOpen: true,
+  isUnbonding: false,
+  commissionPercent: 10,
+  estimatedYearlyRewardsRate: 0.062,
+};
+const OTHER = {
+  address: "aleo1vfukg8ky2mhfprw63000000000000000000000000000000000000000q",
+  name: "Other Validator",
+  stakeMicrocredits: 162_243_084_000_000,
+  isOpen: true,
+  isUnbonding: false,
+  commissionPercent: 10,
+  estimatedYearlyRewardsRate: 0.061,
+};
+
+beforeEach(async () => {
+  mockDomMeasurements();
+  await importLLDCoinFamily("aleo");
+  initSendSubjects();
+  prepareTransactionSpy.mockClear();
+  mockGetAleoCurrencyConfig.mockReturnValue(mockAleoCoinConfig);
+  // Deliberately listed with Figment second, so a passing assertion cannot be an
+  // artifact of it happening to be first.
+  mockUseAleoValidators.mockReturnValue({
+    validators: [OTHER, FIGMENT],
+    loading: false,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  subjectRefs.sync.complete();
+  subjectRefs.sign.complete();
+  document.getElementById("modals")?.remove();
+});
+
+function setupModal(account = ALEO_MAIN_ACCOUNT) {
+  const modalsDiv = document.createElement("div");
+  modalsDiv.id = "modals";
+  document.body.appendChild(modalsDiv);
+
+  return render(<BondPublicFlowModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_ALEO_BOND_PUBLIC: {
+          isOpened: true,
+          data: { account, parentAccount: null },
+        },
+      },
+    },
+  });
+}
+
+async function clickContinueWhenEnabled() {
+  const button = () => screen.getByRole("button", { name: "Continue" });
+  await waitFor(() => expect(button()).not.toBeDisabled());
+  await userEvent.click(button());
+}
+
+// Selection hangs off the row. The name is the explorer link and deliberately selects
+// nothing, so tests that mean to select must target the row.
+async function clickValidatorRow(name: string) {
+  const row = (await screen.findByText(name)).closest("[data-testid='modal-provider-row']");
+  await userEvent.click(row as HTMLElement);
+}
+
+describe("Aleo bond flow — full modal", () => {
+  it("bonds through validator → amount → device → success", async () => {
+    setupModal();
+
+    await screen.findByTestId("selected-validator");
+    await clickContinueWhenEnabled();
+
+    expect(await screen.findByText(/must reach at least 10,000 ALEO/)).toBeInTheDocument();
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(() => expect(screen.getByText("Bond sent")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+  }, 20000);
+
+  // The withdrawal address is never a step: it is pinned to the user's own account at
+  // transaction-creation time, and nothing downstream re-pins it.
+  it("seeds the withdrawal address from the account's fresh address", async () => {
+    setupModal();
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+
+    const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+    expect(transaction).toMatchObject({ withdrawal: ALEO_MAIN_ACCOUNT.freshAddress });
+  });
+
+  it("keeps the withdrawal address pinned after the validator is changed", async () => {
+    setupModal();
+
+    await clickValidatorRow("Other Validator");
+
+    await waitFor(() => {
+      const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+      expect(transaction).toMatchObject({
+        recipient: OTHER.address,
+        withdrawal: ALEO_MAIN_ACCOUNT.freshAddress,
+      });
+    });
+  });
+});
+
+describe("Aleo bond flow — validator pre-selection", () => {
+  it("seeds the transaction with the default validator when nothing is bonded", async () => {
+    setupModal();
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+
+    const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+    expect(transaction.recipient).toBe(DEFAULT_ALEO_VALIDATOR.mainnet);
+    expect(transaction.mode).toBe("bond_public");
+  });
+
+  it("seeds the testnet default validator on testnet", async () => {
+    mockGetAleoCurrencyConfig.mockReturnValue({ ...mockAleoCoinConfig, networkType: "testnet" });
+
+    setupModal();
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+
+    const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+    expect(transaction.recipient).toBe(DEFAULT_ALEO_VALIDATOR.testnet);
+    expect(transaction.recipient).not.toBe(DEFAULT_ALEO_VALIDATOR.mainnet);
+  });
+
+  it("seeds nothing when the network cannot be resolved", async () => {
+    mockGetAleoCurrencyConfig.mockReturnValue(undefined);
+
+    setupModal();
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+
+    const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+    expect(transaction.recipient).toBe("");
+  });
+
+  it("seeds the bonded validator instead of the default when a position is open", async () => {
+    const bonded = {
+      ...ALEO_MAIN_ACCOUNT,
+      aleoResources: {
+        ...ALEO_MAIN_ACCOUNT.aleoResources,
+        bondedValidator: OTHER.address,
+      },
+    };
+
+    setupModal(bonded as typeof ALEO_MAIN_ACCOUNT);
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+
+    const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+    expect(transaction.recipient).toBe(OTHER.address);
+  });
+
+  it("renders the default validator in the list so the selection is visible", async () => {
+    setupModal();
+
+    await waitFor(() => expect(screen.getByText("Figment")).toBeVisible());
+  });
+
+  // The shared ValidatorRow derives its highlight from a voting `value` this picker never
+  // passes, so a correctly seeded recipient can still render as though nothing were chosen.
+  it("marks the pre-selected row as selected in the DOM", async () => {
+    setupModal();
+
+    const selected = await screen.findByTestId("selected-validator");
+    expect(selected).toHaveTextContent("Figment");
+  });
+});
+
+// `bond_public` asserts the validator has no `unbonding` entry, so bonding to one that
+// does always fails on-chain — however open the committee still reports it.
+describe("Aleo bond flow — a validator that is itself unbonding", () => {
+  beforeEach(() => {
+    mockUseAleoValidators.mockReturnValue({
+      validators: [{ ...OTHER, isUnbonding: true }, FIGMENT],
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("says so on the row, rather than leaving it looking bondable", async () => {
+    setupModal();
+
+    expect(await screen.findByText("Validator is unbonding")).toBeVisible();
+  });
+
+  it("does not let it be selected", async () => {
+    setupModal();
+
+    await clickValidatorRow("Other Validator");
+
+    expect(await screen.findByTestId("selected-validator")).toHaveTextContent("Figment");
+    expect(prepareTransactionSpy.mock.calls.at(-1)![1].recipient).toBe(FIGMENT.address);
+  });
+});
+
+// The default is seeded before the list loads, so it can land on a row the list then
+// refuses to select. Left alone that opens the flow on an error the user cannot clear.
+describe("Aleo bond flow — a default that turns out to be unpickable", () => {
+  const seedDefaultAs = (state: Partial<AleoValidator>) =>
+    mockUseAleoValidators.mockReturnValue({
+      validators: [OTHER, { ...FIGMENT, ...state }],
+      loading: false,
+      error: null,
+    });
+
+  it.each<[string, Partial<AleoValidator>]>([
+    ["unbonding", { isUnbonding: true }],
+    ["closed", { isOpen: false }],
+    ["over the concentration cap", { nonEarningReason: "overConcentrated" }],
+  ])("moves off a default that is %s", async (_label, state) => {
+    seedDefaultAs(state);
+
+    setupModal();
+
+    await waitFor(() =>
+      expect(prepareTransactionSpy.mock.calls.at(-1)![1].recipient).toBe(OTHER.address),
+    );
+    expect(await screen.findByTestId("selected-validator")).toHaveTextContent("Other Validator");
+  });
+
+  it("leaves the selection alone when no validator accepts stake", async () => {
+    mockUseAleoValidators.mockReturnValue({
+      validators: [
+        { ...OTHER, isUnbonding: true },
+        { ...FIGMENT, isUnbonding: true },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    setupModal();
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+    expect(prepareTransactionSpy.mock.calls.at(-1)![1].recipient).toBe(FIGMENT.address);
+  });
+
+  it("keeps a bonded validator that is unbonding, rather than switching away from it", async () => {
+    mockUseAleoValidators.mockReturnValue({
+      validators: [OTHER, { ...FIGMENT, isUnbonding: true }],
+      loading: false,
+      error: null,
+    });
+    const bonded = {
+      ...ALEO_MAIN_ACCOUNT,
+      aleoResources: {
+        ...ALEO_MAIN_ACCOUNT.aleoResources,
+        bondedValidator: FIGMENT.address,
+      },
+    };
+
+    setupModal(bonded as typeof ALEO_MAIN_ACCOUNT);
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+    expect(prepareTransactionSpy.mock.calls.at(-1)![1].recipient).toBe(FIGMENT.address);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/stepProps.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/stepProps.mock.ts
@@ -2,8 +2,9 @@ import BigNumber from "bignumber.js";
 import type { TFunction } from "i18next";
 
 import type { StepProps } from "~/renderer/modals/Send/types";
+import type { StepProps as BondStepProps } from "../BondPublicFlowModal/types";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
-import { ALEO_ACCOUNT_1 } from "./account.mock";
+import { ALEO_ACCOUNT_1, ALEO_MAIN_ACCOUNT } from "./account.mock";
 
 const makeAleoAccount = (percentage = 0): AleoAccount => ({
   ...ALEO_ACCOUNT_1,
@@ -54,3 +55,33 @@ export const makeStepProps = (overrides: Partial<StepProps> = {}): StepProps =>
     onFailHandler: jest.fn(),
     ...overrides,
   }) as StepProps;
+
+export const makeBondStepProps = (overrides: Partial<BondStepProps> = {}): BondStepProps =>
+  ({
+    t: jest.fn((key: string) => key) as unknown as TFunction,
+    account: ALEO_MAIN_ACCOUNT,
+    parentAccount: null,
+    transitionTo: jest.fn(),
+    device: null,
+    onRetry: jest.fn(),
+    onClose: jest.fn(),
+    openModal: jest.fn(),
+    optimisticOperation: undefined,
+    error: undefined,
+    signed: false,
+    transaction: null,
+    status: {
+      errors: {},
+      warnings: {},
+      estimatedFees: new BigNumber(0),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(0),
+    },
+    onChangeTransaction: jest.fn(),
+    onUpdateTransaction: jest.fn(),
+    onTransactionError: jest.fn(),
+    onOperationBroadcasted: jest.fn(),
+    setSigned: jest.fn(),
+    bridgePending: false,
+    ...overrides,
+  }) as BondStepProps;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
@@ -1,4 +1,10 @@
 export enum AleoCustomModal {
   SELF_TRANSFER = "MODAL_ALEO_SELF_TRANSFER",
+  BOND_PUBLIC = "MODAL_ALEO_BOND_PUBLIC",
   MANAGE = "MODAL_ALEO_MANAGE",
 }
+
+export const DEFAULT_ALEO_VALIDATOR: Record<"mainnet" | "testnet", string> = {
+  mainnet: "aleo1q3vx8pet0h7739hx5xlekfxh9kus6qdlxhx9qdkxhh9rnva8q5gsskve3t",
+  testnet: "aleo1l7avejc23yv6e8nx4udjwz89dw6mg95dzsp936hf77yuhnjywv9syl0ywc",
+};

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
@@ -7,6 +7,7 @@ import StepSummaryPostAlert from "./modals/send/steps/StepSummaryPostAlert";
 import StepSummaryAdditionalRows from "./modals/send/steps/StepSummaryAdditionalRows";
 import StepSummaryRecipientValue from "./modals/send/steps/StepSummaryRecipientValue";
 import operationDetails from "./operationDetails";
+import transactionConfirmFields from "./TransactionConfirmFields";
 import type { AleoFamily } from "./types";
 
 const family: AleoFamily = {
@@ -15,11 +16,12 @@ const family: AleoFamily = {
   accountHeaderManageActions,
   createSendSteps,
   operationDetails,
+  transactionConfirmFields,
   StepSummaryFromAddress,
   StepSummaryRecipientValue,
   StepSummaryPostAlert,
   StepSummaryAdditionalRows,
-  modalsToPreload: ["MODAL_ALEO_SELF_TRANSFER", "MODAL_ALEO_MANAGE"],
+  modalsToPreload: ["MODAL_ALEO_SELF_TRANSFER", "MODAL_ALEO_BOND_PUBLIC", "MODAL_ALEO_MANAGE"],
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/StepConfirmation.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect } from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { TFunction } from "i18next";
+import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
+import { Account, Operation } from "@ledgerhq/types-live";
+import { Transaction } from "@ledgerhq/live-common/families/aleo/types";
+import { track } from "~/renderer/analytics/segment";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { multiline } from "~/renderer/styles/helpers";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import RetryButton from "~/renderer/components/RetryButton";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+import SuccessDisplay from "~/renderer/components/SuccessDisplay";
+import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { setDrawer } from "~/renderer/drawers/Provider";
+
+type StepConfirmationProps = Readonly<{
+  t: TFunction;
+  optimisticOperation?: Operation;
+  error?: Error;
+  signed: boolean;
+  transaction?: Transaction | null;
+  source?: string;
+}>;
+
+type StepConfirmationFooterProps = Readonly<{
+  account?: Account | null;
+  optimisticOperation?: Operation;
+  error?: Error;
+  onRetry: (a: void) => void;
+  onClose: () => void;
+}>;
+
+const Container = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "neutral.c100",
+}))<{
+  shouldSpace?: boolean;
+}>`
+  justify-content: ${p => (p.shouldSpace ? "space-between" : "center")};
+`;
+
+// Widen only alongside the matching `aleo.<flow>.*` i18n subtree: a flow named here
+// without one renders raw keys.
+export type StakingConfirmationConfig = {
+  flow: "bond";
+  action: "bonding";
+  trackField: "validator";
+};
+
+export function createStepConfirmation({ flow, action, trackField }: StakingConfirmationConfig) {
+  const i18nPrefix = `aleo.${flow}.flow.steps.confirmation`;
+  const flowLabel = `${flow[0].toUpperCase()}${flow.slice(1)} Flow`;
+  const category = `${flow[0].toUpperCase()}${flow.slice(1)} ALEO`;
+
+  function StepConfirmation({
+    t,
+    optimisticOperation,
+    error,
+    signed,
+    transaction,
+    source,
+  }: StepConfirmationProps) {
+    useEffect(() => {
+      const address = transaction?.recipient;
+      if (optimisticOperation && address) {
+        track("staking_completed", {
+          currency: "ALEO",
+          [trackField]: address,
+          source,
+          delegation: action,
+          flow,
+        });
+      }
+    }, [optimisticOperation, source, transaction?.recipient]);
+
+    if (optimisticOperation) {
+      return (
+        <Container>
+          <TrackPage
+            category="Delegation Flow"
+            name="Step Confirmed"
+            flow={flow}
+            action={action}
+            currency="aleo"
+          />
+          <SyncOneAccountOnMount priority={10} accountId={optimisticOperation.accountId} />
+          <SuccessDisplay
+            title={<Trans i18nKey={`${i18nPrefix}.success.title`} />}
+            description={multiline(t(`${i18nPrefix}.success.text`))}
+          />
+        </Container>
+      );
+    }
+
+    if (error) {
+      return (
+        <Container shouldSpace={signed}>
+          <TrackPage
+            category={category}
+            name="Step Confirmation Error"
+            flow={flow}
+            action={action}
+            currency="aleo"
+          />
+          {signed ? (
+            <BroadcastErrorDisclaimer title={<Trans i18nKey={`${i18nPrefix}.broadcastError`} />} />
+          ) : null}
+          <ErrorDisplay error={error} withExportLogs />
+        </Container>
+      );
+    }
+
+    return null;
+  }
+
+  function StepConfirmationFooter({
+    account,
+    onRetry,
+    error,
+    onClose,
+    optimisticOperation,
+  }: StepConfirmationFooterProps) {
+    const concernedOperation = optimisticOperation?.subOperations?.length
+      ? optimisticOperation.subOperations[0]
+      : (optimisticOperation ?? null);
+    return (
+      <Box horizontal alignItems="right">
+        <Button data-testid="modal-close-button" ml={2} onClick={onClose}>
+          <Trans i18nKey="common.close" />
+        </Button>
+        {concernedOperation && (
+          <Button
+            primary
+            ml={2}
+            event={`${flowLabel} Step 3 View OpD Clicked`}
+            onClick={() => {
+              onClose();
+              if (account) {
+                setDrawer(OperationDetails, {
+                  operationId: concernedOperation.id,
+                  accountId: account.id,
+                });
+              }
+            }}
+          >
+            <Trans i18nKey={`${i18nPrefix}.success.cta`} />
+          </Button>
+        )}
+        {!concernedOperation && error && <RetryButton primary ml={2} onClick={onRetry} />}
+      </Box>
+    );
+  }
+
+  return { StepConfirmation, StepConfirmationFooter };
+}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/createStakingFlowBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/createStakingFlowBody.tsx
@@ -1,0 +1,200 @@
+import React, { useState, useCallback } from "react";
+import { compose } from "redux";
+import { connect } from "react-redux";
+import { useDispatch } from "LLD/hooks/redux";
+import { withTranslation } from "react-i18next";
+import { TFunction } from "i18next";
+import { createStructuredSelector } from "reselect";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import Track from "~/renderer/analytics/Track";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { OpenModal, openModal } from "~/renderer/actions/modals";
+import Stepper, { Step } from "~/renderer/components/Stepper";
+import logger from "~/renderer/logger";
+import {
+  AleoAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/aleo/types";
+import { Account, Operation } from "@ledgerhq/types-live";
+
+export type StakingFlowData = {
+  account: AleoAccount;
+  parentAccount?: Account;
+  source?: string;
+};
+
+export type StakingStepProps = {
+  t: TFunction;
+  transitionTo: (a: string) => void;
+  device: Device | undefined | null;
+  account: Account | undefined | null;
+  parentAccount: Account | undefined | null;
+  onRetry: (a: void) => void;
+  onClose: () => void;
+  openModal: OpenModal;
+  optimisticOperation: Operation | undefined;
+  error: Error | undefined;
+  signed: boolean;
+  transaction: Transaction | undefined | null;
+  status: TransactionStatus;
+  onChangeTransaction: (a: Transaction) => void;
+  onUpdateTransaction: (a: (a: Transaction) => Transaction) => void;
+  onTransactionError: (a: Error) => void;
+  onOperationBroadcasted: (a: Operation) => void;
+  setSigned: (a: boolean) => void;
+  bridgePending: boolean;
+  source?: string;
+};
+
+export type StakingFlowBodyOwnProps<StepId extends string> = {
+  stepId: StepId;
+  onClose: () => void;
+  onChangeStepId: (a: StepId) => void;
+  params: StakingFlowData;
+};
+
+type StateProps = {
+  t: TFunction;
+  device: Device | undefined | null;
+  openModal: OpenModal;
+};
+
+type StakingFlowBodyConfig<StepId extends string> = {
+  steps: Array<Step<StepId, StakingStepProps>>;
+  initialStepId: StepId;
+  title: string;
+  trackCloseEvent: string;
+  mode: Transaction["mode"];
+  initialRecipient?: (account: AleoAccount) => string;
+  withdrawalFromFresh?: boolean;
+};
+
+export function createStakingFlowBody<StepId extends string>({
+  steps,
+  initialStepId,
+  title,
+  trackCloseEvent,
+  mode,
+  initialRecipient,
+  withdrawalFromFresh,
+}: StakingFlowBodyConfig<StepId>) {
+  type Props = StakingFlowBodyOwnProps<StepId> & StateProps;
+
+  const confirmationIndex = steps.length - 1;
+  const connectDeviceIndex = steps.length - 2;
+
+  const mapStateToProps = createStructuredSelector({ device: getCurrentDevice });
+  const mapDispatchToProps = { openModal };
+
+  const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }: Props) => {
+    const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
+    const [transactionError, setTransactionError] = useState<Error | null>(null);
+    const [signed, setSigned] = useState(false);
+    const dispatch = useDispatch();
+    const { account, parentAccount, source = "Account Page" } = params;
+    const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
+    const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
+      useBridgeTransaction<Transaction>(bridge, () => {
+        const mainAccount = getMainAccount(account, parentAccount);
+        const t0 = bridge.createTransaction(account);
+        const patch: Partial<Transaction> & { withdrawal?: string } = {
+          mode,
+          recipient: initialRecipient?.(account) ?? "",
+        };
+        if (withdrawalFromFresh) patch.withdrawal = mainAccount.freshAddress;
+        const transaction = bridge.updateTransaction(t0, patch);
+        return { account, parentAccount, transaction };
+      });
+
+    const handleStepChange = useCallback(
+      (e: Step<StepId, StakingStepProps>) => onChangeStepId(e.id),
+      [onChangeStepId],
+    );
+
+    const handleRetry = useCallback(() => {
+      setTransactionError(null);
+      setOptimisticOperation(null);
+      setSigned(false);
+      onChangeStepId(initialStepId);
+    }, [onChangeStepId]);
+
+    const handleTransactionError = useCallback((error: Error) => {
+      if (error?.name !== "UserRefusedOnDevice") {
+        logger.critical(error);
+      }
+      setTransactionError(error);
+    }, []);
+
+    const handleOperationBroadcasted = useCallback(
+      (optimisticOperation: Operation) => {
+        if (!account) return;
+        dispatch(
+          updateAccountWithUpdater(account.id, account =>
+            addPendingOperation(account, optimisticOperation),
+          ),
+        );
+        setOptimisticOperation(optimisticOperation);
+        setTransactionError(null);
+      },
+      [account, dispatch],
+    );
+
+    const error = transactionError || bridgeError;
+    const errorSteps: number[] = [];
+    if (transactionError) {
+      errorSteps.push(
+        stepId === steps[confirmationIndex].id ? confirmationIndex : connectDeviceIndex,
+      );
+    } else if (bridgeError) {
+      errorSteps.push(0);
+    }
+
+    const stepperProps = {
+      title: t(title),
+      device,
+      account,
+      parentAccount,
+      transaction,
+      signed,
+      stepId,
+      steps,
+      errorSteps,
+      disabledSteps: [],
+      hideBreadcrumb: !!error && stepId === initialStepId,
+      onRetry: handleRetry,
+      onStepChange: handleStepChange,
+      onClose,
+      error,
+      status,
+      optimisticOperation,
+      openModal,
+      setSigned,
+      onChangeTransaction: setTransaction,
+      onUpdateTransaction: updateTransaction,
+      onOperationBroadcasted: handleOperationBroadcasted,
+      onTransactionError: handleTransactionError,
+      t,
+      bridgePending,
+      source,
+    };
+
+    return (
+      <Stepper {...stepperProps}>
+        <SyncSkipUnderPriority priority={100} />
+        <Track onUnmount event={trackCloseEvent} />
+      </Stepper>
+    );
+  };
+
+  return compose<React.ComponentType<StakingFlowBodyOwnProps<StepId>>>(
+    connect(mapStateToProps, mapDispatchToProps),
+    withTranslation(),
+  )(Body);
+}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/createStakingFlowModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/createStakingFlowModal.tsx
@@ -1,0 +1,54 @@
+import React, { PureComponent } from "react";
+import Modal from "~/renderer/components/Modal";
+import { ModalData } from "~/renderer/modals/types";
+
+type BodyProps<Data, StepId> = {
+  stepId: StepId;
+  onClose: () => void;
+  onChangeStepId: (stepId: StepId) => void;
+  params: Data;
+};
+
+export function createStakingFlowModal<Name extends keyof ModalData, StepId extends string>({
+  name,
+  initialStepId,
+  Body,
+}: {
+  name: Name;
+  initialStepId: StepId;
+  Body: React.ComponentType<BodyProps<ModalData[Name], StepId>>;
+}) {
+  type State = { stepId: StepId };
+  const INITIAL_STATE: State = { stepId: initialStepId };
+
+  // Data arrives from the redux modal state through Modal's `render` callback, not as props.
+  class StakingFlowModal extends PureComponent<Record<string, never>, State> {
+    state: State = INITIAL_STATE;
+    handleReset = () => this.setState({ ...INITIAL_STATE });
+    handleStepChange = (stepId: StepId) => this.setState({ stepId });
+
+    render() {
+      const { stepId } = this.state;
+      const isModalLocked = (["connectDevice", "confirmation"] as StepId[]).includes(stepId);
+      return (
+        <Modal
+          name={name}
+          centered
+          onHide={this.handleReset}
+          preventBackdropClick={isModalLocked}
+          width={550}
+          render={({ onClose, data }) => (
+            <Body
+              stepId={stepId}
+              onClose={onClose}
+              onChangeStepId={this.handleStepChange}
+              params={data || ({} as ModalData[Name])}
+            />
+          )}
+        />
+      );
+    }
+  }
+
+  return StakingFlowModal;
+}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/types.ts
@@ -4,6 +4,12 @@ import type {
   TransactionStatus,
   AleoOperation,
 } from "@ledgerhq/live-common/families/aleo/types";
-import type { LLDCoinFamily } from "../types";
+import type { FieldComponentProps, LLDCoinFamily } from "../types";
 
 export type AleoFamily = LLDCoinFamily<AleoAccount, Transaction, TransactionStatus, AleoOperation>;
+
+export type AleoFieldComponentProps = FieldComponentProps<
+  AleoAccount,
+  Transaction,
+  TransactionStatus
+>;

--- a/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
@@ -1,6 +1,7 @@
 import React, { use } from "react";
 
 import type { Data as AleoSendData } from "./aleo/modals/send/types";
+import type { Data as AleoBondPublicData } from "./aleo/BondPublicFlowModal/Body";
 import type { Data as AleoManageData } from "./aleo/ManageModal/ManageModal";
 import type { Data as AlgorandOptInData } from "./algorand/OptInFlowModal/Body";
 import type { Data as AlgorandClaimRewardsData } from "./algorand/Rewards/ClaimRewardsFlowModal/Body";
@@ -82,6 +83,7 @@ import type { Data as TezosUnstakeRequiredData } from "./tezos/UnstakeRequiredMo
 
 export type CoinModalsData = {
   MODAL_ALEO_SELF_TRANSFER: AleoSendData;
+  MODAL_ALEO_BOND_PUBLIC: AleoBondPublicData;
   MODAL_ALEO_MANAGE: AleoManageData;
   MODAL_ALGORAND_OPT_IN: AlgorandOptInData;
   MODAL_ALGORAND_CLAIM_REWARDS: AlgorandClaimRewardsData;
@@ -172,6 +174,7 @@ type CoinModalImport = () => Promise<{ default: React.ComponentType<any> }>;
 // preloadCoinModals() (the bundler dedupes, so React.lazy then resolves instantly).
 export const coinModalImports: Record<CoinModalKey, CoinModalImport> = {
   MODAL_ALEO_SELF_TRANSFER: () => import("./aleo/SelfTransferModal"),
+  MODAL_ALEO_BOND_PUBLIC: () => import("./aleo/BondPublicFlowModal"),
   MODAL_ALEO_MANAGE: () => import("./aleo/ManageModal/ManageModal"),
   MODAL_ALGORAND_OPT_IN: () => import("./algorand/OptInFlowModal"),
   MODAL_ALGORAND_CLAIM_REWARDS: () => import("./algorand/Rewards/ClaimRewardsFlowModal"),

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9455,6 +9455,46 @@
         "errorDesc": "Something went wrong, please try again"
       }
     },
+    "bond": {
+      "flow": {
+        "title": "Bond ALEO",
+        "steps": {
+          "validator": {
+            "title": "Validator",
+            "fetchError": "The validator list could not be loaded.",
+            "totalStake": "Total stake",
+            "rateAndCommission": "{{rate}}% est. · {{commission}}% commission",
+            "commissionOnly": "{{commission}}% commission",
+            "rowSubtitleClosed": "Validator is closed to new stake",
+            "rowSubtitleUnbonding": "Validator is unbonding",
+            "unbondingTooltip": "This validator is withdrawing its own stake. The network rejects every new stake to it until that withdrawal is claimed.",
+            "rowSubtitleEarnsNothing": "Validator earns no rewards",
+            "nonEarning": {
+              "fullCommission": "This validator takes 100% commission, so delegators keep nothing.",
+              "overConcentrated": "This validator holds more than 25% of all staked ALEO. The protocol pays it nothing above that cap, so delegators earn nothing."
+            },
+            "topUpOnly": "Aleo allows one validator per account. You can add to your stake with this validator, or unstake first to choose a different one."
+          },
+          "amount": {
+            "title": "Amount",
+            "minimum": "Your total stake with this validator must reach at least 10,000 ALEO to earn rewards. Only public ALEO can be staked - convert your private balance to public first if you want to stake it."
+          },
+          "connectDevice": {
+            "title": "Device",
+            "validatorLabel": "Validator"
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "broadcastError": "Your bond could not be sent.",
+            "success": {
+              "title": "Bond sent",
+              "text": "Your bond is being processed.",
+              "cta": "View details"
+            }
+          }
+        }
+      }
+    },
     "manage": {
       "headerAction": "Earn",
       "title": "Manage staking",

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -136,6 +136,7 @@ export interface AleoResources {
   lastPrivateSyncDate: Date | null;
   hasMigratedPublicTokens?: boolean;
   hasMigratedPrivateTokens?: boolean;
+  bondedValidator?: string | null;
 }
 
 export interface AleoResourcesRaw {
@@ -146,6 +147,7 @@ export interface AleoResourcesRaw {
   lastPrivateSyncDate: string | null;
   hasMigratedPublicTokens?: boolean;
   hasMigratedPrivateTokens?: boolean;
+  bondedValidator?: string | null;
 }
 
 export type AleoAccount = Account & {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds the Aleo **bond public** staking flow on Ledger Live Desktop: pick a validator, enter an
amount, sign on device, confirm. Reachable from the account header **Earn** action and from the
**Manage staking** modal's bond row. Everything stays behind the `enableStaking` currency-config
flag, which remains `false` on this branch.

### New flow

- `MODAL_ALEO_BOND_PUBLIC` — a 4-step stepper modal: `validator → amount → connectDevice → confirmation`.
  - **Validator** — searchable validator list with per-row stake, estimated yearly rate and
    commission; explorer link on the row name; validators that cannot take stake are dimmed,
    sorted to the bottom and not selectable.
  - **Amount** — reuses the shared `AmountField` / `SpendableBanner` / `AccountFooter`, plus a
    hint about the 10,000 ALEO minimum for rewards and the public-only restriction.
  - **Device** — the generic `GenericStepConnectDevice`.
  - **Confirmation** — success/error states, `staking_completed` tracking, and a
    *View details* button opening the operation drawer.
- Registered in `modals-loaders.ts` (typed data + lazy import) and in the family's
  `modalsToPreload`.

### Validator selection rules

- The transaction's recipient is seeded up front:
  - the account's already-bonded validator when a position is open,
  - otherwise a per-network default (`DEFAULT_ALEO_VALIDATOR` for mainnet / testnet),
  - otherwise empty when the network cannot be resolved.
- Aleo allows **one validator per account**, so a bonded account is *locked* to its validator:
  the picker shows that row alone (no search, no toggle) with an explanatory alert, and the user
  can only top up.
- A validator is treated as unpickable (`isDisabled`) when it is closed to new stake, unbonding,
  or over-concentrated (>25% of total stake, so it earns nothing). Full-commission validators stay
  selectable but are labelled as earning nothing.
- If the pre-selected validator turns out to be unpickable, the picker moves the selection to the
  first usable one — but never off a *locked* (bonded) validator.
- The withdrawal address is pinned to the account's fresh address and stays pinned when the
  validator changes.

### Shared staking scaffolding

Extracted so the coming unbond/claim flows can reuse it:

- `shared/createStakingFlowModal.tsx` — modal shell: step state, reset on hide, backdrop lock on
  the device/confirmation steps.
- `shared/createStakingFlowBody.tsx` — bridge transaction setup, error-step mapping, pending-op
  handling, `Stepper` wiring; parameterised by `mode`, initial recipient and withdrawal seeding.
- `shared/StepConfirmation.tsx` — `createStepConfirmation()` factory driving the success/error
  states, analytics and footer from an `aleo.<flow>.*` i18n subtree.

### Entry points

- **Account header** — the Earn action now only shows for main accounts (not token accounts).
  An empty account goes to `MODAL_NO_FUNDS_STAKE`; a bonded account opens the Manage modal;
  anything else opens the bond flow directly.
- **Manage modal** — the bond row is enabled and hands over to the bond flow (closing itself
  first, forwarding `account` / `parentAccount` / `source`). Unbond and claim stay disabled with
  the coming-soon tooltip.

### Device confirmation

- New `transactionConfirmFields` for the family: the address field keeps the raw address and adds
  a **Validator** row naming the recipient when it matches a known validator.

### Types

- `AleoResources` / `AleoResourcesRaw` gain `bondedValidator?: string | null`
  (`libs/coin-modules/coin-aleo/src/types/bridge.ts`).

### i18n

- New `aleo.bond.flow.*` subtree in `static/i18n/en/app.json` (step titles, validator warnings and
  tooltips, minimum-stake hint, confirmation copy).

### Tests

~85 cases added across 7 files:

- Unit: `ValidatorPicker` (loading / stale-list / fetch-error+retry / search / show-all / locked),
  `ValidatorRow` (`isDisabled`, subtitle precedence, selection, explorer link), `StepValidator`,
  `StepAmount`, `StepConfirmation`, `TransactionConfirmFields`.
- Integration (`__integrations__/bondFlow.integ.test.tsx`): full validator → amount → device →
  success run, validator pre-selection per network, unbonding validator handling, withdrawal-address
  pinning.
- Updated `AccountHeaderManageActions` and `ManageModal` tests for the new routing, plus the shared
  `stepProps` mock.

<img width="612" height="708" alt="image" src="https://github.com/user-attachments/assets/3aa2d44a-1c3f-4fdc-b63d-4a3d305a3a0f" />


### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-32807](https://ledgerhq.atlassian.net/browse/LIVE-32807)
