### PR TITLE
[LWDM] refactor(countervalues): drop test casts and trim comment

### DIFF
--- a/libs/live-countervalues-react/src/react.test.ts
+++ b/libs/live-countervalues-react/src/react.test.ts
@@ -201,7 +201,12 @@ describe("CountervaluesProvider", () => {
   it("should use the same API-ID lookup in filter and batching for remapped currencies", async () => {
     // assethub_polkadot maps to "polkadot" via inferCurrencyAPIID.
     // supportedCryptoIds contains API IDs, so the correct key is "polkadot", not "assethub_polkadot".
-    const assethubPolkadot = { type: "CryptoCurrency", id: "assethub_polkadot" } as unknown as Currency;
+    const assethubPolkadot: Currency = {
+      ...bitcoin,
+      id: CryptoCurrencyIdSchema.parse("assethub_polkadot"),
+      name: "Asset Hub Polkadot",
+      ticker: "DOT",
+    };
     const bridge = createBridge({
       supportedCryptoIds: ["polkadot"],
       trackingPairs: [trackingPair(assethubPolkadot)],
@@ -213,10 +218,7 @@ describe("CountervaluesProvider", () => {
     // filterSupportedTrackingPairs resolves assethub_polkadot → polkadot, so the pair is kept
     expect(mockLoadCountervalues.mock.calls[0][1].trackingPairs).toHaveLength(1);
     // shouldBatchCurrencyFrom must also resolve to "polkadot" (rank 0, ≤ marketCapBatchingAfterRank 20) → not batched
-    const solver = mockLoadCountervalues.mock.calls[0][2] as {
-      shouldBatchCurrencyFrom: (c: typeof assethubPolkadot) => boolean;
-    };
-    expect(solver.shouldBatchCurrencyFrom(assethubPolkadot)).toBe(false);
+    expect(mockLoadCountervalues.mock.calls[0][2]?.shouldBatchCurrencyFrom(assethubPolkadot)).toBe(false);
   });
 });
 

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -593,10 +593,7 @@ export function resolveTrackingPairs(pairs: TrackingPair[]): TrackingPair[] {
     .map(id => trackingPairs[id]);
 }
 
-// supportedCryptoIds is the allowlist of crypto ids returned by /v3/supported/crypto.
-// Pairs whose "from" currency is NOT in this list will receive a 422 from the CVS API, so
-// removing this filter (or passing an empty list) silently re-enables those requests and
-// produces 422 errors for accounts holding unsupported currencies.
+// supportedCryptoIds holds API IDs from /v3/supported/crypto; an empty list disables the filter.
 export function filterSupportedTrackingPairs(
   pairs: TrackingPair[],
   supportedCryptoIds?: string[],


### PR DESCRIPTION
### 📝 Description

Review points raised on [#21517](https://github.com/LedgerHQ/ledger-live/pull/21517) that arrived after it merged. **No behaviour change** — a test fixture and a comment.

### 🔀 What changed

**`libs/live-countervalues-react/src/react.test.ts`**

The fixture for the remapped-currency regression test used `as unknown as Currency` on a two-field object literal:

```ts
const assethubPolkadot = { type: "CryptoCurrency", id: "assethub_polkadot" } as unknown as Currency;
```

The double cast was load-bearing: the literal is not a valid `CryptoCurrency`, so the cast was hiding an invalid fixture rather than smoothing a type mismatch. Replaced with the established pattern (also used at `libs/live-countervalues/src/logic.test.ts:69-74`):

```ts
const assethubPolkadot: Currency = {
  ...bitcoin,
  id: CryptoCurrencyIdSchema.parse("assethub_polkadot"),
  name: "Asset Hub Polkadot",
  ticker: "DOT",
};
```

The `as { shouldBatchCurrencyFrom: ... }` cast on the solver is also removed; the mock's inferred type covers it.

**`libs/live-countervalues/src/logic.ts`**

Four-line comment block above `filterSupportedTrackingPairs` trimmed to one line. The documented hazard (empty list silently disables the filter) is preserved.

### ✅ Verification

- `pnpm nx run-many -t typecheck -p @ledgerhq/live-countervalues @ledgerhq/live-countervalues-react` — clean
- `pnpm nx run-many -t test -p @ledgerhq/live-countervalues @ledgerhq/live-countervalues-react` — **11/11 pass**
- The test still discriminates: reverting `shouldBatchCurrencyFrom` to `currency.id` makes it fail, because `indexOf("assethub_polkadot")` returns −1 when the list contains `"polkadot"`.

### 🔗 Context

Follow-up to [#21517](https://github.com/LedgerHQ/ledger-live/pull/21517) (countervalues rename). Direct off `develop`, no stack.