### PR TITLE
[LWDM] feat(near): add signer and usesStakingPositions for generic adapter

### DIFF
--- a/.changeset/near-signer-staking-positions.md
+++ b/.changeset/near-signer-staking-positions.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat(near): wire NEAR signer to generic coin framework

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -144,6 +144,7 @@
     "src/families/near/constants.ts",
     "src/families/near/logic.ts",
     "src/families/near/react.ts",
+    "src/families/near/signer.ts",
     "src/families/near/types.ts",
     "src/families/sui/logic.ts",
     "src/families/sui/react.ts",

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -310,6 +310,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadSetup: () => import("../families/near/setup"),
     loadLocalApi: () => import("../families/near/coinModuleApi").then(m => m.createLocalNearApi),
     loadBridgeApi: () => import("../families/near/bridge/api").then(m => m.default),
+    loadSigner: () => import("../families/near/signer").then(m => m.default),
     loadTransaction: () => import("@ledgerhq/coin-near/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-near/deviceTransactionConfig").then(m => m.default),

--- a/libs/ledger-live-common/src/families/near/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/near/bridge/api.ts
@@ -26,5 +26,6 @@ export function computeIntentType(transaction: Record<string, unknown>): string 
 
 export default {
   stakingSupported: true,
+  usesStakingPositions: true,
   computeIntentType,
 } satisfies BridgeApi;

--- a/libs/ledger-live-common/src/families/near/signer.test.ts
+++ b/libs/ledger-live-common/src/families/near/signer.test.ts
@@ -1,0 +1,75 @@
+import { createSigner } from "./signer";
+
+const mockGetAddress = jest.fn();
+const mockSignTransaction = jest.fn();
+
+jest.mock("@ledgerhq/hw-app-near", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    getAddress: mockGetAddress,
+    signTransaction: mockSignTransaction,
+  })),
+}));
+
+const mockTransport = {} as any;
+
+describe("near/signer createSigner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAddress", () => {
+    it("passes boolean true directly as verify", async () => {
+      mockGetAddress.mockResolvedValue({ address: "addr", publicKey: "pk" });
+      const signer = createSigner(mockTransport);
+      await signer.getAddress("44'/397'/0'/0'/0'", true);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/397'/0'/0'/0'", true);
+    });
+
+    it("extracts verify from options object", async () => {
+      mockGetAddress.mockResolvedValue({ address: "addr", publicKey: "pk" });
+      const signer = createSigner(mockTransport);
+      await signer.getAddress("44'/397'/0'/0'/0'", { verify: true });
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/397'/0'/0'/0'", true);
+    });
+
+    it("defaults verify to false when options is omitted", async () => {
+      mockGetAddress.mockResolvedValue({ address: "addr", publicKey: "pk" });
+      const signer = createSigner(mockTransport);
+      await signer.getAddress("44'/397'/0'/0'/0'");
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/397'/0'/0'/0'", false);
+    });
+
+    it("defaults verify to false when options carries only unrelated properties (e.g. derivationMode)", async () => {
+      mockGetAddress.mockResolvedValue({ address: "addr", publicKey: "pk" });
+      const signer = createSigner(mockTransport);
+      await signer.getAddress("44'/397'/0'/0'/0'", { derivationMode: "" });
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/397'/0'/0'/0'", false);
+    });
+  });
+
+  describe("signTransaction", () => {
+    it("decodes base64 before sending to device and returns hex signature", async () => {
+      const rawSig = Buffer.from("deadbeef", "hex");
+      mockSignTransaction.mockResolvedValue(rawSig);
+      const signer = createSigner(mockTransport);
+
+      const base64Tx = Buffer.from("rawbytes").toString("base64");
+      const result = await signer.signTransaction("44'/397'/0'/0'/0'", base64Tx);
+
+      expect(mockSignTransaction).toHaveBeenCalledWith(
+        Buffer.from(base64Tx, "base64"),
+        "44'/397'/0'/0'/0'",
+      );
+      expect(result).toBe("deadbeef");
+    });
+
+    it("throws when the device returns no signature", async () => {
+      mockSignTransaction.mockResolvedValue(null);
+      const signer = createSigner(mockTransport);
+      await expect(
+        signer.signTransaction("44'/397'/0'/0'/0'", Buffer.from("tx").toString("base64")),
+      ).rejects.toThrow("Near: no signature returned from device");
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/near/signer.ts
+++ b/libs/ledger-live-common/src/families/near/signer.ts
@@ -4,12 +4,16 @@ import type { CoinFrameworkSigner } from "../../bridge/generic-coin-framework/ty
 import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { executeWithSigner } from "../../bridge/setup";
 
-const createSigner = (transport: Transport) => {
+export const createSigner = (transport: Transport) => {
   const near = new Near(transport);
   return {
     // Framework calls signer.getAddress(path, { derivationMode, ... }); resolver calls (path, boolean).
-    // Accept both by normalising the second arg.
-    getAddress: async (path: string, options?: boolean | { verify?: boolean }) => {
+    // Accept both by normalising the second arg. The object form allows arbitrary extra
+    // properties (e.g. derivationMode) since NEAR doesn't need them for address derivation.
+    getAddress: async (
+      path: string,
+      options?: boolean | ({ verify?: boolean } & Record<string, unknown>),
+    ) => {
       const verify = typeof options === "boolean" ? options : (options?.verify ?? false);
       return near.getAddress(path, verify);
     },

--- a/libs/ledger-live-common/src/families/near/signer.ts
+++ b/libs/ledger-live-common/src/families/near/signer.ts
@@ -1,0 +1,44 @@
+import Near from "@ledgerhq/hw-app-near";
+import Transport from "@ledgerhq/hw-transport";
+import type { CoinFrameworkSigner } from "../../bridge/generic-coin-framework/types";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import { executeWithSigner } from "../../bridge/setup";
+
+const createSigner = (transport: Transport) => {
+  const near = new Near(transport);
+  return {
+    // Framework calls signer.getAddress(path, { derivationMode, ... }); resolver calls (path, boolean).
+    // Accept both by normalising the second arg.
+    getAddress: async (path: string, options?: boolean | { verify?: boolean }) => {
+      const verify = typeof options === "boolean" ? options : (options?.verify ?? false);
+      return near.getAddress(path, verify);
+    },
+
+    // Framework calls signTransaction(path, base64Tx, opts) — path first, base64 tx second.
+    signTransaction: async (path: string, base64Tx: string): Promise<string> => {
+      // craftTransaction returns base64 — decode before device call.
+      // Without this: UNKNOWN_ERROR (0xb005) on 2nd APDU chunk.
+      const decoded = Buffer.from(base64Tx, "base64");
+      const sig = await near.signTransaction(decoded, path);
+      if (!sig) throw new Error("Near: no signature returned from device");
+      // hw-app-near returns raw Buffer — combine()'s decodeSignature() expects hex string.
+      // Without this: "Near: signature is not valid hex".
+      return sig.toString("hex");
+    },
+  };
+};
+
+const context = executeWithSigner(createSigner);
+
+// Inline GetAddressFn to avoid SignerContext<frameworkSigner> vs SignerContext<NearSigner> cast.
+const getAddress: GetAddressFn = (deviceId, { path, verify }) =>
+  context(deviceId, signer =>
+    signer
+      .getAddress(path, verify || false)
+      .then(r => ({ address: r.address, publicKey: r.publicKey, path })),
+  );
+
+export default {
+  context,
+  getAddress,
+} satisfies CoinFrameworkSigner;


### PR DESCRIPTION
## Context
Wires NEAR into the Alpaca generic coin framework. After LIVE-34284 (bridge migration, already merged), the framework infrastructure exists but signing is unreachable — no `loadSigner` entry and no `signer.ts`. Ref: [LIVE-36411](https://ledgerhq.atlassian.net/browse/LIVE-36411).

## Changes
- **`families/near/signer.ts`** (new) — `CoinFrameworkSigner` wrapping `hw-app-near` with three encoding fixes confirmed by hardware test (2026-08-05):
  - Decodes base64 output of `craftTransaction` before passing to device (`0xb005` on 2nd APDU chunk otherwise)
  - Returns hex string from `signTransaction` so `logic/combine.ts`'s `decodeSignature()` accepts it
  - Normalises `getAddress` second arg to boolean to handle both framework (`{ derivationMode }`) and resolver (`boolean`) call shapes
- **`coin-modules/loaders.ts`** — adds `loadSigner` to the NEAR entry
- **`families/near/bridge/api.ts`** — adds `usesStakingPositions: true` so `genericGetAccountShape` populates `account.stakingPositions[]` instead of the blob `stakingResources`

## Tests
`pnpm tsc --noEmit` clean on live-common, desktop and mobile. Hardware test done on the full stack with the flag on: send, stake, unstake and withdraw signed on device and broadcast on mainnet.

## Risks
`usesStakingPositions: true` activates per-position staking data — the UI adaptation (LIVE-36412) and flag flip (LIVE-36413) must land before users see any effect. This PR alone is safe to merge in isolation.

## Related
- #21690 (LIVE-36412, UI adaptation, depends on this)
- #21849 (LIVE-36413, flag flip, depends on #21690)

Merge order: this PR → #21690 → #21849.
- LIVE-34284 (bridge migration — prerequisite, merged)

[LIVE-36411]: https://ledgerhq.atlassian.net/browse/LIVE-36411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
