### PR TITLE
chore(cli): drop unused live-countervalues dependency

### DIFF
--- a/.changeset/cli-drop-countervalues-dep.md
+++ b/.changeset/cli-drop-countervalues-dep.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-cli": minor
+---
+
+Remove unused `@ledgerhq/live-countervalues` dependency from `apps/cli`. The package was declared but never imported.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -38,7 +38,6 @@
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-config": "workspace:^",
-    "@ledgerhq/live-countervalues": "workspace:^",
     "@ledgerhq/live-currency-format": "workspace:^",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
     "@shared/env": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -747,9 +747,6 @@ importers:
       '@ledgerhq/live-config':
         specifier: workspace:^
         version: link:../../libs/live-config
-      '@ledgerhq/live-countervalues':
-        specifier: workspace:^
-        version: link:../../libs/live-countervalues
       '@ledgerhq/live-currency-format':
         specifier: workspace:^
         version: link:../../libs/live-currency-format
@@ -23102,7 +23099,6 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28575,7 +28571,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -65376,9 +65372,7 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:


### PR DESCRIPTION
## Summary

- `@ledgerhq/live-countervalues` is declared in `apps/cli/package.json` but never imported anywhere in the package
- Verified with `rg -n 'live-countervalues' apps/cli`: the only hits are in `CHANGELOG.md` (release history); zero source references
- Removing it now unblocks privatisation of `live-countervalues` ([LIVE-36903](https://ledgerhq.atlassian.net/browse/LIVE-36903)), which requires all published packages to have dropped the dependency first

## Changes

- One line removed from `apps/cli/package.json`
- Lockfile updated (8 lines, no unrelated churn — verified with `git diff --stat pnpm-lock.yaml`)
- Changeset: `minor` bump for `@ledgerhq/live-cli`

## Verification

- `rg -n 'live-countervalues' apps/cli` → only `CHANGELOG.md` lines
- `git diff --stat pnpm-lock.yaml` → 8 lines changed
- `pnpm install --frozen-lockfile` → passes
- `pnpm nx run-many -t typecheck` → all 168 projects clean
- `pnpm lint:boundaries` → `✓ module boundaries ok`

[LIVE-36903]: https://ledgerhq.atlassian.net/browse/LIVE-36903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ