### PR TITLE
[LWDM] feat(pay-card): add freeze confirmation dialog (LIVE-37111)

### DIFF
--- a/.changeset/LIVE-33492-pay-card-freeze-unfreeze-confirm.md
+++ b/.changeset/LIVE-33492-pay-card-freeze-unfreeze-confirm.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-card-details": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add freeze/unfreeze confirmation dialog and bottom sheet for pay card

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -921,7 +921,17 @@
       "title": "Crypto card",
       "balanceLabel": "Balance",
       "freeze": "Freeze",
-      "unfreeze": "Unfreeze"
+      "unfreeze": "Unfreeze",
+      "goBack": "Go back",
+      "freezeConfirm": {
+        "title": "Freezing means you cannot use the card anymore",
+        "description": "You can unfreeze your card at any time.",
+        "confirm": "Freeze now"
+      },
+      "unfreezeConfirm": {
+        "title": "Unfreeze your card?",
+        "confirm": "Unfreeze now"
+      }
     },
     "cardOnboarding": {
       "widget": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10215,7 +10215,17 @@
     "card": {
       "title": "Crypto card",
       "freeze": "Freeze",
-      "unfreeze": "Unfreeze"
+      "unfreeze": "Unfreeze",
+      "goBack": "Go back",
+      "freezeConfirm": {
+        "title": "Freezing means you cannot use the card anymore",
+        "description": "You can unfreeze your card at any time.",
+        "confirm": "Freeze now"
+      },
+      "unfreezeConfirm": {
+        "title": "Unfreeze your card?",
+        "confirm": "Unfreeze now"
+      }
     },
     "selectContact": {
       "placeholder": "Enter contact"

--- a/features/flow/pay-card-details/package.json
+++ b/features/flow/pay-card-details/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@domain/api-card-management": "workspace:*",
     "@ledgerhq/lumen-utils-shared": "catalog:",
-    "@shared/i18n": "workspace:*"
+    "@shared/i18n": "workspace:*",
+    "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {
     "@features/platform-style": "workspace:*",

--- a/features/flow/pay-card-details/src/__tests__/i18nWrapper.tsx
+++ b/features/flow/pay-card-details/src/__tests__/i18nWrapper.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { I18nTestProvider } from "@shared/i18n/testing";
+
+export const CARD_COPY = {
+  freeze: "Freeze",
+  unfreeze: "Unfreeze",
+  goBack: "Go back",
+  freezeTitle: "Freezing means you cannot use the card anymore",
+  freezeDescription: "You can unfreeze your card at any time.",
+  freezeConfirm: "Freeze now",
+  unfreezeTitle: "Unfreeze your card?",
+  unfreezeConfirm: "Unfreeze now",
+} as const;
+
+export const CARD_RESOURCES = {
+  en: {
+    translation: {
+      payTab: {
+        card: {
+          freeze: CARD_COPY.freeze,
+          unfreeze: CARD_COPY.unfreeze,
+          goBack: CARD_COPY.goBack,
+          freezeConfirm: {
+            title: CARD_COPY.freezeTitle,
+            description: CARD_COPY.freezeDescription,
+            confirm: CARD_COPY.freezeConfirm,
+          },
+          unfreezeConfirm: {
+            title: CARD_COPY.unfreezeTitle,
+            confirm: CARD_COPY.unfreezeConfirm,
+          },
+        },
+      },
+    },
+  },
+};
+
+export function I18nWrapper({ children }: { children: React.ReactNode }) {
+  return <I18nTestProvider resources={CARD_RESOURCES}>{children}</I18nTestProvider>;
+}

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.native.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen, userEvent } from "@testing-library/react-native";
+import { CARD_COPY, I18nWrapper } from "../../__tests__/i18nWrapper";
+import { FreezeConfirmSheet } from "./FreezeConfirmSheet";
+import type { FreezeConfirmSheetProps } from "../../types";
+
+function renderSheet(props: Partial<FreezeConfirmSheetProps> = {}) {
+  const onConfirm = jest.fn();
+  const onClose = jest.fn();
+
+  const view = render(
+    <FreezeConfirmSheet
+      isOpen
+      isFrozen={false}
+      isLoading={false}
+      onConfirm={onConfirm}
+      onClose={onClose}
+      {...props}
+    />,
+    { wrapper: I18nWrapper },
+  );
+
+  return { user: userEvent.setup(), onConfirm, onClose, ...view };
+}
+
+describe("FreezeConfirmSheet (native)", () => {
+  it("hides the sheet content when closed", () => {
+    renderSheet({ isOpen: false });
+
+    expect(screen.getByTestId("freeze-confirm-sheet").props.accessibilityState.expanded).toBe(
+      false,
+    );
+    expect(screen.queryByTestId("freeze-confirm-sheet-content")).toBeNull();
+  });
+
+  it("shows the freeze confirmation copy", () => {
+    renderSheet();
+
+    expect(screen.getByText(CARD_COPY.freezeTitle)).toBeVisible();
+    expect(screen.getByText(CARD_COPY.freezeDescription)).toBeVisible();
+    expect(screen.getByText(CARD_COPY.freezeConfirm)).toBeVisible();
+  });
+
+  it("shows the unfreeze confirmation copy without the freeze description", () => {
+    renderSheet({ isFrozen: true });
+
+    expect(screen.getByText(CARD_COPY.unfreezeTitle)).toBeVisible();
+    expect(screen.getByText(CARD_COPY.unfreezeConfirm)).toBeVisible();
+    expect(screen.queryByText(CARD_COPY.freezeDescription)).toBeNull();
+  });
+
+  it("calls onConfirm from the confirm button", async () => {
+    const { user, onConfirm, onClose } = renderSheet();
+
+    await user.press(screen.getByTestId("freeze-confirm-action"));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose from the go back button", async () => {
+    const { user, onConfirm, onClose } = renderSheet();
+
+    await user.press(screen.getByTestId("freeze-confirm-cancel"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose from the sheet dismiss control", async () => {
+    const { user, onClose } = renderSheet();
+
+    await user.press(screen.getByTestId("freeze-confirm-sheet-dismiss"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose only once when back and dismiss both fire", async () => {
+    // Going back closes the sheet, which then reports its own dismissal: closing twice would
+    // also pop the screen underneath.
+    const { user, onClose } = renderSheet();
+
+    await user.press(screen.getByTestId("freeze-confirm-cancel"));
+    await user.press(screen.getByTestId("freeze-confirm-sheet-dismiss"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose again after reopening the sheet", async () => {
+    const { user, onClose, rerender } = renderSheet();
+    const props = { isFrozen: false, isLoading: false, onConfirm: jest.fn(), onClose };
+
+    await user.press(screen.getByTestId("freeze-confirm-cancel"));
+    rerender(<FreezeConfirmSheet {...props} isOpen={false} />);
+    rerender(<FreezeConfirmSheet {...props} isOpen />);
+    await user.press(screen.getByTestId("freeze-confirm-cancel"));
+
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables both buttons while loading", () => {
+    renderSheet({ isLoading: true });
+
+    expect(screen.getByTestId("freeze-confirm-action").props.disabled).toBe(true);
+    expect(screen.getByTestId("freeze-confirm-cancel").props.disabled).toBe(true);
+  });
+});

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.native.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.native.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  Spot,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { InformationFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "@shared/i18n";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import { freezeConfirmActionKey, freezeConfirmTitleKey } from "./freezeConfirmCopy";
+import type { FreezeConfirmSheetProps } from "../../types";
+
+export function FreezeConfirmSheet({
+  isOpen,
+  isFrozen,
+  isLoading,
+  onConfirm,
+  onClose,
+}: FreezeConfirmSheetProps) {
+  const { t } = useTranslation();
+  const dismissed = useRef(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      dismissed.current = false;
+    }
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    if (dismissed.current) {
+      return;
+    }
+    dismissed.current = true;
+    onClose();
+  }, [onClose]);
+
+  return (
+    <QueuedBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={handleClose}
+      enableDynamicSizing
+      testID="freeze-confirm-sheet"
+    >
+      {isOpen ? (
+        <BottomSheetView testID="freeze-confirm-sheet-content">
+          <BottomSheetHeader density="compact" spacing />
+          <Box lx={{ alignItems: "center", gap: "s16", paddingHorizontal: "s16" }}>
+            <Spot appearance="icon" icon={InformationFill} size={56} />
+            <Box lx={{ alignItems: "center", gap: "s8" }}>
+              <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+                {t(freezeConfirmTitleKey(isFrozen))}
+              </Text>
+              {!isFrozen ? (
+                <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+                  {t("payTab.card.freezeConfirm.description")}
+                </Text>
+              ) : null}
+            </Box>
+          </Box>
+          <Box lx={{ gap: "s8", margin: "s16" }}>
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              loading={isLoading}
+              disabled={isLoading}
+              onPress={onConfirm}
+              testID="freeze-confirm-action"
+            >
+              {t(freezeConfirmActionKey(isFrozen))}
+            </Button>
+            <Button
+              appearance="gray"
+              size="lg"
+              isFull
+              disabled={isLoading}
+              onPress={handleClose}
+              testID="freeze-confirm-cancel"
+            >
+              {t("payTab.card.goBack")}
+            </Button>
+          </Box>
+        </BottomSheetView>
+      ) : null}
+    </QueuedBottomSheet>
+  );
+}

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.web.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CARD_COPY, I18nWrapper } from "../../__tests__/i18nWrapper";
+import { FreezeConfirmSheet } from "./FreezeConfirmSheet";
+import type { FreezeConfirmSheetProps } from "../../types";
+
+function renderSheet(props: Partial<FreezeConfirmSheetProps> = {}) {
+  const onConfirm = jest.fn();
+  const onClose = jest.fn();
+
+  const view = render(
+    <FreezeConfirmSheet
+      isOpen
+      isFrozen={false}
+      isLoading={false}
+      onConfirm={onConfirm}
+      onClose={onClose}
+      {...props}
+    />,
+    { wrapper: I18nWrapper },
+  );
+
+  return { onConfirm, onClose, ...view };
+}
+
+describe("FreezeConfirmSheet (web)", () => {
+  it("renders nothing when closed", () => {
+    expect(renderSheet({ isOpen: false }).container).toBeNull();
+  });
+
+  it("shows the freeze confirmation copy", () => {
+    renderSheet();
+
+    expect(screen.getByText(CARD_COPY.freezeTitle)).toBeVisible();
+    expect(screen.getByText(CARD_COPY.freezeDescription)).toBeVisible();
+    expect(screen.getByRole("button", { name: CARD_COPY.freezeConfirm })).toBeVisible();
+  });
+
+  it("shows the unfreeze confirmation copy without the freeze description", () => {
+    renderSheet({ isFrozen: true });
+
+    expect(screen.getByText(CARD_COPY.unfreezeTitle)).toBeVisible();
+    expect(screen.getByRole("button", { name: CARD_COPY.unfreezeConfirm })).toBeVisible();
+    expect(screen.queryByText(CARD_COPY.freezeDescription)).not.toBeInTheDocument();
+  });
+
+  it("calls onConfirm from the confirm button", async () => {
+    const { onConfirm, onClose } = renderSheet();
+
+    await userEvent.click(screen.getByRole("button", { name: CARD_COPY.freezeConfirm }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose from the go back button", async () => {
+    const { onConfirm, onClose } = renderSheet();
+
+    await userEvent.click(screen.getByRole("button", { name: CARD_COPY.goBack }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose from the header close button", async () => {
+    const { onConfirm, onClose } = renderSheet();
+
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("disables both buttons while loading", () => {
+    renderSheet({ isLoading: true });
+
+    expect(screen.getByRole("button", { name: CARD_COPY.freezeConfirm })).toBeDisabled();
+    expect(screen.getByRole("button", { name: CARD_COPY.goBack })).toBeDisabled();
+  });
+});

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.web.test.tsx
@@ -26,7 +26,9 @@ function renderSheet(props: Partial<FreezeConfirmSheetProps> = {}) {
 
 describe("FreezeConfirmSheet (web)", () => {
   it("renders nothing when closed", () => {
-    expect(renderSheet({ isOpen: false }).container).toBeNull();
+    renderSheet({ isOpen: false });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("shows the freeze confirmation copy", () => {

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.web.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeConfirmSheet.web.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { InformationFill } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "@shared/i18n";
+import { freezeConfirmActionKey, freezeConfirmTitleKey } from "./freezeConfirmCopy";
+import type { FreezeConfirmSheetProps } from "../../types";
+
+export function FreezeConfirmSheet({
+  isOpen,
+  isFrozen,
+  isLoading,
+  onConfirm,
+  onClose,
+}: FreezeConfirmSheetProps) {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="pb-24" data-testid="freeze-confirm-sheet">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-full bg-gradient-muted"
+        />
+        <DialogHeader density="compact" onClose={onClose} />
+        <DialogBody
+          className="flex flex-col items-center gap-32 px-24 pb-24 text-center"
+          data-testid="freeze-confirm-sheet-content"
+        >
+          <div className="flex flex-col items-center gap-24">
+            <Spot appearance="icon" icon={InformationFill} size={56} />
+            <div className="flex flex-col gap-8">
+              <span className="heading-4-semi-bold text-base">
+                {t(freezeConfirmTitleKey(isFrozen))}
+              </span>
+              {!isFrozen ? (
+                <p className="body-2 text-muted">{t("payTab.card.freezeConfirm.description")}</p>
+              ) : null}
+            </div>
+          </div>
+          <div className="flex w-full flex-col gap-8">
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              loading={isLoading}
+              disabled={isLoading}
+              onClick={onConfirm}
+              data-testid="freeze-confirm-action"
+            >
+              {t(freezeConfirmActionKey(isFrozen))}
+            </Button>
+            <Button
+              appearance="gray"
+              size="lg"
+              isFull
+              disabled={isLoading}
+              onClick={onClose}
+              data-testid="freeze-confirm-cancel"
+            >
+              {t("payTab.card.goBack")}
+            </Button>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, userEvent } from "@testing-library/react-native";
+import { CARD_COPY, I18nWrapper } from "../../__tests__/i18nWrapper";
+import { FreezeView } from "./FreezeView";
+import type { FreezeViewProps } from "../../types";
+
+function renderFreeze(props: Partial<FreezeViewProps> = {}) {
+  const onOpenConfirm = jest.fn();
+  const onCloseConfirm = jest.fn();
+  const onConfirm = jest.fn();
+
+  const view = render(
+    <FreezeView
+      isFrozen={false}
+      isBlocked={false}
+      isStatusLoading={false}
+      isFreezeLoading={false}
+      isUnfreezeLoading={false}
+      isConfirmOpen={false}
+      onOpenConfirm={onOpenConfirm}
+      onCloseConfirm={onCloseConfirm}
+      onConfirm={onConfirm}
+      {...props}
+    />,
+    { wrapper: I18nWrapper },
+  );
+
+  return { user: userEvent.setup(), onOpenConfirm, onCloseConfirm, onConfirm, ...view };
+}
+
+describe("FreezeView (native)", () => {
+  it("renders the freeze tile on an active card", () => {
+    renderFreeze();
+
+    expect(screen.getByText(CARD_COPY.freeze)).toBeVisible();
+  });
+
+  it("renders the unfreeze tile on a frozen card", () => {
+    renderFreeze({ isFrozen: true });
+
+    expect(screen.getByText(CARD_COPY.unfreeze)).toBeVisible();
+  });
+
+  it("opens the confirmation from the tile", async () => {
+    const { user, onOpenConfirm, onConfirm } = renderFreeze();
+
+    await user.press(screen.getByText(CARD_COPY.freeze));
+
+    expect(onOpenConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("keeps the confirmation closed until isConfirmOpen is true", () => {
+    renderFreeze();
+
+    expect(screen.queryByText(CARD_COPY.freezeTitle)).toBeNull();
+  });
+
+  it("shows the unfreeze confirmation when the sheet is open", () => {
+    renderFreeze({ isConfirmOpen: true, isFrozen: true });
+
+    expect(screen.getByText(CARD_COPY.unfreezeTitle)).toBeVisible();
+  });
+
+  it("disables the confirm button while freeze is loading", () => {
+    renderFreeze({ isConfirmOpen: true, isFreezeLoading: true });
+
+    expect(screen.getByTestId("freeze-confirm-action").props.disabled).toBe(true);
+  });
+
+  it.each([
+    ["the card is blocked", { isBlocked: true }],
+    ["card status is loading", { isStatusLoading: true }],
+    ["freeze is loading", { isFreezeLoading: true }],
+    ["unfreeze is loading", { isUnfreezeLoading: true }],
+  ])("disables the tile while %s", (_reason, props) => {
+    renderFreeze(props);
+
+    expect(screen.getByText(CARD_COPY.freeze).parent?.props.disabled).toBe(true);
+  });
+});

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TileButton } from "@ledgerhq/lumen-ui-rnative";
 import { Snow } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "@shared/i18n";
+import { FreezeConfirmSheet } from "./FreezeConfirmSheet";
 import type { FreezeViewProps } from "../../types";
 
 export function FreezeView({
@@ -10,19 +11,31 @@ export function FreezeView({
   isStatusLoading,
   isFreezeLoading,
   isUnfreezeLoading,
-  onFreeze,
-  onUnfreeze,
+  isConfirmOpen,
+  onOpenConfirm,
+  onCloseConfirm,
+  onConfirm,
 }: FreezeViewProps) {
   const { t } = useTranslation();
 
   return (
-    <TileButton
-      icon={Snow}
-      onPress={isFrozen ? onUnfreeze : onFreeze}
-      disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
-      isFull
-    >
-      {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
-    </TileButton>
+    <>
+      <TileButton
+        icon={Snow}
+        onPress={onOpenConfirm}
+        disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
+        isFull
+      >
+        {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
+      </TileButton>
+
+      <FreezeConfirmSheet
+        isOpen={isConfirmOpen}
+        isFrozen={isFrozen}
+        isLoading={isFreezeLoading || isUnfreezeLoading}
+        onConfirm={onConfirm}
+        onClose={onCloseConfirm}
+      />
+    </>
   );
 }

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CARD_COPY, I18nWrapper } from "../../__tests__/i18nWrapper";
+import { FreezeView } from "./FreezeView";
+import type { FreezeViewProps } from "../../types";
+
+function renderFreeze(props: Partial<FreezeViewProps> = {}) {
+  const onOpenConfirm = jest.fn();
+  const onCloseConfirm = jest.fn();
+  const onConfirm = jest.fn();
+
+  const view = render(
+    <FreezeView
+      isFrozen={false}
+      isBlocked={false}
+      isStatusLoading={false}
+      isFreezeLoading={false}
+      isUnfreezeLoading={false}
+      isConfirmOpen={false}
+      onOpenConfirm={onOpenConfirm}
+      onCloseConfirm={onCloseConfirm}
+      onConfirm={onConfirm}
+      {...props}
+    />,
+    { wrapper: I18nWrapper },
+  );
+
+  return { onOpenConfirm, onCloseConfirm, onConfirm, ...view };
+}
+
+describe("FreezeView (web)", () => {
+  it("renders the freeze tile on an active card", () => {
+    renderFreeze();
+
+    expect(screen.getByRole("button", { name: CARD_COPY.freeze })).toBeVisible();
+  });
+
+  it("renders the unfreeze tile on a frozen card", () => {
+    renderFreeze({ isFrozen: true });
+
+    expect(screen.getByRole("button", { name: CARD_COPY.unfreeze })).toBeVisible();
+  });
+
+  it("opens the confirmation from the tile", async () => {
+    const { onOpenConfirm, onConfirm } = renderFreeze();
+
+    await userEvent.click(screen.getByRole("button", { name: CARD_COPY.freeze }));
+
+    expect(onOpenConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("keeps the confirmation closed until isConfirmOpen is true", () => {
+    renderFreeze();
+
+    expect(screen.queryByText(CARD_COPY.freezeTitle)).not.toBeInTheDocument();
+  });
+
+  it("shows the unfreeze confirmation when the sheet is open", () => {
+    renderFreeze({ isConfirmOpen: true, isFrozen: true });
+
+    expect(screen.getByText(CARD_COPY.unfreezeTitle)).toBeVisible();
+  });
+
+  it("disables the confirm button while freeze is loading", () => {
+    renderFreeze({ isConfirmOpen: true, isFreezeLoading: true });
+
+    expect(screen.getByRole("button", { name: CARD_COPY.freezeConfirm })).toBeDisabled();
+  });
+
+  it.each([
+    ["the card is blocked", { isBlocked: true }],
+    ["card status is loading", { isStatusLoading: true }],
+    ["freeze is loading", { isFreezeLoading: true }],
+    ["unfreeze is loading", { isUnfreezeLoading: true }],
+  ])("disables the tile while %s", (_reason, props) => {
+    renderFreeze(props);
+
+    expect(screen.getByRole("button", { name: CARD_COPY.freeze })).toBeDisabled();
+  });
+});

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TileButton } from "@ledgerhq/lumen-ui-react";
 import { Snow } from "@ledgerhq/lumen-ui-react/symbols";
 import { useTranslation } from "@shared/i18n";
+import { FreezeConfirmSheet } from "./FreezeConfirmSheet";
 import type { FreezeViewProps } from "../../types";
 
 export function FreezeView({
@@ -10,19 +11,31 @@ export function FreezeView({
   isStatusLoading,
   isFreezeLoading,
   isUnfreezeLoading,
-  onFreeze,
-  onUnfreeze,
+  isConfirmOpen,
+  onOpenConfirm,
+  onCloseConfirm,
+  onConfirm,
 }: FreezeViewProps) {
   const { t } = useTranslation();
 
   return (
-    <TileButton
-      icon={Snow}
-      onClick={isFrozen ? onUnfreeze : onFreeze}
-      disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
-      isFull
-    >
-      {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
-    </TileButton>
+    <>
+      <TileButton
+        icon={Snow}
+        onClick={onOpenConfirm}
+        disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
+        isFull
+      >
+        {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
+      </TileButton>
+
+      <FreezeConfirmSheet
+        isOpen={isConfirmOpen}
+        isFrozen={isFrozen}
+        isLoading={isFreezeLoading || isUnfreezeLoading}
+        onConfirm={onConfirm}
+        onClose={onCloseConfirm}
+      />
+    </>
   );
 }

--- a/features/flow/pay-card-details/src/components/Freeze/freezeConfirmCopy.test.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/freezeConfirmCopy.test.ts
@@ -1,0 +1,13 @@
+import { freezeConfirmActionKey, freezeConfirmTitleKey } from "./freezeConfirmCopy";
+
+describe("freezeConfirmCopy", () => {
+  it("returns freeze keys while the card is active", () => {
+    expect(freezeConfirmTitleKey(false)).toBe("payTab.card.freezeConfirm.title");
+    expect(freezeConfirmActionKey(false)).toBe("payTab.card.freezeConfirm.confirm");
+  });
+
+  it("returns unfreeze keys while the card is frozen", () => {
+    expect(freezeConfirmTitleKey(true)).toBe("payTab.card.unfreezeConfirm.title");
+    expect(freezeConfirmActionKey(true)).toBe("payTab.card.unfreezeConfirm.confirm");
+  });
+});

--- a/features/flow/pay-card-details/src/components/Freeze/freezeConfirmCopy.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/freezeConfirmCopy.ts
@@ -1,0 +1,12 @@
+const FREEZE_TITLE = "payTab.card.freezeConfirm.title";
+const UNFREEZE_TITLE = "payTab.card.unfreezeConfirm.title";
+const FREEZE_CONFIRM = "payTab.card.freezeConfirm.confirm";
+const UNFREEZE_CONFIRM = "payTab.card.unfreezeConfirm.confirm";
+
+export function freezeConfirmTitleKey(isFrozen: boolean) {
+  return isFrozen ? UNFREEZE_TITLE : FREEZE_TITLE;
+}
+
+export function freezeConfirmActionKey(isFrozen: boolean) {
+  return isFrozen ? UNFREEZE_CONFIRM : FREEZE_CONFIRM;
+}

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { useFreezeCardViewModel } from "./useFreezeCardViewModel";
 
 jest.mock("@domain/api-card-management", () => ({
@@ -14,14 +14,23 @@ import {
   type PayCardStatus,
 } from "@domain/api-card-management";
 
-function setupMocks({
-  status = "ACTIVE" as PayCardStatus["status"] | null,
+type Setup = {
+  status?: PayCardStatus["status"] | null;
+  isStatusLoading?: boolean;
+  isFreezeLoading?: boolean;
+  isFreezeError?: boolean;
+  isUnfreezeLoading?: boolean;
+  isUnfreezeError?: boolean;
+};
+
+function renderWith({
+  status = "ACTIVE",
   isStatusLoading = false,
   isFreezeLoading = false,
   isFreezeError = false,
   isUnfreezeLoading = false,
   isUnfreezeError = false,
-} = {}) {
+}: Setup = {}) {
   const freeze = jest.fn();
   const unfreeze = jest.fn();
 
@@ -46,7 +55,7 @@ function setupMocks({
       { isLoading: isUnfreezeLoading, isError: isUnfreezeError },
     ] as unknown as ReturnType<typeof useUnfreezeCardMutation>);
 
-  return { freeze, unfreeze };
+  return { freeze, unfreeze, ...renderHook(() => useFreezeCardViewModel()) };
 }
 
 describe("useFreezeCardViewModel", () => {
@@ -54,72 +63,91 @@ describe("useFreezeCardViewModel", () => {
     jest.clearAllMocks();
   });
 
-  it("returns isFrozen: false when status is ACTIVE", () => {
-    setupMocks({ status: "ACTIVE" });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isFrozen).toBe(false);
+  it.each([
+    ["ACTIVE", false],
+    ["FROZEN", true],
+    ["BLOCKED", false],
+  ] as const)("reads a %s card as frozen: %s", (status, isFrozen) => {
+    expect(renderWith({ status }).result.current.isFrozen).toBe(isFrozen);
   });
 
-  it("returns isFrozen: true when status is FROZEN", () => {
-    setupMocks({ status: "FROZEN" });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isFrozen).toBe(true);
+  it("locks the actions only on a BLOCKED card", () => {
+    expect(renderWith({ status: "BLOCKED" }).result.current.isBlocked).toBe(true);
+    expect(renderWith({ status: "FROZEN" }).result.current.isBlocked).toBe(false);
   });
 
-  it("returns isFrozen: true (optimistic) while freeze mutation is loading", () => {
-    setupMocks({ status: "ACTIVE", isFreezeLoading: true });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isFrozen).toBe(true);
+  it("offers the freeze action while the status is still on its way", () => {
+    const { result } = renderWith({ status: null, isStatusLoading: true });
+
+    expect(result.current).toMatchObject({
+      isFrozen: false,
+      isBlocked: false,
+      isStatusLoading: true,
+    });
   });
 
-  it("returns isFrozen: false (optimistic) while unfreeze mutation is loading", () => {
-    setupMocks({ status: "FROZEN", isUnfreezeLoading: true });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isFrozen).toBe(false);
+  it("shows the card frozen as soon as the freeze starts", () => {
+    // The provider only answers FROZEN on the next status refetch, and the tile must not keep
+    // offering "Freeze" until then.
+    expect(renderWith({ status: "ACTIVE", isFreezeLoading: true }).result.current.isFrozen).toBe(
+      true,
+    );
   });
 
-  it("returns isBlocked: true when status is BLOCKED", () => {
-    setupMocks({ status: "BLOCKED" });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isBlocked).toBe(true);
+  it("shows the card unfrozen as soon as the unfreeze starts", () => {
+    expect(renderWith({ status: "FROZEN", isUnfreezeLoading: true }).result.current.isFrozen).toBe(
+      false,
+    );
   });
 
-  it("returns isBlocked: false for non-BLOCKED statuses", () => {
-    setupMocks({ status: "ACTIVE" });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isBlocked).toBe(false);
+  it("surfaces a freeze that failed", () => {
+    expect(renderWith({ isFreezeError: true }).result.current.isFreezeError).toBe(true);
   });
 
-  it("calls freeze mutation when onFreeze is invoked", () => {
-    const { freeze } = setupMocks({ status: "ACTIVE" });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    result.current.onFreeze();
+  it("surfaces an unfreeze that failed", () => {
+    expect(renderWith({ isUnfreezeError: true }).result.current.isUnfreezeError).toBe(true);
+  });
+
+  it("keeps the confirmation closed until the tile is pressed", () => {
+    expect(renderWith().result.current.isConfirmOpen).toBe(false);
+  });
+
+  it("opens the confirmation from the tile", () => {
+    const { result } = renderWith();
+
+    act(() => result.current.onOpenConfirm());
+
+    expect(result.current.isConfirmOpen).toBe(true);
+  });
+
+  it("closes the confirmation when it is dismissed", () => {
+    const { result } = renderWith();
+
+    act(() => result.current.onOpenConfirm());
+    act(() => result.current.onCloseConfirm());
+
+    expect(result.current.isConfirmOpen).toBe(false);
+  });
+
+  it("freezes a card that is not frozen, and closes the confirmation", () => {
+    const { freeze, unfreeze, result } = renderWith({ status: "ACTIVE" });
+
+    act(() => result.current.onOpenConfirm());
+    act(() => result.current.onConfirm());
+
     expect(freeze).toHaveBeenCalledTimes(1);
+    expect(unfreeze).not.toHaveBeenCalled();
+    expect(result.current.isConfirmOpen).toBe(false);
   });
 
-  it("calls unfreeze mutation when onUnfreeze is invoked", () => {
-    const { unfreeze } = setupMocks({ status: "FROZEN" });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    result.current.onUnfreeze();
+  it("unfreezes a frozen card, and closes the confirmation", () => {
+    const { freeze, unfreeze, result } = renderWith({ status: "FROZEN" });
+
+    act(() => result.current.onOpenConfirm());
+    act(() => result.current.onConfirm());
+
     expect(unfreeze).toHaveBeenCalledTimes(1);
-  });
-
-  it("exposes isFreezeError: true when freeze mutation errored", () => {
-    setupMocks({ isFreezeError: true });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isFreezeError).toBe(true);
-  });
-
-  it("exposes isUnfreezeError: true when unfreeze mutation errored", () => {
-    setupMocks({ isUnfreezeError: true });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isUnfreezeError).toBe(true);
-  });
-
-  it("exposes isStatusLoading: true while card status query is loading", () => {
-    setupMocks({ isStatusLoading: true, status: null });
-    const { result } = renderHook(() => useFreezeCardViewModel());
-    expect(result.current.isStatusLoading).toBe(true);
-    expect(result.current.isFrozen).toBe(false);
+    expect(freeze).not.toHaveBeenCalled();
+    expect(result.current.isConfirmOpen).toBe(false);
   });
 });

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   useFreezeCardMutation,
   useGetCardStatusQuery,
@@ -23,11 +23,24 @@ export function useFreezeCardViewModel(): FreezeCardViewProps {
   const [unfreeze, { isLoading: isUnfreezeLoading, isError: isUnfreezeError }] =
     useUnfreezeCardMutation();
 
-  return useMemo(() => {
-    const statusFromApi = cardStatus?.status;
-    const isFrozen = resolveOptimisticFrozen(statusFromApi, isFreezeLoading, isUnfreezeLoading);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
-    return {
+  const statusFromApi = cardStatus?.status;
+  const isFrozen = resolveOptimisticFrozen(statusFromApi, isFreezeLoading, isUnfreezeLoading);
+
+  const onOpenConfirm = useCallback(() => setIsConfirmOpen(true), []);
+  const onCloseConfirm = useCallback(() => setIsConfirmOpen(false), []);
+  const onConfirm = useCallback(() => {
+    setIsConfirmOpen(false);
+    if (isFrozen) {
+      unfreeze();
+    } else {
+      freeze();
+    }
+  }, [isFrozen, freeze, unfreeze]);
+
+  return useMemo(
+    () => ({
       isFrozen,
       isBlocked: statusFromApi === "BLOCKED",
       isStatusLoading,
@@ -35,17 +48,23 @@ export function useFreezeCardViewModel(): FreezeCardViewProps {
       isUnfreezeLoading,
       isFreezeError,
       isUnfreezeError,
-      onFreeze: () => void freeze(),
-      onUnfreeze: () => void unfreeze(),
-    };
-  }, [
-    cardStatus,
-    isStatusLoading,
-    isFreezeLoading,
-    isUnfreezeLoading,
-    isFreezeError,
-    isUnfreezeError,
-    freeze,
-    unfreeze,
-  ]);
+      isConfirmOpen,
+      onOpenConfirm,
+      onCloseConfirm,
+      onConfirm,
+    }),
+    [
+      isFrozen,
+      statusFromApi,
+      isStatusLoading,
+      isFreezeLoading,
+      isUnfreezeLoading,
+      isFreezeError,
+      isUnfreezeError,
+      isConfirmOpen,
+      onOpenConfirm,
+      onCloseConfirm,
+      onConfirm,
+    ],
+  );
 }

--- a/features/flow/pay-card-details/src/types.ts
+++ b/features/flow/pay-card-details/src/types.ts
@@ -25,8 +25,10 @@ export type FreezeCardViewProps = Readonly<{
   isUnfreezeLoading: boolean;
   isFreezeError: boolean;
   isUnfreezeError: boolean;
-  onFreeze: () => void;
-  onUnfreeze: () => void;
+  isConfirmOpen: boolean;
+  onOpenConfirm: () => void;
+  onCloseConfirm: () => void;
+  onConfirm: () => void;
 }>;
 
 export type FreezeViewProps = Pick<
@@ -36,6 +38,16 @@ export type FreezeViewProps = Pick<
   | "isStatusLoading"
   | "isFreezeLoading"
   | "isUnfreezeLoading"
-  | "onFreeze"
-  | "onUnfreeze"
+  | "isConfirmOpen"
+  | "onOpenConfirm"
+  | "onCloseConfirm"
+  | "onConfirm"
 >;
+
+export type FreezeConfirmSheetProps = Readonly<{
+  isOpen: boolean;
+  isFrozen: boolean;
+  isLoading: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6944,6 +6944,9 @@ importers:
       '@shared/i18n':
         specifier: workspace:*
         version: link:../../../shared/i18n
+      '@shared/ui-queued-bottom-sheet':
+        specifier: workspace:*
+        version: link:../../../shared/ui-queued-bottom-sheet
     devDependencies:
       '@features/platform-style':
         specifier: workspace:*


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds a freeze/unfreeze confirmation step on the Pay card tile so the freeze mutation no longer runs from the first tap.

Desktop opens a Lumen `Dialog`. Mobile opens a queued bottom sheet. Shared view-model state (`isConfirmOpen` / `onConfirm`) drives both platforms. Copy lives in the English source locale files.

This PR is the base of the stacked frozen-card visual follow-up.

https://github.com/user-attachments/assets/c8c2a985-e07f-402a-bc78-4a3864c9ed3e

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37111](https://ledgerhq.atlassian.net/browse/LIVE-37111) (desktop), [LIVE-37113](https://ledgerhq.atlassian.net/browse/LIVE-37113) (mobile)
- **ADR** (if any): n/a

[LIVE-37111]: https://ledgerhq.atlassian.net/browse/LIVE-37111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37113]: https://ledgerhq.atlassian.net/browse/LIVE-37113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ