### PR TITLE
[LWD] feat(pay-card): show frozen card visual (LIVE-37112)

### DIFF
--- a/.changeset/pay-card-frozen-card-visual.md
+++ b/.changeset/pay-card-frozen-card-visual.md
@@ -1,0 +1,8 @@
+---
+"@features/flow-pay-card-details": minor
+"@support/jest-features-flow": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Mark a frozen pay card on the card visual: the card face fades out behind a centered snow `Spot`, read from the same card status the freeze tile uses. The features/flow jest projects now compile `@ledgerhq/lumen-utils-shared` instead of leaving its ESM untransformed, so views can use `cn`.

--- a/.changeset/pay-card-frozen-card-visual.md
+++ b/.changeset/pay-card-frozen-card-visual.md
@@ -1,5 +1,6 @@
 ---
 "@features/flow-pay-card-details": minor
+"@domain/api-card-management": minor
 "@support/jest-features-flow": minor
 "ledger-live-desktop": minor
 "live-mobile": minor

--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -62,6 +62,7 @@ const transformIncludePatterns = [
   "ky",
   "@ledgerhq\\+lumen-ui-react",
   "@ledgerhq\\+lumen-design-core",
+  "@ledgerhq\\+lumen-utils-shared",
   "@ledgerhq\\+crypto-icons",
   "@mysten\\+",
   "@scure\\+",

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -47,6 +47,14 @@ function request(spy: jest.SpyInstance): Request {
   return spy.mock.calls[0][0] as Request;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 // The provider's own example response.
 const cardStatus = {
   id: "000000000050277836",
@@ -499,6 +507,38 @@ describe("cardManagementApi requests", () => {
       });
     });
 
+    it("optimistically shares FROZEN through the status cache and rolls back on failure", async () => {
+      const freezeResponse = deferred<Response>();
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          if (new URL((input as Request).url).pathname === "/v1/card/freeze") {
+            return freezeResponse.promise;
+          }
+          return jsonResponse(cardStatus);
+        });
+
+      const store = makeStore("session-token");
+      const subscription = store.dispatch(
+        cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
+      );
+      await subscription;
+
+      const mutation = store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
+
+      expect(
+        cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
+      ).toBe("FROZEN");
+
+      freezeResponse.resolve(errorResponse(500, "Freeze failed"));
+      await mutation;
+      expect(
+        cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
+      ).toBe("ACTIVE");
+
+      subscription.unsubscribe();
+    });
+
     it("refetches the card status, because freezing moves it to FROZEN", async () => {
       let cardState = "ACTIVE";
       fetchSpy = jest
@@ -555,6 +595,38 @@ describe("cardManagementApi requests", () => {
 
       expect(result.data).toBeUndefined();
       expect(result.error).toMatchObject({ status: 400, data: { message: "Card is not frozen" } });
+    });
+
+    it("optimistically shares ACTIVE through the status cache and rolls back on failure", async () => {
+      const unfreezeResponse = deferred<Response>();
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          if (new URL((input as Request).url).pathname === "/v1/card/unfreeze") {
+            return unfreezeResponse.promise;
+          }
+          return jsonResponse({ ...cardStatus, status: "FROZEN" });
+        });
+
+      const store = makeStore("session-token");
+      const subscription = store.dispatch(
+        cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
+      );
+      await subscription;
+
+      const mutation = store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
+
+      expect(
+        cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
+      ).toBe("ACTIVE");
+
+      unfreezeResponse.resolve(errorResponse(500, "Unfreeze failed"));
+      await mutation;
+      expect(
+        cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
+      ).toBe("FROZEN");
+
+      subscription.unsubscribe();
     });
 
     it("refetches the card status, because unfreezing moves it back to ACTIVE", async () => {

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -129,6 +129,9 @@ export const cardManagementApi = cardApi
           url: "/v1/card/freeze",
           method: "POST",
         }),
+        async onQueryStarted(_, { dispatch, queryFulfilled }) {
+          await patchCardStatus(dispatch, queryFulfilled, "FROZEN");
+        },
         responseSchema: PayCardFreezeStateResponseSchema,
         invalidatesTags: ["CardStatus"],
       }),
@@ -138,6 +141,9 @@ export const cardManagementApi = cardApi
           url: "/v1/card/unfreeze",
           method: "POST",
         }),
+        async onQueryStarted(_, { dispatch, queryFulfilled }) {
+          await patchCardStatus(dispatch, queryFulfilled, "ACTIVE");
+        },
         responseSchema: PayCardFreezeStateResponseSchema,
         invalidatesTags: ["CardStatus"],
       }),
@@ -184,3 +190,23 @@ export const {
   useGetCardLinkedWalletsQuery,
   useGetCardOnboardingStatusQuery,
 } = cardManagementApi;
+
+async function patchCardStatus(
+  dispatch: (action: ReturnType<(typeof cardManagementApi.util)["updateQueryData"]>) => {
+    undo: () => void;
+  },
+  queryFulfilled: Promise<unknown>,
+  status: PayCardStatus["status"],
+) {
+  const patch = dispatch(
+    cardManagementApi.util.updateQueryData("getCardStatus", undefined, draft => {
+      draft.status = status;
+    }),
+  );
+
+  try {
+    await queryFulfilled;
+  } catch {
+    patch.undo();
+  }
+}

--- a/features/flow/pay-card-details/README.md
+++ b/features/flow/pay-card-details/README.md
@@ -6,7 +6,8 @@
 Dual-platform flow package for the Pay tab **card visual** for Ledger Wallet: the physical card
 face (dark gradient + halftone artwork + network logo) and, on top of it, the card balance overlay.
 
-Props-only and i18n-agnostic — the host owns data fetching, currency formatting and labels.
+The host owns currency formatting and the balance label, and hands both over as props. Card state
+(status, freeze/unfreeze) is the package's own business: it reads it from the card API itself.
 
 ## Usage
 
@@ -18,6 +19,10 @@ import { CardVisual } from "@features/flow-pay-card-details";
 
 `CardVisual` composes the `CardArtwork` (card face) with the balance overlay. `CardArtwork` is also
 exported on its own for consumers that only need the card face.
+
+The frozen state is not a host prop: `useCardVisualViewModel` reads the same `CardStatus` query the
+freeze tile uses, so the card face and the tile can never disagree. A frozen card fades out and
+takes a centered snow `Spot`.
 
 ## Platform resolution
 
@@ -46,7 +51,8 @@ pay-card-details/
     │   │   └── CardArtwork.native.test.tsx
     │   └── CardVisual/
     │       ├── CardVisual.tsx
-    │       ├── CardVisualView.web.tsx         # Artwork + balance overlay
+    │       ├── useCardVisualViewModel.ts      # Frozen state, read from the card status
+    │       ├── CardVisualView.web.tsx         # Artwork + balance overlay + frozen marker
     │       ├── CardVisualView.native.tsx      # Empty stub until LWM design
     │       ├── CardVisual.web.test.tsx
     │       ├── CardVisual.native.test.tsx

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisual.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisual.native.test.tsx
@@ -3,6 +3,12 @@ import { render, screen } from "@testing-library/react-native";
 import { CardVisual } from "./CardVisual";
 import type { FormattedValue } from "../../types";
 
+jest.mock("@domain/api-card-management", () => ({
+  useGetCardStatusQuery: jest.fn(),
+}));
+
+import { useGetCardStatusQuery } from "@domain/api-card-management";
+
 const formatCountervalue = (value: number): FormattedValue => ({
   integerPart: String(Math.trunc(value)),
   decimalPart: "00",
@@ -13,6 +19,10 @@ const formatCountervalue = (value: number): FormattedValue => ({
 
 describe("CardVisual (native)", () => {
   it("renders nothing until the native card visual ships", () => {
+    jest.mocked(useGetCardStatusQuery).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useGetCardStatusQuery>);
+
     render(
       <CardVisual balance={100} formatCountervalue={formatCountervalue} balanceLabel="Balance" />,
     );

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisual.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisual.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { CardVisualView } from "./CardVisualView";
+import { useCardVisualViewModel } from "./useCardVisualViewModel";
 import type { CardVisualProps } from "../../types";
 
 export function CardVisual(props: CardVisualProps) {
-  return <CardVisualView {...props} />;
+  return <CardVisualView {...useCardVisualViewModel(props)} />;
 }

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisual.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisual.web.test.tsx
@@ -3,6 +3,12 @@ import { render, screen } from "@testing-library/react";
 import { CardVisual } from "./CardVisual";
 import type { FormattedValue } from "../../types";
 
+jest.mock("@domain/api-card-management", () => ({
+  useGetCardStatusQuery: jest.fn(),
+}));
+
+import { useGetCardStatusQuery, type PayCardStatus } from "@domain/api-card-management";
+
 const formatCountervalue = (value: number): FormattedValue => ({
   integerPart: String(Math.trunc(value)),
   decimalPart: "00",
@@ -11,15 +17,40 @@ const formatCountervalue = (value: number): FormattedValue => ({
   currencyPosition: "start",
 });
 
+function renderWithStatus(status: PayCardStatus["status"] | undefined) {
+  jest.mocked(useGetCardStatusQuery).mockReturnValue({
+    data: status
+      ? { id: "card-id", panLast4: "1234", status, type: "VIRTUAL" as const, orderedAt: "" }
+      : undefined,
+  } as unknown as ReturnType<typeof useGetCardStatusQuery>);
+
+  return render(
+    <CardVisual balance={100} formatCountervalue={formatCountervalue} balanceLabel="Balance" />,
+  );
+}
+
 describe("CardVisual (web)", () => {
-  it("renders the card artwork with the balance caption and amount", () => {
-    render(
-      <CardVisual balance={100} formatCountervalue={formatCountervalue} balanceLabel="Balance" />,
-    );
+  it("renders the card face with the balance caption and amount", () => {
+    renderWithStatus("ACTIVE");
 
     expect(screen.getByTestId("card-visual")).toBeVisible();
     expect(screen.getByTestId("card-artwork")).toBeVisible();
     expect(screen.getByText("Balance")).toBeVisible();
     expect(screen.getByTestId("card-visual-amount")).toBeVisible();
   });
+
+  it("shows the frozen marker once the card status reads FROZEN", () => {
+    renderWithStatus("FROZEN");
+
+    expect(screen.getByTestId("card-visual-frozen")).toBeVisible();
+  });
+
+  it.each<PayCardStatus["status"] | undefined>(["ACTIVE", "BLOCKED", undefined])(
+    "leaves the card unmarked on status %s",
+    status => {
+      renderWithStatus(status);
+
+      expect(screen.queryByTestId("card-visual-frozen")).not.toBeInTheDocument();
+    },
+  );
 });

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.native.test.tsx
@@ -19,6 +19,7 @@ describe("CardVisualView (native)", () => {
         formatCountervalue={formatCountervalue}
         balanceLabel="Balance"
         isLoading={false}
+        isFrozen={false}
       />,
     );
 

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { CardVisualView } from "./CardVisualView";
-import type { FormattedValue } from "../../types";
+import type { CardVisualViewProps, FormattedValue } from "../../types";
 
 const formatCountervalue = (value: number): FormattedValue => ({
   integerPart: String(Math.trunc(value)),
@@ -11,19 +11,36 @@ const formatCountervalue = (value: number): FormattedValue => ({
   currencyPosition: "start",
 });
 
+function renderCardVisual(props: Partial<CardVisualViewProps> = {}) {
+  return render(
+    <CardVisualView
+      balance={100}
+      formatCountervalue={formatCountervalue}
+      balanceLabel="Balance"
+      isLoading={false}
+      isFrozen={false}
+      {...props}
+    />,
+  );
+}
+
 describe("CardVisualView (web)", () => {
-  it("renders the card artwork with the balance caption and amount", () => {
-    render(
-      <CardVisualView
-        balance={100}
-        formatCountervalue={formatCountervalue}
-        balanceLabel="Balance"
-        isLoading={false}
-      />,
-    );
+  it("renders the card face with the balance caption and amount", () => {
+    renderCardVisual();
 
     expect(screen.getByTestId("card-visual")).toBeVisible();
     expect(screen.getByTestId("card-artwork")).toBeVisible();
+    expect(screen.getByText("Balance")).toBeVisible();
+    expect(screen.getByTestId("card-visual-amount")).toBeVisible();
+    expect(screen.queryByTestId("card-visual-frozen")).not.toBeInTheDocument();
+    expect(screen.getByTestId("card-artwork").parentElement).not.toHaveClass("opacity-50");
+  });
+
+  it("fades the card face behind the snow spot on a frozen card", () => {
+    renderCardVisual({ isFrozen: true });
+
+    expect(screen.getByTestId("card-visual-frozen")).toBeVisible();
+    expect(screen.getByTestId("card-artwork").parentElement).toHaveClass("opacity-50");
     expect(screen.getByText("Balance")).toBeVisible();
     expect(screen.getByTestId("card-visual-amount")).toBeVisible();
   });

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.tsx
@@ -1,31 +1,38 @@
 import React from "react";
-import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
+import { AmountDisplay, Spot } from "@ledgerhq/lumen-ui-react";
+import { Snow } from "@ledgerhq/lumen-ui-react/symbols";
+import { cn } from "@ledgerhq/lumen-utils-shared";
 import { CardArtwork } from "../CardArtwork/CardArtwork";
 import type { CardVisualViewProps } from "../../types";
 
-/**
- * The card face with the balance overlay. The card is always dark, so the overlay is scoped to the
- * `dark` color-scheme class to keep the caption and amount legible whatever the app theme is.
- */
 export function CardVisualView({
   balance,
   formatCountervalue,
   balanceLabel,
   isLoading = false,
+  isFrozen,
 }: CardVisualViewProps) {
   return (
     <div className="dark relative w-full" data-testid="card-visual">
-      <CardArtwork />
-      <div className="absolute inset-x-0 top-0 flex flex-col gap-4 p-20">
-        <span className="body-3 text-muted">{balanceLabel}</span>
-        <AmountDisplay
-          value={balance}
-          formatter={formatCountervalue}
-          loading={isLoading}
-          size="sm"
-          data-testid="card-visual-amount"
-        />
+      <div className={cn("relative", isFrozen && "opacity-50")}>
+        <CardArtwork />
+        <div className="absolute inset-x-0 top-0 flex flex-col gap-4 p-20">
+          <span className="body-3 text-muted">{balanceLabel}</span>
+          <AmountDisplay
+            value={balance}
+            formatter={formatCountervalue}
+            loading={isLoading}
+            size="sm"
+            data-testid="card-visual-amount"
+          />
+        </div>
       </div>
+
+      {isFrozen && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Spot appearance="icon" icon={Snow} data-testid="card-visual-frozen" />
+        </div>
+      )}
     </div>
   );
 }

--- a/features/flow/pay-card-details/src/components/CardVisual/useCardVisualViewModel.ts
+++ b/features/flow/pay-card-details/src/components/CardVisual/useCardVisualViewModel.ts
@@ -1,0 +1,8 @@
+import { useGetCardStatusQuery } from "@domain/api-card-management";
+import type { CardVisualProps, CardVisualViewProps } from "../../types";
+
+export function useCardVisualViewModel(props: CardVisualProps): CardVisualViewProps {
+  const { data: cardStatus } = useGetCardStatusQuery();
+
+  return { ...props, isFrozen: cardStatus?.status === "FROZEN" };
+}

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.test.tsx
@@ -12,10 +12,8 @@ function renderFreeze(props: Partial<FreezeViewProps> = {}) {
   const view = render(
     <FreezeView
       isFrozen={false}
-      isBlocked={false}
-      isStatusLoading={false}
-      isFreezeLoading={false}
-      isUnfreezeLoading={false}
+      isUpdating={false}
+      isActionDisabled={false}
       isConfirmOpen={false}
       onOpenConfirm={onOpenConfirm}
       onCloseConfirm={onCloseConfirm}
@@ -50,31 +48,26 @@ describe("FreezeView (native)", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it("keeps the confirmation closed until isConfirmOpen is true", () => {
+  it("hides the confirmation until it is opened", () => {
     renderFreeze();
 
     expect(screen.queryByText(CARD_COPY.freezeTitle)).toBeNull();
   });
 
-  it("shows the unfreeze confirmation when the sheet is open", () => {
+  it("asks to confirm the unfreeze of a frozen card", () => {
     renderFreeze({ isConfirmOpen: true, isFrozen: true });
 
     expect(screen.getByText(CARD_COPY.unfreezeTitle)).toBeVisible();
   });
 
-  it("disables the confirm button while freeze is loading", () => {
-    renderFreeze({ isConfirmOpen: true, isFreezeLoading: true });
+  it("disables the confirm button while the card is updating", () => {
+    renderFreeze({ isConfirmOpen: true, isUpdating: true });
 
     expect(screen.getByTestId("freeze-confirm-action").props.disabled).toBe(true);
   });
 
-  it.each([
-    ["the card is blocked", { isBlocked: true }],
-    ["card status is loading", { isStatusLoading: true }],
-    ["freeze is loading", { isFreezeLoading: true }],
-    ["unfreeze is loading", { isUnfreezeLoading: true }],
-  ])("disables the tile while %s", (_reason, props) => {
-    renderFreeze(props);
+  it("disables the tile when the action is unavailable", () => {
+    renderFreeze({ isActionDisabled: true });
 
     expect(screen.getByText(CARD_COPY.freeze).parent?.props.disabled).toBe(true);
   });

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.native.tsx
@@ -7,10 +7,8 @@ import type { FreezeViewProps } from "../../types";
 
 export function FreezeView({
   isFrozen,
-  isBlocked,
-  isStatusLoading,
-  isFreezeLoading,
-  isUnfreezeLoading,
+  isUpdating,
+  isActionDisabled,
   isConfirmOpen,
   onOpenConfirm,
   onCloseConfirm,
@@ -20,19 +18,14 @@ export function FreezeView({
 
   return (
     <>
-      <TileButton
-        icon={Snow}
-        onPress={onOpenConfirm}
-        disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
-        isFull
-      >
+      <TileButton icon={Snow} onPress={onOpenConfirm} disabled={isActionDisabled} isFull>
         {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
       </TileButton>
 
       <FreezeConfirmSheet
         isOpen={isConfirmOpen}
         isFrozen={isFrozen}
-        isLoading={isFreezeLoading || isUnfreezeLoading}
+        isLoading={isUpdating}
         onConfirm={onConfirm}
         onClose={onCloseConfirm}
       />

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.test.tsx
@@ -13,10 +13,8 @@ function renderFreeze(props: Partial<FreezeViewProps> = {}) {
   const view = render(
     <FreezeView
       isFrozen={false}
-      isBlocked={false}
-      isStatusLoading={false}
-      isFreezeLoading={false}
-      isUnfreezeLoading={false}
+      isUpdating={false}
+      isActionDisabled={false}
       isConfirmOpen={false}
       onOpenConfirm={onOpenConfirm}
       onCloseConfirm={onCloseConfirm}
@@ -51,31 +49,26 @@ describe("FreezeView (web)", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it("keeps the confirmation closed until isConfirmOpen is true", () => {
+  it("hides the confirmation until it is opened", () => {
     renderFreeze();
 
     expect(screen.queryByText(CARD_COPY.freezeTitle)).not.toBeInTheDocument();
   });
 
-  it("shows the unfreeze confirmation when the sheet is open", () => {
+  it("asks to confirm the unfreeze of a frozen card", () => {
     renderFreeze({ isConfirmOpen: true, isFrozen: true });
 
     expect(screen.getByText(CARD_COPY.unfreezeTitle)).toBeVisible();
   });
 
-  it("disables the confirm button while freeze is loading", () => {
-    renderFreeze({ isConfirmOpen: true, isFreezeLoading: true });
+  it("disables the confirm button while the card is updating", () => {
+    renderFreeze({ isConfirmOpen: true, isUpdating: true });
 
     expect(screen.getByRole("button", { name: CARD_COPY.freezeConfirm })).toBeDisabled();
   });
 
-  it.each([
-    ["the card is blocked", { isBlocked: true }],
-    ["card status is loading", { isStatusLoading: true }],
-    ["freeze is loading", { isFreezeLoading: true }],
-    ["unfreeze is loading", { isUnfreezeLoading: true }],
-  ])("disables the tile while %s", (_reason, props) => {
-    renderFreeze(props);
+  it("disables the tile when the action is unavailable", () => {
+    renderFreeze({ isActionDisabled: true });
 
     expect(screen.getByRole("button", { name: CARD_COPY.freeze })).toBeDisabled();
   });

--- a/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
+++ b/features/flow/pay-card-details/src/components/Freeze/FreezeView.web.tsx
@@ -7,10 +7,8 @@ import type { FreezeViewProps } from "../../types";
 
 export function FreezeView({
   isFrozen,
-  isBlocked,
-  isStatusLoading,
-  isFreezeLoading,
-  isUnfreezeLoading,
+  isUpdating,
+  isActionDisabled,
   isConfirmOpen,
   onOpenConfirm,
   onCloseConfirm,
@@ -20,19 +18,14 @@ export function FreezeView({
 
   return (
     <>
-      <TileButton
-        icon={Snow}
-        onClick={onOpenConfirm}
-        disabled={isBlocked || isStatusLoading || isFreezeLoading || isUnfreezeLoading}
-        isFull
-      >
+      <TileButton icon={Snow} onClick={onOpenConfirm} disabled={isActionDisabled} isFull>
         {isFrozen ? t("payTab.card.unfreeze") : t("payTab.card.freeze")}
       </TileButton>
 
       <FreezeConfirmSheet
         isOpen={isConfirmOpen}
         isFrozen={isFrozen}
-        isLoading={isFreezeLoading || isUnfreezeLoading}
+        isLoading={isUpdating}
         onConfirm={onConfirm}
         onClose={onCloseConfirm}
       />

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
@@ -86,20 +86,6 @@ describe("useFreezeCardViewModel", () => {
     });
   });
 
-  it("shows the card frozen as soon as the freeze starts", () => {
-    // The provider only answers FROZEN on the next status refetch, and the tile must not keep
-    // offering "Freeze" until then.
-    expect(renderWith({ status: "ACTIVE", isFreezeLoading: true }).result.current.isFrozen).toBe(
-      true,
-    );
-  });
-
-  it("shows the card unfrozen as soon as the unfreeze starts", () => {
-    expect(renderWith({ status: "FROZEN", isUnfreezeLoading: true }).result.current.isFrozen).toBe(
-      false,
-    );
-  });
-
   it("surfaces a freeze that failed", () => {
     expect(renderWith({ isFreezeError: true }).result.current.isFreezeError).toBe(true);
   });

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.test.ts
@@ -18,18 +18,14 @@ type Setup = {
   status?: PayCardStatus["status"] | null;
   isStatusLoading?: boolean;
   isFreezeLoading?: boolean;
-  isFreezeError?: boolean;
   isUnfreezeLoading?: boolean;
-  isUnfreezeError?: boolean;
 };
 
 function renderWith({
   status = "ACTIVE",
   isStatusLoading = false,
   isFreezeLoading = false,
-  isFreezeError = false,
   isUnfreezeLoading = false,
-  isUnfreezeError = false,
 }: Setup = {}) {
   const freeze = jest.fn();
   const unfreeze = jest.fn();
@@ -43,17 +39,15 @@ function renderWith({
 
   jest
     .mocked(useFreezeCardMutation)
-    .mockReturnValue([
-      freeze,
-      { isLoading: isFreezeLoading, isError: isFreezeError },
-    ] as unknown as ReturnType<typeof useFreezeCardMutation>);
+    .mockReturnValue([freeze, { isLoading: isFreezeLoading }] as unknown as ReturnType<
+      typeof useFreezeCardMutation
+    >);
 
   jest
     .mocked(useUnfreezeCardMutation)
-    .mockReturnValue([
-      unfreeze,
-      { isLoading: isUnfreezeLoading, isError: isUnfreezeError },
-    ] as unknown as ReturnType<typeof useUnfreezeCardMutation>);
+    .mockReturnValue([unfreeze, { isLoading: isUnfreezeLoading }] as unknown as ReturnType<
+      typeof useUnfreezeCardMutation
+    >);
 
   return { freeze, unfreeze, ...renderHook(() => useFreezeCardViewModel()) };
 }
@@ -63,42 +57,43 @@ describe("useFreezeCardViewModel", () => {
     jest.clearAllMocks();
   });
 
+  it("reads a FROZEN card as frozen", () => {
+    expect(renderWith({ status: "FROZEN" }).result.current.isFrozen).toBe(true);
+  });
+
+  it.each(["ACTIVE", "BLOCKED"] as const)("does not read a %s card as frozen", status => {
+    expect(renderWith({ status }).result.current.isFrozen).toBe(false);
+  });
+
+  it.each(["ACTIVE", "FROZEN"] as const)("keeps the action available on a %s card", status => {
+    expect(renderWith({ status }).result.current.isActionDisabled).toBe(false);
+  });
+
   it.each([
-    ["ACTIVE", false],
-    ["FROZEN", true],
-    ["BLOCKED", false],
-  ] as const)("reads a %s card as frozen: %s", (status, isFrozen) => {
-    expect(renderWith({ status }).result.current.isFrozen).toBe(isFrozen);
+    ["the card is blocked", { status: "BLOCKED" }],
+    ["the card status has not arrived yet", { status: null, isStatusLoading: true }],
+    ["a freeze is in flight", { isFreezeLoading: true }],
+    ["an unfreeze is in flight", { isUnfreezeLoading: true }],
+  ] as const)("makes the action unavailable when %s", (_reason, setup) => {
+    expect(renderWith(setup).result.current.isActionDisabled).toBe(true);
   });
 
-  it("locks the actions only on a BLOCKED card", () => {
-    expect(renderWith({ status: "BLOCKED" }).result.current.isBlocked).toBe(true);
-    expect(renderWith({ status: "FROZEN" }).result.current.isBlocked).toBe(false);
+  it.each([
+    ["freeze", { isFreezeLoading: true }],
+    ["unfreeze", { isUnfreezeLoading: true }],
+  ] as const)("marks the card as updating while the %s request is in flight", (_request, setup) => {
+    expect(renderWith(setup).result.current.isUpdating).toBe(true);
   });
 
-  it("offers the freeze action while the status is still on its way", () => {
-    const { result } = renderWith({ status: null, isStatusLoading: true });
-
-    expect(result.current).toMatchObject({
-      isFrozen: false,
-      isBlocked: false,
-      isStatusLoading: true,
-    });
-  });
-
-  it("surfaces a freeze that failed", () => {
-    expect(renderWith({ isFreezeError: true }).result.current.isFreezeError).toBe(true);
-  });
-
-  it("surfaces an unfreeze that failed", () => {
-    expect(renderWith({ isUnfreezeError: true }).result.current.isUnfreezeError).toBe(true);
+  it("marks an idle card as not updating", () => {
+    expect(renderWith().result.current.isUpdating).toBe(false);
   });
 
   it("keeps the confirmation closed until the tile is pressed", () => {
     expect(renderWith().result.current.isConfirmOpen).toBe(false);
   });
 
-  it("opens the confirmation from the tile", () => {
+  it("opens the confirmation on request", () => {
     const { result } = renderWith();
 
     act(() => result.current.onOpenConfirm());
@@ -115,7 +110,7 @@ describe("useFreezeCardViewModel", () => {
     expect(result.current.isConfirmOpen).toBe(false);
   });
 
-  it("freezes a card that is not frozen, and closes the confirmation", () => {
+  it("freezes an unfrozen card and closes the confirmation", () => {
     const { freeze, unfreeze, result } = renderWith({ status: "ACTIVE" });
 
     act(() => result.current.onOpenConfirm());
@@ -126,7 +121,7 @@ describe("useFreezeCardViewModel", () => {
     expect(result.current.isConfirmOpen).toBe(false);
   });
 
-  it("unfreezes a frozen card, and closes the confirmation", () => {
+  it("unfreezes a frozen card and closes the confirmation", () => {
     const { freeze, unfreeze, result } = renderWith({ status: "FROZEN" });
 
     act(() => result.current.onOpenConfirm());

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
@@ -4,18 +4,19 @@ import {
   useGetCardStatusQuery,
   useUnfreezeCardMutation,
 } from "@domain/api-card-management";
-import type { FreezeCardViewProps } from "../../types";
+import type { FreezeViewProps } from "../../types";
 
-export function useFreezeCardViewModel(): FreezeCardViewProps {
+export function useFreezeCardViewModel(): FreezeViewProps {
   const { data: cardStatus, isLoading: isStatusLoading } = useGetCardStatusQuery();
-  const [freeze, { isLoading: isFreezeLoading, isError: isFreezeError }] = useFreezeCardMutation();
-  const [unfreeze, { isLoading: isUnfreezeLoading, isError: isUnfreezeError }] =
-    useUnfreezeCardMutation();
+  const [freeze, { isLoading: isFreezeLoading }] = useFreezeCardMutation();
+  const [unfreeze, { isLoading: isUnfreezeLoading }] = useUnfreezeCardMutation();
 
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const statusFromApi = cardStatus?.status;
   const isFrozen = statusFromApi === "FROZEN";
+  const isBlocked = statusFromApi === "BLOCKED";
+  const isUpdating = isFreezeLoading || isUnfreezeLoading;
 
   const onOpenConfirm = useCallback(() => setIsConfirmOpen(true), []);
   const onCloseConfirm = useCallback(() => setIsConfirmOpen(false), []);
@@ -31,12 +32,8 @@ export function useFreezeCardViewModel(): FreezeCardViewProps {
   return useMemo(
     () => ({
       isFrozen,
-      isBlocked: statusFromApi === "BLOCKED",
-      isStatusLoading,
-      isFreezeLoading,
-      isUnfreezeLoading,
-      isFreezeError,
-      isUnfreezeError,
+      isUpdating,
+      isActionDisabled: isBlocked || isStatusLoading || isUpdating,
       isConfirmOpen,
       onOpenConfirm,
       onCloseConfirm,
@@ -44,12 +41,9 @@ export function useFreezeCardViewModel(): FreezeCardViewProps {
     }),
     [
       isFrozen,
-      statusFromApi,
+      isUpdating,
+      isBlocked,
       isStatusLoading,
-      isFreezeLoading,
-      isUnfreezeLoading,
-      isFreezeError,
-      isUnfreezeError,
       isConfirmOpen,
       onOpenConfirm,
       onCloseConfirm,

--- a/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
+++ b/features/flow/pay-card-details/src/components/Freeze/useFreezeCardViewModel.ts
@@ -3,19 +3,8 @@ import {
   useFreezeCardMutation,
   useGetCardStatusQuery,
   useUnfreezeCardMutation,
-  type PayCardStatus,
 } from "@domain/api-card-management";
 import type { FreezeCardViewProps } from "../../types";
-
-function resolveOptimisticFrozen(
-  statusFromApi: PayCardStatus["status"] | undefined,
-  isFreezeLoading: boolean,
-  isUnfreezeLoading: boolean,
-): boolean {
-  if (isFreezeLoading) return true;
-  if (isUnfreezeLoading) return false;
-  return statusFromApi === "FROZEN";
-}
 
 export function useFreezeCardViewModel(): FreezeCardViewProps {
   const { data: cardStatus, isLoading: isStatusLoading } = useGetCardStatusQuery();
@@ -26,7 +15,7 @@ export function useFreezeCardViewModel(): FreezeCardViewProps {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const statusFromApi = cardStatus?.status;
-  const isFrozen = resolveOptimisticFrozen(statusFromApi, isFreezeLoading, isUnfreezeLoading);
+  const isFrozen = statusFromApi === "FROZEN";
 
   const onOpenConfirm = useCallback(() => setIsConfirmOpen(true), []);
   const onCloseConfirm = useCallback(() => setIsConfirmOpen(false), []);

--- a/features/flow/pay-card-details/src/types.ts
+++ b/features/flow/pay-card-details/src/types.ts
@@ -20,33 +20,15 @@ export type CardVisualViewProps = CardVisualProps &
     isFrozen: boolean;
   }>;
 
-export type FreezeCardViewProps = Readonly<{
+export type FreezeViewProps = Readonly<{
   isFrozen: boolean;
-  /** `true` when card status is BLOCKED — disables all freeze/unfreeze actions. */
-  isBlocked: boolean;
-  isStatusLoading: boolean;
-  isFreezeLoading: boolean;
-  isUnfreezeLoading: boolean;
-  isFreezeError: boolean;
-  isUnfreezeError: boolean;
+  isUpdating: boolean;
+  isActionDisabled: boolean;
   isConfirmOpen: boolean;
   onOpenConfirm: () => void;
   onCloseConfirm: () => void;
   onConfirm: () => void;
 }>;
-
-export type FreezeViewProps = Pick<
-  FreezeCardViewProps,
-  | "isFrozen"
-  | "isBlocked"
-  | "isStatusLoading"
-  | "isFreezeLoading"
-  | "isUnfreezeLoading"
-  | "isConfirmOpen"
-  | "onOpenConfirm"
-  | "onCloseConfirm"
-  | "onConfirm"
->;
 
 export type FreezeConfirmSheetProps = Readonly<{
   isOpen: boolean;

--- a/features/flow/pay-card-details/src/types.ts
+++ b/features/flow/pay-card-details/src/types.ts
@@ -14,7 +14,11 @@ export type CardVisualProps = Readonly<{
   isLoading?: boolean;
 }>;
 
-export type CardVisualViewProps = CardVisualProps;
+export type CardVisualViewProps = CardVisualProps &
+  Readonly<{
+    /** Dims the card face and overlays the frozen marker. */
+    isFrozen: boolean;
+  }>;
 
 export type FreezeCardViewProps = Readonly<{
   isFrozen: boolean;

--- a/support/jest-features-flow/index.js
+++ b/support/jest-features-flow/index.js
@@ -15,6 +15,11 @@ const webMocks = {
   "\\.(webp|png|jpg|jpeg|gif|svg)$": path.join(__dirname, "mocks/file-stub.js"),
 };
 
+// Lumen's shared utils (`cn`, the amount formatters) ship as ESM and are real logic the views
+// call, so SWC has to compile them instead of a stub standing in — unlike the component barrels
+// above, which only need to render a DOM node. Entries match the pnpm store directory names.
+const transformAllowlist = ["@ledgerhq\\+lumen-utils-shared"];
+
 const nativeMocks = {
   // Stub react-native itself (Flow-typed ESM) so native tests run in a plain node env.
   // Mapped here (not jest.mock in a setup file) so it also intercepts react-native imports
@@ -47,6 +52,7 @@ function createFlowJestConfig(overrides = {}) {
   const base = {
     testPathIgnorePatterns,
     transform: swcTransform,
+    transformIgnorePatterns: [`node_modules/.pnpm/(?!(${transformAllowlist.join("|")}))`],
     coverageReporters,
   };
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Marks a frozen Pay card on the card visual. The face fades out behind a centered snow `Spot`, using the same card-status query as the freeze tile so the two cannot disagree.

Desktop implements the overlay. Mobile wires `isFrozen` through the shared view-model and tests (native artwork is still the existing stub). Features/flow Jest now compiles `@ledgerhq/lumen-utils-shared` so views can use `cn`.

<img width="374" height="236" alt="Screenshot 2026-09-08 at 14 31 08" src="https://github.com/user-attachments/assets/82385690-bdaf-4e94-a73f-c9afdbd030c3" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37112](https://ledgerhq.atlassian.net/browse/LIVE-37112) (desktop), [LIVE-37114](https://ledgerhq.atlassian.net/browse/LIVE-37114) (mobile)
- **ADR** (if any): n/a

[LIVE-37112]: https://ledgerhq.atlassian.net/browse/LIVE-37112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37114]: https://ledgerhq.atlassian.net/browse/LIVE-37114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ