### PR TITLE
[LWDM] refactor(lkrp): make the dependency closure publishable (LIVE-37116)

### DIFF
--- a/.changeset/lkrp-public-dependency-closure.md
+++ b/.changeset/lkrp-public-dependency-closure.md
@@ -1,0 +1,30 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": patch
+---
+
+Make the LKRP dependency closure publishable
+
+`@ledgerhq/ledger-key-ring-protocol` is meant to move out of this monorepo as-is, which requires
+every package it installs to be resolvable from outside. Two workspace-private ones were not.
+
+`@ledgerhq/speculos-transport` is replaced by a local harness in `tests/test-helpers/speculos.ts`.
+The recorder only ever needed three things from a Speculos container — exchange APDUs, press buttons,
+read the automation event stream — and all three are covered by two already-published DMK packages:
+`@ledgerhq/device-transport-kit-speculos` (`HttpSpeculosDatasource.postApdu` / `openEventStream`) and
+`@ledgerhq/speculos-device-controller` (`buttonFactory`). Both peer-depend on
+`@ledgerhq/device-management-kit`, which joins the devDependencies — without it the harness throws
+`Cannot find module` at require time. The `@ledgerhq/hw-transport` shape that
+`hw-ledger-key-ring-protocol`'s ApduDevice needs comes from implementing `exchange` alone, since the
+ledgerjs base class builds `send` on top of it. The harness is test-only: `tsconfig.build.json`
+excludes `tests/`, and only `pnpm e2e` (Docker + `COIN_APPS`) reaches it.
+
+`@shared/env` is gone from the tests, following the four exits in `libs/env/MIGRATION.md`:
+`setEnv("GET_CALLS_RETRY", 0)` was dead (`live-network` reads only `getNetworkState()`, and both
+helpers already call `setNetworkState({ getCallsRetry: 0 })` on the next line),
+`TRUSTCHAIN_API_STAGING` becomes a plain constant, and `MOCK` is dropped — nothing set it, and
+`mock.sdk.test.ts`, the only place that ever turned it on (a `setEnv`/`getEnv` round-trip in the same
+file), now passes `true` directly. `jest.setup.js` existed solely to inject env definitions before
+`getEnv()` and is removed with its last caller.
+
+The package's runtime closure is now `hw-ledger-key-ring-protocol` (which moves alongside it),
+`hw-transport`, `ledger-auth`, `live-network`, `types-devices` and `logs` — all published.

--- a/libs/ledger-key-ring-protocol/README.md
+++ b/libs/ledger-key-ring-protocol/README.md
@@ -49,15 +49,16 @@ and no network needed in CI.
     served by MSW from the recorded transactions, and `crypto` randomness is mocked from
     the recorded outputs. Each request is matched against the snapshot, so a change in SDK
     behaviour (different call, body, or order) fails the test.
-  - `mock.sdk.test.ts` runs the same scenarios against the in-memory mock SDK
-    (`MOCK=1`), skipping the ones listed as non-mockable.
+  - `mock.sdk.test.ts` runs the same scenarios against the in-memory mock SDK,
+    skipping the ones listed as non-mockable.
 
 ### Recording / re-recording a snapshot
 
 Recording runs the scenario for real — against a Speculos device (Docker) and the staging
 trustchain backend — and writes the snapshot. Prerequisites:
 
-- Docker running (Speculos is launched in a container),
+- Docker running (Speculos is launched in a container), its CLI installed in
+  `/usr/local/bin`, `/usr/bin` or `/opt/homebrew/bin`,
 - `COIN_APPS` pointing to a clone of [coin-apps](https://github.com/LedgerHQ/coin-apps)
   (provides the Ledger Sync app loaded into Speculos),
 - network access to staging.

--- a/libs/ledger-key-ring-protocol/jest.config.js
+++ b/libs/ledger-key-ring-protocol/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  setupFilesAfterEnv: ["./jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",

--- a/libs/ledger-key-ring-protocol/jest.setup.js
+++ b/libs/ledger-key-ring-protocol/jest.setup.js
@@ -1,4 +1,0 @@
-"use strict";
-
-// Ensure live-env definitions are injected before any getEnv() call in tests.
-require("@shared/env");

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -70,11 +70,12 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/device-management-kit": "catalog:",
+    "@ledgerhq/device-transport-kit-speculos": "catalog:",
     "@ledgerhq/hw-transport-mocker": "workspace:*",
-    "@ledgerhq/speculos-transport": "workspace:*",
+    "@ledgerhq/speculos-device-controller": "catalog:",
     "@ledgerhq/test-quarantine": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
-    "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
@@ -1,12 +1,10 @@
 import path from "path";
 import fs from "fs";
 import { RecordStore, TransportReplayer } from "@ledgerhq/hw-transport-mocker";
-import { getEnv, setEnv } from "@shared/env";
+import { TRUSTCHAIN_API_STAGING } from "../../../tests/test-helpers/config";
 import { ScenarioOptions } from "../../../tests/test-helpers/types";
 import { getSdk } from "../..";
 import { WithDevice } from "../../types";
-
-setEnv("MOCK", "true");
 
 const nonMockableScenarios = [
   "randomMemberTryToDestroy", // can't simulate seed<>trustchain relationship
@@ -34,11 +32,11 @@ fs.readdirSync(scenarioFolder).forEach(file => {
         withDevice,
         sdkForName: (name, opts) =>
           getSdk(
-            !!getEnv("MOCK"),
+            true, // this suite always exercises the mock SDK
             {
               applicationId: opts?.applicationId ?? 16,
               name,
-              apiBaseUrl: getEnv("TRUSTCHAIN_API_STAGING"),
+              apiBaseUrl: TRUSTCHAIN_API_STAGING,
             },
             withDevice,
           ),

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
@@ -18,7 +18,7 @@ import {
   hashCommandBlock,
   signCommandBlock,
 } from "@ledgerhq/hw-ledger-key-ring-protocol/CommandBlock";
-import { getEnv } from "@shared/env";
+import { TRUSTCHAIN_API_STAGING } from "../../../tests/test-helpers/config";
 import { PutCommandsRequest } from "../../api";
 import { HWDeviceProvider } from "../../HWDeviceProvider";
 import { SDK } from "../../sdk";
@@ -68,7 +68,7 @@ describe("Trustchain SDK", () => {
     mswServer.close();
   });
 
-  const apiBaseUrl = getEnv("TRUSTCHAIN_API_STAGING");
+  const apiBaseUrl = TRUSTCHAIN_API_STAGING;
   const sdkContext = { applicationId: 16, name: "alice", apiBaseUrl };
 
   beforeEach(() => {

--- a/libs/ledger-key-ring-protocol/tests/scenarios/tokenExpires.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/tokenExpires.ts
@@ -1,10 +1,10 @@
+import { TRUSTCHAIN_API_STAGING } from "../test-helpers/config";
 import { ScenarioOptions } from "../test-helpers/types";
 import { HWDeviceProvider } from "../../src/HWDeviceProvider";
 import { SDK } from "../../src/sdk";
-import { getEnv } from "@shared/env";
 
 export async function scenario(deviceId: string, { withDevice, pauseRecorder }: ScenarioOptions) {
-  const apiBaseUrl = getEnv("TRUSTCHAIN_API_STAGING");
+  const apiBaseUrl = TRUSTCHAIN_API_STAGING;
   const hwDeviceProvider = new HWDeviceProvider(apiBaseUrl, withDevice);
   const applicationId = 16;
   const sdk = new SDK({ applicationId, name: "Foo", apiBaseUrl }, hwDeviceProvider);

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/config.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/config.ts
@@ -1,0 +1,1 @@
+export const TRUSTCHAIN_API_STAGING = "https://trustchain-backend.api.aws.stg.ldg-tech.com";

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/recordTrustchainSdkTests.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/recordTrustchainSdkTests.ts
@@ -2,16 +2,15 @@ import fsPromises from "fs/promises";
 import zlib from "zlib";
 import { setupServer } from "msw/node";
 import { RecordStore } from "@ledgerhq/hw-transport-mocker";
-import { createSpeculosDevice, releaseSpeculosDevice } from "@ledgerhq/speculos-transport";
+import { createSpeculosDevice, releaseSpeculosDevice } from "./speculos";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { crypto, TRUSTCHAIN_APP_NAME } from "@ledgerhq/hw-ledger-key-ring-protocol";
-import { getEnv, setEnv } from "@shared/env";
 import { setNetworkState } from "@ledgerhq/live-network";
+import { TRUSTCHAIN_API_STAGING } from "./config";
 import { RecorderConfig, ScenarioOptions, genSeed, recorderConfigDefaults } from "./types";
 import { getSdk } from "../../src";
 import { WithDevice } from "../../src/types";
 
-setEnv("GET_CALLS_RETRY", 0);
 setNetworkState({ getCallsRetry: 0 });
 
 export async function recordTestTrustchainSdk(
@@ -147,11 +146,11 @@ export async function recordTestTrustchainSdk(
     withDevice,
     sdkForName: (name, opts) =>
       getSdk(
-        !!getEnv("MOCK"),
+        false,
         {
           applicationId: opts?.applicationId ?? 16,
           name,
-          apiBaseUrl: getEnv("TRUSTCHAIN_API_STAGING"),
+          apiBaseUrl: TRUSTCHAIN_API_STAGING,
         },
         withDevice,
       ),

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/replayTrustchainSdkTests.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/replayTrustchainSdkTests.ts
@@ -2,13 +2,12 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
-import { getEnv, setEnv } from "@shared/env";
 import { setNetworkState } from "@ledgerhq/live-network";
+import { TRUSTCHAIN_API_STAGING } from "./config";
 import { ScenarioOptions } from "./types";
 import { getSdk } from "../../src";
 import { WithDevice } from "../../src/types";
 
-setEnv("GET_CALLS_RETRY", 0);
 setNetworkState({ getCallsRetry: 0 });
 
 /**
@@ -125,11 +124,11 @@ export async function replayTrustchainSdkTests<Json extends JsonShape>(
       withDevice,
       sdkForName: (name, opts) =>
         getSdk(
-          !!getEnv("MOCK"),
+          false,
           {
             applicationId: opts?.applicationId ?? 16,
             name,
-            apiBaseUrl: getEnv("TRUSTCHAIN_API_STAGING"),
+            apiBaseUrl: TRUSTCHAIN_API_STAGING,
           },
           withDevice,
         ),

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/speculos.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/speculos.ts
@@ -1,0 +1,300 @@
+import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { randomInt, randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { createServer } from "node:net";
+import Transport from "@ledgerhq/hw-transport";
+import { log } from "@ledgerhq/logs";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { HttpSpeculosDatasource } from "@ledgerhq/device-transport-kit-speculos";
+import {
+  type ButtonKey,
+  deviceControllerClientFactory,
+} from "@ledgerhq/speculos-device-controller";
+import { Observable, share } from "rxjs";
+
+/**
+ * Minimal Speculos harness for the LKRP recorder.
+ *
+ * The recorder needs three things from a Speculos container: exchange APDUs,
+ * press buttons and observe the automation event stream. All three are covered
+ * by the two published DMK packages imported above, so this file deliberately
+ * avoids `@ledgerhq/speculos-transport` and `@ledgerhq/live-dmk-speculos`: both
+ * are private to this monorepo, and the latter carries a DMK session cache,
+ * device discovery and reconnect logic that only the Live apps need.
+ *
+ * Keeping it here means the LKRP packages depend on published code only, which
+ * is what lets them move out of this repo. It is test-only: `tsconfig.build.json`
+ * excludes `tests/`, and only `pnpm e2e` (Docker + COIN_APPS) reaches it.
+ */
+
+/** Directory name used under `coinapps`, per the coin-apps repository layout. */
+const APP_DIR_BY_MODEL: Partial<Record<DeviceModelId, string>> = {
+  [DeviceModelId.nanoS]: "nanos",
+  [DeviceModelId.nanoSP]: "nanos+",
+  [DeviceModelId.nanoX]: "nanox",
+  [DeviceModelId.stax]: "stax",
+  [DeviceModelId.europa]: "flex",
+};
+
+/** Value expected by the Speculos `--model` flag. */
+const SPECULOS_MODEL: Partial<Record<DeviceModelId, string>> = {
+  [DeviceModelId.nanoS]: "nanos",
+  [DeviceModelId.nanoSP]: "nanosp",
+  [DeviceModelId.nanoX]: "nanox",
+  [DeviceModelId.stax]: "stax",
+  [DeviceModelId.europa]: "flex",
+};
+
+const DEFAULT_IMAGE = "ghcr.io/ledgerhq/speculos:sha-e262a0c";
+
+/** Generous enough to cover a cold `docker run` that first pulls the image. */
+const BOOT_TIMEOUT_MS = 180_000;
+
+const DOCKER_PATHS = ["/usr/local/bin/docker", "/usr/bin/docker", "/opt/homebrew/bin/docker"];
+
+/** Resolving plain `docker` through `PATH` lets a writable PATH entry shadow the binary. */
+function dockerBin(): string {
+  const bin = DOCKER_PATHS.find(existsSync);
+  if (!bin) throw new Error(`Docker CLI not found in ${DOCKER_PATHS.join(", ")}`);
+  return bin;
+}
+
+export type SpeculosDeviceParams = {
+  model: DeviceModelId;
+  firmware: string;
+  appName: string;
+  appVersion: string;
+  seed: string;
+  /** Root folder holding the app binaries (a clone of LedgerHQ/coin-apps). */
+  coinapps: string;
+};
+
+export type SpeculosDevice = {
+  id: string;
+  transport: SpeculosApduTransport;
+};
+
+/**
+ * A `@ledgerhq/hw-transport` over the Speculos REST API.
+ *
+ * Only `exchange` is implemented: the base class builds `send` on top of it,
+ * which is all `@ledgerhq/hw-ledger-key-ring-protocol`'s ApduDevice uses.
+ */
+export class SpeculosApduTransport extends Transport {
+  private readonly datasource: HttpSpeculosDatasource;
+  private buttons: ReturnType<
+    ReturnType<typeof deviceControllerClientFactory>["buttonFactory"]
+  > | null = null;
+
+  /**
+   * Speculos automation events. Lazy: the SSE stream opens on first
+   * subscription and is torn down when the last subscriber leaves.
+   */
+  readonly automationEvents: Observable<Record<string, unknown>>;
+
+  constructor(private readonly baseUrl: string) {
+    super();
+    this.datasource = new HttpSpeculosDatasource(baseUrl);
+    this.automationEvents = this.createAutomationEvents$();
+  }
+
+  private createAutomationEvents$(): Observable<Record<string, unknown>> {
+    return new Observable<Record<string, unknown>>(observer => {
+      let stream: { cancel?: () => Promise<void> } | null = null;
+      let unsubscribed = false;
+
+      this.datasource
+        .openEventStream(
+          event => observer.next(event),
+          () => observer.complete(),
+        )
+        .then(opened => {
+          if (unsubscribed) {
+            opened.cancel?.().catch(() => {});
+          } else {
+            stream = opened;
+          }
+        })
+        .catch(error => {
+          log("speculos-event", `SSE connection error: ${String(error)}`);
+          observer.error(error);
+        });
+
+      return () => {
+        unsubscribed = true;
+        stream?.cancel?.().catch(() => {});
+      };
+    }).pipe(share({ resetOnRefCountZero: true }));
+  }
+
+  async exchange(apdu: Buffer): Promise<Buffer> {
+    const request = apdu.toString("hex");
+    log("apdu", "=> " + request);
+    const response = await this.datasource.postApdu(request);
+    log("apdu", "<= " + response);
+    return Buffer.from(response, "hex");
+  }
+
+  async button(key: ButtonKey): Promise<void> {
+    if (!this.buttons) {
+      this.buttons = deviceControllerClientFactory(this.baseUrl).buttonFactory();
+    }
+    log("speculos-button", "press-and-release", key);
+    return this.buttons.press(key);
+  }
+
+  async close(): Promise<void> {
+    this.buttons = null;
+  }
+}
+
+const devices: Record<
+  string,
+  { process: ChildProcessWithoutNullStreams; destroy: () => Promise<void> }
+> = {};
+
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => server.close(() => resolve(true)));
+    server.listen(port);
+  });
+}
+
+async function getAvailablePort(): Promise<number> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const port = randomInt(61000, 65536);
+    if (await isPortAvailable(port)) return port;
+  }
+  throw new Error("Failed to find an available port for Speculos after 10 attempts");
+}
+
+function appSubpath({ model, firmware, appName, appVersion }: SpeculosDeviceParams): string {
+  const dir = APP_DIR_BY_MODEL[model];
+  if (!dir) throw new Error(`Unsupported Speculos device model: ${model}`);
+  return `${dir}/${firmware}/${appName.replaceAll(" ", "")}/app_${appVersion}.elf`;
+}
+
+/** Boots a Speculos container running `appName` and connects a transport to it. */
+export async function createSpeculosDevice(params: SpeculosDeviceParams): Promise<SpeculosDevice> {
+  const { model, seed, coinapps } = params;
+  const speculosModel = SPECULOS_MODEL[model];
+  if (!speculosModel) throw new Error(`Unsupported Speculos device model: ${model}`);
+
+  const id = `speculosID-${randomUUID()}`;
+  const docker = dockerBin();
+  const apiPort = await getAvailablePort();
+
+  const args = [
+    "run",
+    "-v",
+    `${coinapps}:/speculos/apps:ro`,
+    "-p",
+    `${apiPort}:40000`,
+    "--name",
+    id,
+    process.env.SPECULOS_IMAGE_TAG ?? DEFAULT_IMAGE,
+    "--model",
+    speculosModel,
+    `./apps/${appSubpath(params)}`,
+    "--display",
+    "headless",
+    "--api-port",
+    "40000",
+    "--seed",
+    seed,
+  ];
+
+  const loggedArgs = args.map((arg, i) => (args[i - 1] === "--seed" ? "<redacted>" : arg));
+  log("speculos", `${id}: spawning = ${loggedArgs.join(" ")}`);
+  const child = spawn(docker, args);
+
+  let stdout = "";
+  let stderr = "";
+  let destroyed = false;
+
+  const destroy = () =>
+    new Promise<void>((resolve, reject) => {
+      if (destroyed) return resolve();
+      destroyed = true;
+      delete devices[id];
+      const rm = spawn(docker, ["rm", "-f", id]);
+      const fail = (error: Error) => {
+        log("speculos-error", `${id} not destroyed: ${String(error)}`);
+        reject(error);
+      };
+      rm.on("error", fail);
+      rm.on("close", code => {
+        if (code !== 0) {
+          fail(new Error(`docker rm -f ${id} exited with code ${String(code)}`));
+        } else {
+          log("speculos", `destroyed ${id}`);
+          resolve();
+        }
+      });
+    });
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const done = () => {
+      clearTimeout(bootTimer);
+      resolve();
+    };
+
+    const fail = (message: string) => {
+      clearTimeout(bootTimer);
+      const extra = [stdout && `--- stdout ---\n${stdout}`, stderr && `--- stderr ---\n${stderr}`]
+        .filter(Boolean)
+        .join("\n");
+      reject(new Error(extra ? `${message}\n\n${extra}` : message));
+    };
+
+    const bootTimer = setTimeout(() => {
+      destroy().catch(() => {});
+      fail(`Speculos did not become ready within ${BOOT_TIMEOUT_MS}ms`);
+    }, BOOT_TIMEOUT_MS);
+
+    child.on("error", error => fail(`Speculos could not be spawned: ${String(error)}`));
+
+    child.stdout.on("data", data => {
+      const text = String(data).trim();
+      if (!text) return;
+      stdout += (stdout ? "\n" : "") + text;
+      log("speculos-stdout", `${id}: ${text}`);
+    });
+
+    child.stderr.on("data", data => {
+      const text = String(data).trim();
+      if (!text) return;
+      stderr += (stderr ? "\n" : "") + text;
+      if (!text.includes("apdu: ")) log("speculos-stderr", `${id}: ${text}`);
+
+      // Speculos logs this once the emulator is up and listening.
+      if (/using\s(?:SDK|API_LEVEL)/.test(text)) {
+        setTimeout(done, 500);
+      } else if (text.includes("is already in use by") || text.includes("address already in use")) {
+        fail("Speculos could not start: the container name or port is already in use");
+      }
+    });
+
+    child.on("close", async () => {
+      log("speculos", `${id} closed`);
+      if (!destroyed) {
+        await destroy().catch(() => {});
+        fail("Speculos process exited unexpectedly");
+      }
+    });
+  });
+
+  await ready;
+
+  devices[id] = { process: child, destroy };
+
+  return { id, transport: new SpeculosApduTransport(`http://127.0.0.1:${apiPort}`) };
+}
+
+/** Stops and removes a device created by {@link createSpeculosDevice}. */
+export async function releaseSpeculosDevice(id: string): Promise<void> {
+  log("speculos", "release " + id);
+  await devices[id]?.destroy();
+}

--- a/libs/ledger-key-ring-protocol/tests/tsconfig.json
+++ b/libs/ledger-key-ring-protocol/tests/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
       "noEmit": true,
       "esModuleInterop": true,
-      "lib": ["es2020"],
+      "lib": ["es2021"],
       "types": ["jest"]
   }
 }

--- a/libs/ledger-key-ring-protocol/tsconfig.json
+++ b/libs/ledger-key-ring-protocol/tsconfig.json
@@ -5,7 +5,7 @@
     "declarationMap": true,
     "noImplicitAny": false,
     "noImplicitThis": false,
-    "lib": ["es2020", "dom"],
+    "lib": ["es2021", "dom"],
     "types": ["node", "jest"],
     "outDir": "lib",
     "rootDir": "."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12830,21 +12830,24 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/device-management-kit':
+        specifier: 'catalog:'
+        version: 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/device-transport-kit-speculos':
+        specifier: 'catalog:'
+        version: 1.2.1(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport-mocker':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport-mocker
-      '@ledgerhq/speculos-transport':
-        specifier: workspace:*
-        version: link:../speculos-transport
+      '@ledgerhq/speculos-device-controller':
+        specifier: 'catalog:'
+        version: 0.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/test-quarantine':
         specifier: workspace:*
         version: link:../../support/test-quarantine
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
-      '@shared/env':
-        specifier: workspace:*
-        version: link:../../shared/env
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -35427,10 +35430,6 @@ packages:
   minipass-fetch@2.1.2:
     resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
-  minipass-flush@1.0.5:
-    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
-    engines: {node: '>= 8'}
 
   minipass-flush@1.0.7:
     resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
@@ -64801,7 +64800,7 @@ snapshots:
       minipass: 3.3.6
       minipass-collect: 1.0.2
       minipass-fetch: 1.4.1
-      minipass-flush: 1.0.5
+      minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
@@ -66079,11 +66078,6 @@ snapshots:
       minizlib: 2.1.2
     optionalDependencies:
       encoding: 0.1.13
-
-  minipass-flush@1.0.5:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
 
   minipass-flush@1.0.7:
     dependencies:


### PR DESCRIPTION
- [x] locally confirm that the recorder still works

### 📝 Description

`@ledgerhq/ledger-key-ring-protocol` is meant to leave this monorepo **as-is** (not gated on the LKRP SDK split from [architecture-as-code#380](https://github.com/LedgerHQ/architecture-as-code/pull/380)). For that, every package it installs must resolve from outside — `devDependencies` included, since they are installed in the target repo too. Two workspace-private ones were not.

**1. `@ledgerhq/speculos-transport` → a local harness.** No new package: `tests/test-helpers/speculos.ts`, next to its only consumer. The recorder needs exactly three things from a Speculos container, and all three are already published:

| Need | Published source |
| --- | --- |
| exchange APDUs | `HttpSpeculosDatasource.postApdu` — `@ledgerhq/device-transport-kit-speculos` |
| automation event stream | `HttpSpeculosDatasource.openEventStream` — same package |
| button presses | `deviceControllerClientFactory(url).buttonFactory()` — `@ledgerhq/speculos-device-controller` |

The `@ledgerhq/hw-transport` shape comes for free: `hw-ledger-key-ring-protocol`'s `ApduDevice` only ever calls `transport.send` (12×) and `transport.close` (1×), and `send` is a **concrete** method on the ledgerjs base class written in terms of `exchange`. So implementing `exchange` alone is sufficient:

```ts
async exchange(apdu: Buffer): Promise<Buffer> {
  return Buffer.from(await this.datasource.postApdu(apdu.toString("hex")), "hex");
}
```

This deliberately does **not** reuse `@ledgerhq/live-dmk-speculos`, whose 283 lines exist for the Live apps (DMK session cache per baseURL, device discovery, reconnect-on-APDU-failure, model passthrough) and are dead weight for a recorder talking to a container it just booted itself.

**2. `@shared/env` → gone from the tests**, per the four exits in `libs/env/MIGRATION.md`:

- `setEnv("GET_CALLS_RETRY", 0)` (×2) was **dead code**: `live-network` reads only `getNetworkState().getCallsRetry`, never `getEnv`, and both helpers already call `setNetworkState({ getCallsRetry: 0 })` on the very next line.
- `TRUSTCHAIN_API_STAGING` (×5) → plain **constant**, keeping the env definition's default. Nothing ever set the variable, so there is no override to keep.
- `MOCK` → **dropped**. The only place that turned it on was `mock.sdk.test.ts`, via a `setEnv` then `getEnv` round-trip in the same file; it now passes `true` directly, and the record/replay helpers pass `false`.
- `jest.setup.js` existed solely to `require("@shared/env")` before any `getEnv()`. It goes with its last caller.

### Result

LKRP's runtime closure is now `hw-ledger-key-ring-protocol` (which moves alongside it), `hw-transport`, `ledger-auth`, `live-network`, `types-devices`, `logs` — all published. `hw-ledger-key-ring-protocol`'s own closure is just `hw-transport` → `devices`, both published, and it has zero `@shared/env`.

> [!NOTE]
> One workspace-private devDependency remains: `@ledgerhq/test-quarantine` (`support/`, flaky-test retries + reporter in `jest.config.js`). Left untouched on purpose — it is CI infrastructure, unrelated to this cleanup, and the plan is to drop it at move time rather than publish a `0.0.0` internal package.

### ✅ Checks

`typecheck`, `build`, `lint` and 91/91 jest tests green on `@ledgerhq/ledger-key-ring-protocol`.

Verified against a real Speculos container and staging (nanoS+ 1.1.2, Ledger Sync 1.0.1, local `coin-apps` clone):

- boot → APDU exchange → `button()` → automation SSE stream → release, container removed on teardown;
- scenarios `create2trustchainInARow`, `userRefusesAuth` and `twoAddMembersFollowedByDeviceAdd` replayed live end-to-end (`RUN_EVEN_IF_SNAPSHOT_EXISTS` path, snapshots untouched).

That run is what surfaced the missing `@ledgerhq/device-management-kit` devDependency: both DMK packages peer-depend on it, so `require` of the harness threw `Cannot find module` — invisible to typecheck and to the unit suite, since only `pnpm e2e` loads that file.

> [!NOTE]
> `success` fails at its last line, where the just-removed member 2 calls `destroyTrustchain`: staging now answers `Not a member of trustchain`, while the committed snapshot recorded `200` + `204`. Backend drift, unrelated to this PR (no device involved in that call) — it will need a re-record. CI is unaffected: the suites replay snapshots.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37116](https://ledgerhq.atlassian.net/browse/LIVE-37116)
- **ADR** (if any): none. Prepares the ground for moving LKRP out; independent of the SDK split in [architecture-as-code#380](https://github.com/LedgerHQ/architecture-as-code/pull/380).


[LIVE-37116]: https://ledgerhq.atlassian.net/browse/LIVE-37116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
