### PR TITLE
fix(pay): keep request qr scannable in light

### DIFF
--- a/.changeset/pay-request-receive-qr-light.md
+++ b/.changeset/pay-request-receive-qr-light.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-request": minor
+"@features/flow-pay-contact": patch
+"live-mobile": minor
+---
+
+Keep the Pay Request receive QR scannable in light on mobile (white card, black modules) and use base color for Pay tab contact names (LIVE-37096).

--- a/features/flow/pay-contact/src/components/ContactTile/ContactTile.native.tsx
+++ b/features/flow/pay-contact/src/components/ContactTile/ContactTile.native.tsx
@@ -22,7 +22,7 @@ export function ContactTile({ contact, index, onPress }: ContactTileProps): Reac
     >
       <ContactAvatar contactId={contact.id} name={contact.name} size="lg" />
       <TileContent>
-        <TileTitle lx={{ color: "muted" }}>{contact.name}</TileTitle>
+        <TileTitle lx={{ color: "base" }}>{contact.name}</TileTitle>
       </TileContent>
     </Tile>
   );

--- a/features/flow/pay-contact/src/components/PayTile/PayTile.native.tsx
+++ b/features/flow/pay-contact/src/components/PayTile/PayTile.native.tsx
@@ -19,7 +19,7 @@ export function PayTile({ label, onPress }: PayTileProps): React.JSX.Element {
     >
       <Spot size={56} appearance="icon" icon={Telegram} />
       <TileContent>
-        <TileTitle lx={{ color: "muted" }}>{label}</TileTitle>
+        <TileTitle lx={{ color: "base" }}>{label}</TileTitle>
       </TileContent>
     </Tile>
   );

--- a/features/flow/pay-request/src/components/RequestReceive/RequestReceiveAddress.native.tsx
+++ b/features/flow/pay-request/src/components/RequestReceive/RequestReceiveAddress.native.tsx
@@ -13,17 +13,17 @@ export function RequestReceiveAddress({ addressParts }: RequestReceiveAddressPro
 
   return (
     <Text
-      typography="body2"
+      typography="body1"
       lx={{ color: "muted", textAlign: "center" }}
       testID="pay-request-receive-address"
     >
-      <Text typography="body2SemiBold" lx={{ color: "base" }}>
+      <Text typography="body1" lx={{ color: "base" }}>
         {start}
       </Text>
       {middleFirstLine}
       {middle ? "\n" : null}
       {middleSecondLine}
-      <Text typography="body2SemiBold" lx={{ color: "base" }}>
+      <Text typography="body1" lx={{ color: "base" }}>
         {end}
       </Text>
     </Text>

--- a/features/flow/pay-request/src/components/RequestReceive/RequestReceiveSummary.native.tsx
+++ b/features/flow/pay-request/src/components/RequestReceive/RequestReceiveSummary.native.tsx
@@ -37,11 +37,11 @@ export function RequestReceiveSummary({
       lx={{
         alignItems: "center",
         alignSelf: "stretch",
-        backgroundColor: "surface",
-        borderRadius: "2xl",
         gap: "s32",
         padding: "s24",
         width: "full",
+        backgroundColor: "surface",
+        borderRadius: "md",
       }}
       testID="pay-request-receive-summary"
     >
@@ -67,18 +67,32 @@ export function RequestReceiveSummary({
           </Text>
         </Box>
       </Box>
-      <QrCode
-        value={qrPayload}
-        testID="pay-request-receive-qr-code"
-        centerContent={
-          <CryptoIcon
-            ledgerId={assetIcon.ledgerId}
-            ticker={assetIcon.ticker}
-            size={QR_CENTER_ICON_SIZE}
-            shape="circle"
-          />
-        }
-      />
+      <Box
+        lx={{
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "s24",
+          backgroundColor: "white",
+          borderRadius: "2xl",
+          borderWidth: "s1",
+          borderColor: "mutedSubtle",
+          boxShadow: "lg",
+        }}
+      >
+        <QrCode
+          value={qrPayload}
+          foregroundColor="#000000"
+          testID="pay-request-receive-qr-code"
+          centerContent={
+            <CryptoIcon
+              ledgerId={assetIcon.ledgerId}
+              ticker={assetIcon.ticker}
+              size={QR_CENTER_ICON_SIZE}
+              shape="circle"
+            />
+          }
+        />
+      </Box>
       <RequestReceiveAddress addressParts={addressParts} />
     </Box>
   );

--- a/features/flow/pay-request/src/components/RequestReceive/__tests__/RequestReceiveView.native.test.tsx
+++ b/features/flow/pay-request/src/components/RequestReceive/__tests__/RequestReceiveView.native.test.tsx
@@ -6,9 +6,21 @@ import { createRequestReceiveViewProps, REQUEST_RECEIVE_LABELS } from "./fixture
 const VERIFY_HINT_COPY = "Verify your address on your Ledger device before sharing";
 
 jest.mock("@shared/ui-qr-code", () => ({
-  QrCode: ({ value, testID }: { value: string; testID?: string }) => {
+  QrCode: ({
+    value,
+    testID,
+    foregroundColor,
+  }: {
+    value: string;
+    testID?: string;
+    foregroundColor?: string;
+  }) => {
     const React = require("react");
-    return React.createElement("View", { testID }, React.createElement("Text", null, value));
+    return React.createElement(
+      "View",
+      { testID, foregroundColor },
+      React.createElement("Text", null, value),
+    );
   },
 }));
 
@@ -25,6 +37,10 @@ describe("RequestReceiveView (Native)", () => {
     expect(screen.getByTestId("pay-request-receive-summary")).toBeVisible();
     expect(screen.getByText(REQUEST_RECEIVE_LABELS.title)).toBeVisible();
     expect(screen.getByTestId("pay-request-receive-qr-code")).toBeVisible();
+    expect(screen.getByTestId("pay-request-receive-qr-code")).toHaveProp(
+      "foregroundColor",
+      "#000000",
+    );
     expect(screen.getByTestId("pay-request-receive-address")).toBeVisible();
     expect(screen.getByText(REQUEST_RECEIVE_LABELS.actions.share)).toBeVisible();
     expect(screen.getByText(REQUEST_RECEIVE_LABELS.actions.copy)).toBeVisible();

--- a/features/flow/pay-request/src/utils/__tests__/splitMiddleForTwoLines.native.test.ts
+++ b/features/flow/pay-request/src/utils/__tests__/splitMiddleForTwoLines.native.test.ts
@@ -11,7 +11,7 @@ function lineLengths(address: string) {
 }
 
 describe("splitMiddleForTwoLines", () => {
-  it("keeps about 55% of the address on the second line", () => {
+  it("keeps about 51% of the address on the second line", () => {
     for (const address of [
       "0x1234567890abcdef1234567890abcdef12345678",
       "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq0dxpg8ndv0hqm",
@@ -20,7 +20,7 @@ describe("splitMiddleForTwoLines", () => {
       const [first, second] = lineLengths(address);
 
       expect(first).toBeLessThan(second);
-      expect(second / address.length).toBeGreaterThanOrEqual(0.55);
+      expect(second / address.length).toBeGreaterThanOrEqual(0.51);
     }
   });
 

--- a/features/flow/pay-request/src/utils/splitMiddleForTwoLines.native.ts
+++ b/features/flow/pay-request/src/utils/splitMiddleForTwoLines.native.ts
@@ -1,6 +1,6 @@
 import type { AddressParts } from "./splitAddress";
 
-const SECOND_LINE_RATIO = 0.55;
+const SECOND_LINE_RATIO = 0.51;
 
 export function splitMiddleForTwoLines(
   { start, middle, end }: AddressParts,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

In light theme the Pay Request receive QR used the shared default of white modules on a light surface, so the code was unscannable. Pay tab contact names and the New tile used muted gray.

Mobile only: black modules on a white framed card (Contacts-style). Title, QR, and address sit on a `surface` capture card so Share PNGs are opaque. Screen stays `canvas`. Address is `body1` (no edge SemiBold), two-line wrap is 49/51. Contact / New tile titles use `base`. Tests assert the black QR foreground. Desktop is unchanged.

**Problem**: Light-theme Request QR did not scan on mobile; contact rows looked washed out.

**Solution**:
- Force QR `foregroundColor` to black and frame it on white (native)
- Capture zone uses `surface` (same as the action tiles)
- Pay contact / New tile titles use `base`

### Screenshots

<img width="373" height="781" alt="image" src="https://github.com/user-attachments/assets/bba38ff2-2916-4023-94db-abd3310bf391" />

<img width="394" height="790" alt="image" src="https://github.com/user-attachments/assets/92bf0de4-abfa-4cc3-969c-ba2ba397eb52" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37096](https://ledgerhq.atlassian.net/browse/LIVE-37096)
- **ADR** (if any):

### Test plan

- [ ] Light theme: Pay → Request — QR is black and scannable on a white card; screen is `canvas`
- [ ] Dark theme: same screen readable; Share PNG has a `surface` card (title + QR + address), not a transparent crop
- [ ] Pay tab: contact names and the New tile use `base` (black in light)
- [ ] Desktop Request dialog: unchanged

[LIVE-37096]: https://ledgerhq.atlassian.net/browse/LIVE-37096