### PR TITLE
[LWD] feat(desktop): add Q3 Wallet V4 Tour setup (LIVE-36385)

### DIFF
--- a/.changeset/calm-q3-tour-desktop.md
+++ b/.changeset/calm-q3-tour-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Q3 Wallet V4 Tour persisted seen state and desktop debug setup, gated by releaseTour.

--- a/.changeset/calm-q3-tour-desktop.md
+++ b/.changeset/calm-q3-tour-desktop.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": minor
 ---
 
-Add Q3 Wallet V4 Tour persisted seen state and desktop debug setup, gated by releaseTour.
+Add Q3 tour persisted seen state and Wallet Features debug controls on desktop, gated by releaseTour (q3_a) rather than lwdWallet40. Open Drawer stays disabled.

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -402,6 +402,11 @@ export const setHasSeenQ2Tour = (hasSeenQ2Tour: boolean) => ({
   payload: hasSeenQ2Tour,
 });
 
+export const setHasSeenQ3Tour = (hasSeenQ3Tour: boolean) => ({
+  type: "SET_HAS_SEEN_Q3_TOUR",
+  payload: hasSeenQ3Tour,
+});
+
 export const setProductTourCompleted = (productTourCompleted: boolean) => ({
   type: SET_PRODUCT_TOUR_COMPLETED,
   payload: productTourCompleted,

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -131,6 +131,7 @@ export type SettingsState = {
   anonymousUserNotifications: { LNSUpsell?: number } & Record<string, number>;
   hasSeenWalletV4Tour: boolean;
   hasSeenQ2Tour: boolean;
+  hasSeenQ3Tour: boolean;
   productTourCompleted: boolean;
   hasDismissedContactsFeatureIntroduction: boolean;
   hasClickedRecover: boolean;
@@ -239,6 +240,7 @@ export const INITIAL_STATE: SettingsState = {
   anonymousUserNotifications: {},
   hasSeenWalletV4Tour: false,
   hasSeenQ2Tour: false,
+  hasSeenQ3Tour: false,
   productTourCompleted: false,
   hasDismissedContactsFeatureIntroduction: false,
   hasClickedRecover: false,
@@ -307,6 +309,7 @@ type HandlersPayloads = {
   };
   SET_HAS_SEEN_WALLET_V4_TOUR: boolean;
   SET_HAS_SEEN_Q2_TOUR: boolean;
+  SET_HAS_SEEN_Q3_TOUR: boolean;
   [SET_PRODUCT_TOUR_COMPLETED]: boolean;
   [SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION]: boolean;
   SET_HAS_CLICKED_RECOVER: boolean;
@@ -542,6 +545,10 @@ const handlers: SettingsHandlers = {
   SET_HAS_SEEN_Q2_TOUR: (state: SettingsState, { payload }) => ({
     ...state,
     hasSeenQ2Tour: payload,
+  }),
+  SET_HAS_SEEN_Q3_TOUR: (state: SettingsState, { payload }) => ({
+    ...state,
+    hasSeenQ3Tour: payload,
   }),
   [SET_PRODUCT_TOUR_COMPLETED]: (state: SettingsState, { payload }) => ({
     ...state,
@@ -877,6 +884,7 @@ export const anonymousUserNotificationsSelector = (state: State) =>
   state.settings.anonymousUserNotifications;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
 export const hasSeenQ2TourSelector = (state: State) => state.settings.hasSeenQ2Tour;
+export const hasSeenQ3TourSelector = (state: State) => state.settings.hasSeenQ3Tour;
 export const productTourCompletedSelector = (state: State) => state.settings.productTourCompleted;
 
 export const hasDismissedContactsFeatureIntroductionSelector = (state: State) =>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/WalletFeaturesDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/WalletFeaturesDevToolContent.tsx
@@ -10,6 +10,7 @@ import {
   MainFeatureToggle,
   TourSection,
   Q2TourSection,
+  Q3TourSection,
 } from "./components";
 import { Divider } from "@ledgerhq/lumen-ui-react";
 import {
@@ -17,6 +18,7 @@ import {
   WalletV4TourDialog,
 } from "LLD/features/WalletV4Tour/Drawer";
 import { Q2TourDialog, useQ2TourDrawerViewModel } from "LLD/features/Q2Tour";
+
 export const WalletFeaturesDevToolContent = ({ expanded }: WalletFeaturesDevToolContentProps) => {
   const { t } = useTranslation();
   const {
@@ -27,12 +29,16 @@ export const WalletFeaturesDevToolContent = ({ expanded }: WalletFeaturesDevTool
     hasSeenWalletV4Tour,
     hasSeenQ2Tour,
     isQ2TourEnabled,
+    hasSeenQ3Tour,
+    isQ3TourEnabled,
     handleToggleAll,
     handleToggleEnabled,
     handleToggleParam,
     handleToggleHasSeenTour,
     handleToggleQ2TourHasSeen,
     handleToggleQ2TourEnabled,
+    handleToggleQ3TourHasSeen,
+    handleToggleQ3TourEnabled,
   } = useWalletFeaturesDevToolViewModel();
   const { isDialogOpen, handleOpenDialog, closeDrawer, completeDrawer, onSlideChange } =
     useWalletV4TourDrawerViewModel();
@@ -91,6 +97,13 @@ export const WalletFeaturesDevToolContent = ({ expanded }: WalletFeaturesDevTool
             onToggleHasSeen={handleToggleQ2TourHasSeen}
             onToggleEnabled={handleToggleQ2TourEnabled}
             onOpenDrawer={handleOpenQ2Tour}
+          />
+
+          <Q3TourSection
+            hasSeen={hasSeenQ3Tour}
+            isEnabled={isQ3TourEnabled}
+            onToggleHasSeen={handleToggleQ3TourHasSeen}
+            onToggleEnabled={handleToggleQ3TourEnabled}
           />
 
           <TourSection

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/__integrations__/Q3TourSetup.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/__integrations__/Q3TourSetup.integration.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import { selectFeature } from "@shared/feature-flags";
+import { Q3TourSection } from "../components/Q3TourSection";
+import { useWalletFeaturesDevToolViewModel } from "../hooks/useWalletFeaturesDevToolViewModel";
+import {
+  hasSeenQ2TourSelector,
+  hasSeenQ3TourSelector,
+  hasSeenWalletV4TourSelector,
+} from "~/renderer/reducers/settings";
+
+function Q3TourSetupHarness() {
+  const { hasSeenQ3Tour, isQ3TourEnabled, handleToggleQ3TourHasSeen, handleToggleQ3TourEnabled } =
+    useWalletFeaturesDevToolViewModel();
+
+  return (
+    <Q3TourSection
+      hasSeen={hasSeenQ3Tour}
+      isEnabled={isQ3TourEnabled}
+      onToggleHasSeen={handleToggleQ3TourHasSeen}
+      onToggleEnabled={handleToggleQ3TourEnabled}
+    />
+  );
+}
+
+const getFlagSwitch = () => screen.getAllByRole("switch")[0];
+const getHasSeenSwitch = () => screen.getAllByRole("switch")[1];
+
+describe("Q3 Tour setup", () => {
+  it("should toggle the Q3 tour flag independently", async () => {
+    const { user, store } = render(<Q3TourSetupHarness />);
+
+    expect(selectFeature(store.getState(), "releaseTour")?.enabled).toBe(false);
+
+    await user.click(getFlagSwitch());
+
+    expect(selectFeature(store.getState(), "releaseTour")?.enabled).toBe(true);
+    expect(selectFeature(store.getState(), "releaseTour")?.params?.variant).toBe("q3_a");
+  });
+
+  it("should toggle the persisted Q3 tour seen state independently", async () => {
+    const { user, store } = render(<Q3TourSetupHarness />);
+
+    expect(hasSeenQ3TourSelector(store.getState())).toBe(false);
+
+    await user.click(getHasSeenSwitch());
+
+    expect(hasSeenQ3TourSelector(store.getState())).toBe(true);
+    expect(hasSeenQ2TourSelector(store.getState())).toBe(false);
+    expect(hasSeenWalletV4TourSelector(store.getState())).toBe(false);
+  });
+
+  it("should keep Open Drawer disabled", () => {
+    render(<Q3TourSetupHarness />, {
+      initialState: withFlagOverrides({
+        releaseTour: { enabled: true, params: { variant: "q3_a" } },
+      }),
+    });
+
+    expect(screen.getByRole("button", { name: /open drawer/i })).toBeDisabled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/Q3TourSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/Q3TourSection.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Divider } from "@ledgerhq/lumen-ui-react";
+import { DeveloperToggleRow } from "../../components/DeveloperToggleRow";
+
+interface Q3TourSectionProps {
+  readonly hasSeen: boolean;
+  readonly isEnabled: boolean;
+  readonly onToggleHasSeen: () => void;
+  readonly onToggleEnabled: () => void;
+}
+
+export const Q3TourSection = ({
+  hasSeen,
+  isEnabled,
+  onToggleHasSeen,
+  onToggleEnabled,
+}: Q3TourSectionProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="body-2-semi-bold text-muted">Q3 Tour</span>
+      <Divider />
+      <DeveloperToggleRow
+        name="wallet-feature-q3-tour-enabled"
+        label="Q3 release tour"
+        selected={isEnabled}
+        onChange={onToggleEnabled}
+        description="Toggles releaseTour enabled with variant q3_a."
+      />
+      <DeveloperToggleRow
+        name="wallet-feature-q3-tour-has-seen"
+        label="Has Seen Q3 Tour"
+        selected={hasSeen}
+        onChange={onToggleHasSeen}
+        description={
+          hasSeen
+            ? "User has already seen the tour. Toggle to reset."
+            : "User has not seen the tour yet."
+        }
+      />
+      <Button appearance="accent" size="sm" disabled>
+        {t("settings.developer.walletFeaturesDevTool.openDrawer")}
+      </Button>
+    </div>
+  );
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/index.ts
@@ -4,3 +4,4 @@ export { FeatureFlagPreview } from "./FeatureFlagPreview";
 export { MainFeatureToggle } from "./MainFeatureToggle";
 export { TourSection } from "./TourSection";
 export { Q2TourSection } from "./Q2TourSection";
+export { Q3TourSection } from "./Q3TourSection";

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/hooks/useWalletFeaturesDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/hooks/useWalletFeaturesDevToolViewModel.ts
@@ -2,9 +2,20 @@ import { useCallback, useMemo } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { useFeature } from "@features/platform-feature-flags";
 import { setOverride } from "@shared/feature-flags";
-import { hasSeenWalletV4TourSelector, hasSeenQ2TourSelector } from "~/renderer/reducers/settings";
-import { setHasSeenWalletV4Tour, setHasSeenQ2Tour } from "~/renderer/actions/settings";
-import { isQ2ReleaseTourEnabled } from "LLD/features/Q2Tour/releaseTourGate";
+import {
+  hasSeenWalletV4TourSelector,
+  hasSeenQ2TourSelector,
+  hasSeenQ3TourSelector,
+} from "~/renderer/reducers/settings";
+import {
+  setHasSeenWalletV4Tour,
+  setHasSeenQ2Tour,
+  setHasSeenQ3Tour,
+} from "~/renderer/actions/settings";
+import {
+  isQ2ReleaseTourEnabled,
+  isQ3ReleaseTourEnabled,
+} from "LLD/features/Q2Tour/releaseTourGate";
 import {
   RELEASE_TOUR_FLAG,
   WALLET_FEATURES_FLAG,
@@ -19,9 +30,11 @@ export const useWalletFeaturesDevToolViewModel = (): WalletFeaturesViewModel => 
   const releaseTour = useFeature(RELEASE_TOUR_FLAG);
   const hasSeenWalletV4Tour = useSelector(hasSeenWalletV4TourSelector);
   const hasSeenQ2Tour = useSelector(hasSeenQ2TourSelector);
+  const hasSeenQ3Tour = useSelector(hasSeenQ3TourSelector);
 
   const isEnabled = featureFlag?.enabled ?? false;
   const isQ2TourEnabled = isQ2ReleaseTourEnabled(releaseTour);
+  const isQ3TourEnabled = isQ3ReleaseTourEnabled(releaseTour);
 
   const params = useMemo<WalletFeatureParams>(
     () => (featureFlag?.params as WalletFeatureParams) ?? {},
@@ -100,6 +113,23 @@ export const useWalletFeaturesDevToolViewModel = (): WalletFeaturesViewModel => 
     );
   }, [dispatch, isQ2TourEnabled, releaseTour]);
 
+  const handleToggleQ3TourHasSeen = useCallback(() => {
+    dispatch(setHasSeenQ3Tour(!hasSeenQ3Tour));
+  }, [dispatch, hasSeenQ3Tour]);
+
+  const handleToggleQ3TourEnabled = useCallback(() => {
+    const next = !isQ3TourEnabled;
+    dispatch(
+      setOverride({
+        key: RELEASE_TOUR_FLAG,
+        value: {
+          enabled: next,
+          params: { variant: next ? "q3_a" : releaseTour?.params?.variant },
+        },
+      }),
+    );
+  }, [dispatch, isQ3TourEnabled, releaseTour]);
+
   return {
     featureFlag,
     isEnabled,
@@ -108,11 +138,15 @@ export const useWalletFeaturesDevToolViewModel = (): WalletFeaturesViewModel => 
     hasSeenWalletV4Tour,
     hasSeenQ2Tour,
     isQ2TourEnabled,
+    hasSeenQ3Tour,
+    isQ3TourEnabled,
     handleToggleAll,
     handleToggleEnabled,
     handleToggleParam,
     handleToggleHasSeenTour,
     handleToggleQ2TourHasSeen,
     handleToggleQ2TourEnabled,
+    handleToggleQ3TourHasSeen,
+    handleToggleQ3TourEnabled,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/types.ts
@@ -15,12 +15,16 @@ export interface WalletFeaturesViewModel {
   readonly hasSeenWalletV4Tour: boolean;
   readonly hasSeenQ2Tour: boolean;
   readonly isQ2TourEnabled: boolean;
+  readonly hasSeenQ3Tour: boolean;
+  readonly isQ3TourEnabled: boolean;
   readonly handleToggleAll: (enable: boolean) => void;
   readonly handleToggleEnabled: () => void;
   readonly handleToggleParam: (key: WalletFeatureParamKey) => void;
   readonly handleToggleHasSeenTour: () => void;
   readonly handleToggleQ2TourHasSeen: () => void;
   readonly handleToggleQ2TourEnabled: () => void;
+  readonly handleToggleQ3TourHasSeen: () => void;
+  readonly handleToggleQ3TourEnabled: () => void;
 }
 
 export interface FeatureParamRowProps<T extends string = WalletFeatureParamKey> {


### PR DESCRIPTION
### 📝 Description

This PR sets up the Q3 Wallet V4 Product Tour foundation on desktop, kept independent from the Q1, Q2, and Wallet V4 tours. Same limited scope as mobile [#21656](https://github.com/LedgerHQ/ledger-live/pull/21656), updated after [#21730](https://github.com/LedgerHQ/ledger-live/pull/21730).

**Problem**: The Q3 static Product Tour needs persisted seen state and QA debug plumbing before content and Portfolio triggering can land.

**Solution**: Desktop setup only (not the full Q2 PRs [#18620](https://github.com/LedgerHQ/ledger-live/pull/18620) / [#18685](https://github.com/LedgerHQ/ledger-live/pull/18685) / [#18701](https://github.com/LedgerHQ/ledger-live/pull/18701)):

- Gate Q3 with the shared `releaseTour` flag (`enabled` + variant `q3_a` / `q3_b` / `q3_b2`)
- Persist `hasSeenQ3Tour` in settings (same pattern as Q2; separate key)
- Add a Q3 section in Wallet Features Dev Tool to toggle `releaseTour` (defaults to `q3_a` when enabling) and the seen state
- Do **not** ship Q3 copy, assets, drawer UI, tour events, or Portfolio auto-open (LIVE-37092 / LIVE-37093)

### 🧪 Test coverage

- Integration test on the Q3 debug section covers independent `releaseTour` and `hasSeen` toggling vs Q2 / Wallet V4
- Open Drawer stays disabled in the Q3 debug section

### 🎯 QA focus

- Settings → Developer → Wallet Features Dev Tool
- Toggle **Q3 release tour** (`releaseTour` + `q3_a`) without changing Wallet 4.0 params
- Toggle **Has Seen Q3 Tour**; it persists independently of Q2 / Wallet V4
- With `releaseTour` off or a non-Q3 variant, no Q3 tour UI or trigger appears (none ships in this PR)
- **Open Drawer** stays disabled by design

### 🖼 Screenshots

Debug tool only (no user-facing tour UI in this PR):

<img width="1191" height="788" alt="image" src="https://github.com/user-attachments/assets/935f3748-d16c-458c-b2e4-00043ac44d9c" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36385](https://ledgerhq.atlassian.net/browse/LIVE-36385)
- **Parent epic**: [LIVE-36287](https://ledgerhq.atlassian.net/browse/LIVE-36287)
- **Follow-ups**: [LIVE-37092](https://ledgerhq.atlassian.net/browse/LIVE-37092), [LIVE-37093](https://ledgerhq.atlassian.net/browse/LIVE-37093)
- **Related**: [LIVE-36388](https://ledgerhq.atlassian.net/browse/LIVE-36388) / [#21656](https://github.com/LedgerHQ/ledger-live/pull/21656), [#21730](https://github.com/LedgerHQ/ledger-live/pull/21730)
- **ADR** (if any): n/a

[LIVE-36385]: https://ledgerhq.atlassian.net/browse/LIVE-36385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ