### PR TITLE
test(e2e): choose the CELO vote validator dynamically (QAA-1356)

### DIFF
--- a/e2e/desktop/tests/page/drawer/delegate.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/delegate.drawer.ts
@@ -5,8 +5,7 @@ import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
 import { expect } from "@playwright/test";
 
 export class DelegateDrawer extends Drawer {
-  private provider = (provider: string) =>
-    this.page.getByTestId("drawer-content").locator(`text=${provider}`).first();
+  private provider = (provider: string) => this.content.getByText(provider).first();
   private amountValue = this.page.getByTestId("amountReceived-drawer").first();
   private transactionType = this.page.getByTestId("transaction-type").first();
   private operationType = this.page.getByTestId("operation-type");
@@ -16,6 +15,11 @@ export class DelegateDrawer extends Drawer {
     if (account.account.currency === Currency.ATOM) {
       await expect(this.provider(account.provider)).toBeVisible();
     }
+  }
+
+  @step("Verify validator group is $0")
+  async validatorGroupIsVisible(validatorGroup: string) {
+    await expect(this.provider(validatorGroup)).toBeVisible();
   }
 
   @step("Verify amount is visible")

--- a/e2e/desktop/tests/page/modal/delegate.modal.ts
+++ b/e2e/desktop/tests/page/modal/delegate.modal.ts
@@ -48,8 +48,10 @@ export class DelegateModal extends Modal {
   }
 
   @step("Select provider on row $0")
-  async selectProviderOnRow(row: number) {
-    await this.selectProviderByName(await this.getTitleProvider(row));
+  async selectProviderOnRow(row: number): Promise<string> {
+    const provider = await this.getTitleProvider(row);
+    await this.selectProviderByName(provider);
+    return provider;
   }
 
   @step("Select provider $0")

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -351,7 +351,7 @@ test.describe("Delegate", () => {
       await app.account.startStakingFlowFromMainStakeButton();
       await app.delegate.checkCeloManageAssetModal();
       await app.delegate.clickCeloVoteButton();
-      await app.delegate.selectProviderOnRow(1);
+      const provider = await app.delegate.selectProviderOnRow(1);
       await app.delegate.continue();
       await app.delegate.fillAmount(account.amount);
       await app.delegate.continue();
@@ -361,7 +361,7 @@ test.describe("Delegate", () => {
       await app.drawer.waitForDrawerToBeVisible();
       await app.delegateDrawer.verifyTxTypeIsVisible();
       await app.delegateDrawer.verifyTxTypeIs("Voted");
-      await app.delegateDrawer.providerIsVisible(account);
+      await app.delegateDrawer.validatorGroupIsVisible(provider);
       await app.delegateDrawer.operationTypeIsCorrect("Voted");
       await app.drawer.closeDrawer();
     },

--- a/e2e/mobile/page/trade/stake.page.ts
+++ b/e2e/mobile/page/trade/stake.page.ts
@@ -1,6 +1,9 @@
 import { Step } from "jest-allure2-reporter/api";
 import invariant from "invariant";
 
+const PROVIDER_ROW_PREFIX = "provider-row-";
+const PROVIDER_ROW_REGEX = new RegExp(`^${PROVIDER_ROW_PREFIX}.+$`);
+
 export default class StakePage {
   celoLockAmountInput = "celo-lock-amount-input";
   celoVoteAmountId = "celo-vote-amount";
@@ -25,7 +28,7 @@ export default class StakePage {
   delegationAmountContinueId = (currencyId: string) =>
     `enabled-${currencyId}-delegation-amount-continue`;
   currencyRow = (currencyId: string) => `currency-row-${currencyId}`;
-  providerRow = (providerTicker: string) => `provider-row-${providerTicker}`;
+  providerRow = (providerTicker: string) => `${PROVIDER_ROW_PREFIX}${providerTicker}`;
 
   @Step("Select currency {{{0}}}")
   async selectCurrency(currencyId: string) {
@@ -75,6 +78,16 @@ export default class StakePage {
     await typeTextById(this.searchPoolInput, ticker);
     await waitForElementById(this.searchPoolInput);
     await tapById(this.providerRow(ticker));
+  }
+
+  @Step("Select the first provider offered for {{{0}}}")
+  async selectFirstValidator(currencyId: string): Promise<string> {
+    await tapById(this.delegationSummaryValidatorId(currencyId));
+    await waitForElementById(PROVIDER_ROW_REGEX);
+    const rowId = await getIdByRegexp(PROVIDER_ROW_REGEX);
+    await tapById(rowId);
+    await waitForElementById(this.delegationSummaryValidatorId(currencyId));
+    return rowId.slice(PROVIDER_ROW_PREFIX.length);
   }
 
   @Step("Verify fees visible in summary {{{0}}}")

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -176,7 +176,8 @@ export function runVoteCelo(delegation: DelegateType, tmsLinks: string[], tags: 
 
       await app.celoManageAssets.checkManagePage();
       await app.celoManageAssets.clickVote();
-      await app.stake.selectValidator(delegation.account.currency.id, delegation.provider);
+      const provider = await app.stake.selectFirstValidator(delegation.account.currency.id);
+      const votedDelegation = { ...delegation, provider };
 
       await app.stake.openCeloVoteAmount();
       await app.stake.setCeloVoteAmount(delegation.amount);
@@ -184,12 +185,12 @@ export function runVoteCelo(delegation: DelegateType, tmsLinks: string[], tags: 
       await app.stake.validateCeloVoteAmount();
       await app.stake.celoVoteSummaryContinue();
 
-      await verifyAppValidationStakeInfo(delegation, amountWithCode);
-      await app.speculos.signDelegationTransaction(delegation);
+      await verifyAppValidationStakeInfo(votedDelegation, amountWithCode);
+      await app.speculos.signDelegationTransaction(votedDelegation);
 
       await app.common.successViewDetails();
 
-      await verifyStakeOperationDetailsInfo(delegation, amountWithCode, undefined, "VOTE");
+      await verifyStakeOperationDetailsInfo(votedDelegation, amountWithCode, undefined, "VOTE");
     });
   });
 }

--- a/e2e/mobile/specs/delegate/voteCELO.spec.ts
+++ b/e2e/mobile/specs/delegate/voteCELO.spec.ts
@@ -1,7 +1,7 @@
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { runVoteCelo } from "@e2e/specs/delegate/delegate";
 
-const delegation = new Delegate(Account.CELO_1, "0.001", "GrassrootsEconomics");
+const delegation = new Delegate(Account.CELO_1, "0.001", "first-available");
 runVoteCelo(
   delegation,
   ["B2CQA-201"],


### PR DESCRIPTION
### 📝 Description

The CELO vote e2e test hardcoded the validator group it votes for. That string has been rewritten **four times in one month**, every time because the group disappeared from the list the app renders:

| Commit | Provider | Why it changed |
| --- | --- | --- |
| `75718af9be2` | `moonli.me` | initial vote/lock specs |
| `ac73f0aef4c` | `Ledger by Figment` | switch to Ledger's own group |
| `3b9ad8e3340` | `cLabs` | prod deprecated "Ledger by Figment" and dropped it from the list |
| `0c9b5fc7992` | `GrassrootsEconomics` | prod started excluding saturated groups; `cLabs` was at its vote cap |

**Problem.** The group list is live on-chain data. `coin-celo/src/network/hubble.ts` rebuilds it from the indexer, intersects it with `Election.getEligibleValidatorGroups()`, drops saturated groups (`getNumVotesReceivable > getTotalVotesForGroup`), drops the deprecated "Ledger by Figment" group, and sorts by TVL. Membership *and* order move with chain state, so **any** hardcoded name is a scheduled failure. The failure quoted in QAA-1356 (`TOBEVISIBLE WITH MATCHER(id == "device-validation-scroll-view") TIMEOUT(1m)`) was the downstream symptom: the pinned group was still listed but could not receive votes, so the transaction never reached the device.

**Solution.** Read the validator from the list the app actually renders, instead of naming it up front.

- **LWM** — new `stake.page.ts#selectFirstValidator(currencyId)` taps the summary validator field, waits for `/^provider-row-.+$/`, resolves the first row's test id with `getIdByRegexp`, taps it and **returns the group name**. `runVoteCelo` threads that name through the device, Speculos and operation-details assertions as `{ ...delegation, provider }`, so the exact-match check in `checkCeloValidatorGroup` now compares against the group that was actually voted for. The spec carries the `"first-available"` sentinel already used by `delegateSEI.spec.ts`.
- **LWD** — `selectProviderOnRow(row)` now returns the name it selected, and the Vote test asserts it in the operation drawer via a new `validatorGroupIsVisible` step. Desktop already selected by row index, but discarded the name — `providerIsVisible` short-circuits on every currency except ATOM, so LWD was never verifying *which* group it voted for.

The new mobile helper is currency-agnostic: mina, cosmos, multiversx and cardano mobile rows use the same `provider-row-` test id convention, so other families can adopt it. `selectValidator(currencyId, provider)` stays for ADA / OSMO / MultiversX, which deliberately target a named provider.

`lockCELO` is untouched — the lock flow picks no validator, so its `"N/A"` provider is never read.

**Why this is safe at the top of the list.** The saturation filter only guarantees headroom `> 0`, but `getNumVotesReceivable` is of the order of millions of CELO for a real group, against a `0.001 CELO` vote. If it ever did bite, `buildVoteTx` fails with an explicit `vote cap exceeded`, and the mitigation is a one-character change (`getIdByRegexp(regex, 1)`).

**No changeset**: test-only change, no product code touched. Both `ledger-live-mobile-e2e-tests` and `ledger-live-desktop-e2e-tests` are `private`, and the equivalent prior change (`ac73f0aef4c`) carried none.

#### ✅ Verification

| Check | Result |
| --- | --- |
| `ledger-live-mobile-e2e-tests` typecheck / lint / `format:check` | pass |
| `ledger-live-desktop-e2e-tests` nx typecheck / lint / `format:check` | pass — 0 errors under `tests/` |

E2E CI triggered on this branch (LWM + LWD), filtered to `@celo`.

#### 🔍 QA focus

- **LWM** `voteCELO` — the Allure step `Select the first provider offered for celo` should report a real group name, and `Check CELO validator group in operation details <name>` should assert that same name rather than `first-available`.
- **LWM** `lockCELO` — unchanged, but re-run it: `providerRow` was repointed at a shared prefix constant.
- **LWD** `delegate` Celo Vote — the operation drawer now asserts the group name for the first time; Celo Lock must stay green (it reuses `providerIsVisible` with `"N/A"`, deliberately left as a no-op).
- Regression on the untouched named-provider path: `delegateADA` / `delegateOSMO` / `delegateEGLD`, which still go through `selectValidator`.

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1356](https://ledgerhq.atlassian.net/browse/QAA-1356)
- **ADR** (if any): n/a


[QAA-1356]: https://ledgerhq.atlassian.net/browse/QAA-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ