### PR TITLE
test(pay-card): mock card-management HTTP with MSW (LIVE-37119)

### DIFF
--- a/.changeset/pay-card-card-management-msw.md
+++ b/.changeset/pay-card-card-management-msw.md
@@ -1,0 +1,5 @@
+---
+"@domain/api-card-management": patch
+---
+
+Mock card-management HTTP with MSW in tests

--- a/domain/api/card-management/package.json
+++ b/domain/api/card-management/package.json
@@ -35,6 +35,7 @@
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
+    "msw": "catalog:",
     "react": "catalog:",
     "react-redux": "catalog:",
     "typescript": "catalog:"

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -18,44 +18,17 @@ import {
   useOrderCardMutation,
   useUnfreezeCardMutation,
 } from "./api";
-import { PayCardErrorResponseSchema } from "./schema";
+import {
+  CARD_API_BASE_URL,
+  deferred,
+  errorResponse,
+  flushPendingRequests,
+  jsonResponse,
+  mockCardProvider,
+} from "./cardProvider.mock";
 
-function jsonResponse(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
+const provider = mockCardProvider();
 
-function errorResponse(status: number, message: string): Response {
-  return new Response(JSON.stringify(PayCardErrorResponseSchema.parse({ message })), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
-/**
- * The refetch an invalidation triggers only reaches `fetch` a tick later: the base query awaits the
- * session token first. Drain the queue before counting requests, so the assertion does not depend on
- * how many microtasks the awaited dispatch happened to spend.
- */
-function flushPendingRequests(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, 0));
-}
-
-function request(spy: jest.SpyInstance): Request {
-  return spy.mock.calls[0][0] as Request;
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>(resolvePromise => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
-// The provider's own example response.
 const cardStatus = {
   id: "000000000050277836",
   holderName: "JOHN DOE",
@@ -66,7 +39,6 @@ const cardStatus = {
   orderedAt: "2023-03-27T17:07:12.662Z",
 };
 
-// The provider's own example responses, as they arrive on the wire.
 const internalWalletsOnTheWire = [
   {
     id: "098aeb90-e7f7-4f81-bc2e-4963330122c5",
@@ -109,7 +81,6 @@ const linkedWallets = [
   },
 ];
 
-// Wired the way the apps wire it: the store registers the service api, never this package.
 const makeStore = (sessionToken: string | null = null, overrides: Partial<CardApiExtra> = {}) =>
   configureStore({
     reducer: {
@@ -119,7 +90,7 @@ const makeStore = (sessionToken: string | null = null, overrides: Partial<CardAp
       gdm({
         thunk: {
           extraArgument: cardApiExtra({
-            getCardApiBaseUrl: () => "https://card.test",
+            getCardApiBaseUrl: () => CARD_API_BASE_URL,
             getCardBaanxClientKey: () => "client-key",
             readCardSession: () => Promise.resolve({ token: sessionToken, sessionId: 1 }),
             isCardSessionCurrent: () => true,
@@ -130,8 +101,17 @@ const makeStore = (sessionToken: string | null = null, overrides: Partial<CardAp
       }).concat(cardApi.middleware),
   });
 
+function expectSessionRequest(method: "GET" | "POST", path: string) {
+  const sent = provider.sent();
+
+  expect(sent.method).toBe(method);
+  expect(sent.url).toBe(`${CARD_API_BASE_URL}${path}`);
+  expect(sent.headers.get("authorization")).toBe("Bearer session-token");
+  expect(sent.headers.get("x-client-key")).toBe("client-key");
+}
+
 describe("cardManagementApi configuration", () => {
-  it("is the Card service api, mutated in place by injectEndpoints", () => {
+  it("is the shared cardApi, injected in place", () => {
     expect(cardManagementApi).toBe(cardApi);
     expect(cardManagementApi.reducerPath).toBe("cardApi");
   });
@@ -153,7 +133,7 @@ describe("cardManagementApi configuration", () => {
     ]);
   });
 
-  it("names the two grants the redaction knows", () => {
+  it("names both OAuth2 grants in the list the redaction reads", () => {
     expect([...CARD_GRANT_ENDPOINTS].sort()).toEqual([
       "exchangeAuthorizationCode",
       "refreshSession",
@@ -168,43 +148,42 @@ describe("cardManagementApi configuration", () => {
     expect(Object.keys(apiModule)).not.toContain("useRefreshSessionMutation");
   });
 
-  it("exposes the orderCard endpoint and its hook", () => {
+  it("exposes orderCard and its hook", () => {
     expect(cardManagementApi.endpoints.orderCard).toBeDefined();
     expect(useOrderCardMutation).toBeDefined();
   });
 
-  it("exposes the getCardStatus endpoint and its hook", () => {
+  it("exposes getCardStatus with its hook and the lazy hook the devtool presses", () => {
     expect(cardManagementApi.endpoints.getCardStatus).toBeDefined();
     expect(useGetCardStatusQuery).toBeDefined();
-    // The devtool fetches on press, not on mount, so the lazy hook is part of the surface too.
     expect(useLazyGetCardStatusQuery).toBeDefined();
   });
 
-  it("exposes the card details token endpoint and its hook", () => {
+  it("exposes createCardDetailsToken and its hook", () => {
     expect(cardManagementApi.endpoints.createCardDetailsToken).toBeDefined();
     expect(useCreateCardDetailsTokenMutation).toBeDefined();
   });
 
-  it("exposes the freeze endpoints and their hooks", () => {
+  it("exposes freezeCard and unfreezeCard with their hooks", () => {
     expect(cardManagementApi.endpoints.freezeCard).toBeDefined();
     expect(useFreezeCardMutation).toBeDefined();
     expect(cardManagementApi.endpoints.unfreezeCard).toBeDefined();
     expect(useUnfreezeCardMutation).toBeDefined();
   });
 
-  it("exposes the wallet endpoints and their hooks", () => {
+  it("exposes both wallet endpoints with their hooks", () => {
     expect(cardManagementApi.endpoints.getInternalWallets).toBeDefined();
     expect(useGetInternalWalletsQuery).toBeDefined();
     expect(cardManagementApi.endpoints.getCardLinkedWallets).toBeDefined();
     expect(useGetCardLinkedWalletsQuery).toBeDefined();
   });
 
-  it("exposes the onboarding status endpoint and its hook", () => {
+  it("exposes getCardOnboardingStatus and its hook", () => {
     expect(cardManagementApi.endpoints.getCardOnboardingStatus).toBeDefined();
     expect(useGetCardOnboardingStatusQuery).toBeDefined();
   });
 
-  it("shares the Card service reducer and middleware once registered in a store", () => {
+  it("registers under the shared cardApi reducer path", () => {
     const store = makeStore();
 
     expect(store.getState()).toHaveProperty(cardManagementApi.reducerPath);
@@ -212,13 +191,9 @@ describe("cardManagementApi configuration", () => {
 });
 
 describe("cardManagementApi requests", () => {
-  let fetchSpy: jest.SpyInstance;
-
-  afterEach(() => {
-    fetchSpy?.mockRestore();
-  });
-
   describe("the OAuth2 grants", () => {
+    const TOKEN_PATH = "/v1/auth/oauth2/token";
+
     const sessionResponse = {
       access_token: "at_token",
       expires_in: 21600,
@@ -231,8 +206,8 @@ describe("cardManagementApi requests", () => {
       refreshToken: "rt_token",
     };
 
-    it("posts the code and the verifier, and answers with the session", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(sessionResponse));
+    it("exchanges the code and the verifier for a session", async () => {
+      provider.post(TOKEN_PATH, () => jsonResponse(sessionResponse));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
@@ -243,16 +218,16 @@ describe("cardManagementApi requests", () => {
       );
 
       expect(result.data).toEqual(session);
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/oauth2/token");
-      await expect(request(fetchSpy).json()).resolves.toEqual({
+      expect(provider.sent().url).toBe(`${CARD_API_BASE_URL}${TOKEN_PATH}`);
+      expect(JSON.parse(provider.sent().body)).toEqual({
         grant_type: "authorization_code",
         code: "auth-code",
         code_verifier: "verifier",
       });
     });
 
-    it("posts the refresh token to the same path, and answers with the session", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(sessionResponse));
+    it("rotates the session with the refresh token, and sends no bearer token", async () => {
+      provider.post(TOKEN_PATH, () => jsonResponse(sessionResponse));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
@@ -263,18 +238,16 @@ describe("cardManagementApi requests", () => {
       );
 
       expect(result.data).toEqual(session);
-      await expect(request(fetchSpy).json()).resolves.toEqual({
+      expect(JSON.parse(provider.sent().body)).toEqual({
         grant_type: "refresh_token",
         refresh_token: "rt_stored",
       });
-      expect(request(fetchSpy).headers.get("authorization")).toBeNull();
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(provider.sent().headers.get("authorization")).toBeNull();
+      expect(provider.sent().headers.get("x-client-key")).toBe("client-key");
     });
 
-    it("writes no cache entry, because both grants run untracked", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async () => jsonResponse(sessionResponse));
+    it("caches nothing, because both grants run untracked", async () => {
+      provider.post(TOKEN_PATH, () => jsonResponse(sessionResponse));
 
       const store = makeStore("session-token");
       await store.dispatch(
@@ -289,8 +262,8 @@ describe("cardManagementApi requests", () => {
       expect(state.mutations).toEqual({});
     });
 
-    it("fails, and quotes no token, when the answer is not a session", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+    it("quotes no token when the answer is not a session", async () => {
+      provider.post(TOKEN_PATH, () =>
         jsonResponse({
           access_token: "sensitive-access-token",
           refresh_token: "sensitive-refresh-token",
@@ -311,10 +284,8 @@ describe("cardManagementApi requests", () => {
       expect(JSON.stringify(result.error)).not.toContain("sensitive-refresh-token");
     });
 
-    it("reports the status when the provider refuses the grant", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(errorResponse(400, "invalid_grant"));
+    it("fails with 400 when the provider refuses the grant", async () => {
+      provider.post(TOKEN_PATH, () => errorResponse(400, "invalid_grant"));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
@@ -329,32 +300,29 @@ describe("cardManagementApi requests", () => {
   });
 
   describe("logout", () => {
-    it("omits the bearer token when no session is open", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
-
-      const store = makeStore();
-      await store.dispatch(cardManagementApi.endpoints.logout.initiate());
-
-      expect(request(fetchSpy).headers.get("authorization")).toBeNull();
-    });
-
-    it("sends the session bearer token alongside the client key", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+    it("ends the session", async () => {
+      provider.post("/v1/auth/logout", () => jsonResponse({ success: true }));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.logout.initiate());
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/logout");
-      expect(request(fetchSpy).method).toBe("POST");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expectSessionRequest("POST", "/v1/auth/logout");
       expect(result.data).toEqual({ success: true });
+    });
+
+    it("omits the bearer token when no session is open", async () => {
+      provider.post("/v1/auth/logout", () => jsonResponse({ success: true }));
+
+      const store = makeStore();
+      await store.dispatch(cardManagementApi.endpoints.logout.initiate());
+
+      expect(provider.sent().headers.get("authorization")).toBeNull();
     });
   });
 
   describe("getUser", () => {
-    it("keeps the personal data the endpoint returns out of the cache", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+    it("returns the id and the verification state, and drops the personal data", async () => {
+      provider.get("/v1/user", () =>
         jsonResponse({
           id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
           verificationState: "VERIFIED",
@@ -373,36 +341,40 @@ describe("cardManagementApi requests", () => {
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getUser.initiate());
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/user");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expectSessionRequest("GET", "/v1/user");
       expect(result.data).toEqual({
         id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
         verificationState: "VERIFIED",
       });
     });
+
+    it("rejects a response that does not match the wire contract", async () => {
+      provider.get("/v1/user", () =>
+        jsonResponse({ id: "not-a-uuid", verification_state: "VERIFIED" }),
+      );
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.getUser.initiate());
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
   });
 
   describe("orderCard", () => {
-    it("posts a virtual card order with the session bearer token and the client key", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+    it("orders a virtual card", async () => {
+      provider.post("/v1/card/order", () => jsonResponse({ success: true }));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/order");
-      expect(request(fetchSpy).method).toBe("POST");
-      expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
-        type: "VIRTUAL",
-      });
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expectSessionRequest("POST", "/v1/card/order");
+      expect(JSON.parse(provider.sent().body)).toEqual({ type: "VIRTUAL" });
       expect(result.data).toEqual({ success: true });
     });
 
     it("rejects a response whose success flag is not a boolean", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse({ success: "yes" }));
+      provider.post("/v1/card/order", () => jsonResponse({ success: "yes" }));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
@@ -413,22 +385,18 @@ describe("cardManagementApi requests", () => {
   });
 
   describe("getCardStatus", () => {
-    it("reads the card and drops everything the wire contract does not declare", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(cardStatus));
+    it("reads the card status", async () => {
+      provider.get("/v1/card/status", () => jsonResponse(cardStatus));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/status");
-      expect(request(fetchSpy).method).toBe("GET");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expectSessionRequest("GET", "/v1/card/status");
       expect(result.data).toEqual(cardStatus);
     });
 
-    it("reports a user who never ordered a card as a 404", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(errorResponse(404, "Card not found"));
+    it("fails with 404 when the user never ordered a card", async () => {
+      provider.get("/v1/card/status", () => errorResponse(404, "Card not found"));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
@@ -438,9 +406,9 @@ describe("cardManagementApi requests", () => {
     });
 
     it("rejects a status the wire contract does not name", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse({ ...cardStatus, status: "SOMETHING_ELSE" }));
+      provider.get("/v1/card/status", () =>
+        jsonResponse({ ...cardStatus, status: "SOMETHING_ELSE" }),
+      );
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
@@ -449,53 +417,37 @@ describe("cardManagementApi requests", () => {
       expect(result.error).toBeDefined();
     });
 
-    it("refetches after an order, because the order invalidates the card status", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) =>
-          new URL((input as Request).url).pathname === "/v1/card/order"
-            ? jsonResponse({ success: true })
-            : jsonResponse(cardStatus),
-        );
+    it("refetches after an order", async () => {
+      provider.get("/v1/card/status", () => jsonResponse(cardStatus));
+      provider.post("/v1/card/order", () => jsonResponse({ success: true }));
 
       const store = makeStore("session-token");
-      // Subscribed, so the invalidation has a live cache entry to refetch.
       const status = store.dispatch(
-        cardManagementApi.endpoints.getCardStatus.initiate(undefined, {
-          subscribe: true,
-        }),
+        cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
       );
       await status;
       await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
       await flushPendingRequests();
 
-      const statusRequests = fetchSpy.mock.calls.filter(
-        ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
-      );
-      expect(statusRequests).toHaveLength(2);
+      expect(provider.sentTo("/v1/card/status")).toHaveLength(2);
 
       status.unsubscribe();
     });
   });
 
   describe("freezeCard", () => {
-    it("posts the freeze with the session bearer token and the client key", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+    it("freezes the card", async () => {
+      provider.post("/v1/card/freeze", () => jsonResponse({ success: true }));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/freeze");
-      expect(request(fetchSpy).method).toBe("POST");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expectSessionRequest("POST", "/v1/card/freeze");
       expect(result.data).toEqual({ success: true });
     });
 
-    it("surfaces a card that is already frozen as a 400", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(errorResponse(400, "Card is already frozen"));
+    it("fails with 400 when the card is already frozen", async () => {
+      provider.post("/v1/card/freeze", () => errorResponse(400, "Card is already frozen"));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
@@ -507,16 +459,10 @@ describe("cardManagementApi requests", () => {
       });
     });
 
-    it("optimistically shares FROZEN through the status cache and rolls back on failure", async () => {
-      const freezeResponse = deferred<Response>();
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) => {
-          if (new URL((input as Request).url).pathname === "/v1/card/freeze") {
-            return freezeResponse.promise;
-          }
-          return jsonResponse(cardStatus);
-        });
+    it("shows FROZEN in the status cache while in flight, and rolls back when it fails", async () => {
+      const freeze = deferred<Response>();
+      provider.get("/v1/card/status", () => jsonResponse(cardStatus));
+      provider.post("/v1/card/freeze", () => freeze.promise);
 
       const store = makeStore("session-token");
       const subscription = store.dispatch(
@@ -530,7 +476,7 @@ describe("cardManagementApi requests", () => {
         cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
       ).toBe("FROZEN");
 
-      freezeResponse.resolve(errorResponse(500, "Freeze failed"));
+      freeze.resolve(errorResponse(500, "Freeze failed"));
       await mutation;
       expect(
         cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
@@ -539,17 +485,13 @@ describe("cardManagementApi requests", () => {
       subscription.unsubscribe();
     });
 
-    it("refetches the card status, because freezing moves it to FROZEN", async () => {
+    it("refetches the card status, which then reads FROZEN", async () => {
       let cardState = "ACTIVE";
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) => {
-          if (new URL((input as Request).url).pathname === "/v1/card/freeze") {
-            cardState = "FROZEN";
-            return jsonResponse({ success: true });
-          }
-          return jsonResponse({ ...cardStatus, status: cardState });
-        });
+      provider.get("/v1/card/status", () => jsonResponse({ ...cardStatus, status: cardState }));
+      provider.post("/v1/card/freeze", () => {
+        cardState = "FROZEN";
+        return jsonResponse({ success: true });
+      });
 
       const store = makeStore("session-token");
       const subscription = store.dispatch(
@@ -559,10 +501,7 @@ describe("cardManagementApi requests", () => {
       await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
       await flushPendingRequests();
 
-      const statusRequests = fetchSpy.mock.calls.filter(
-        ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
-      );
-      expect(statusRequests).toHaveLength(2);
+      expect(provider.sentTo("/v1/card/status")).toHaveLength(2);
       expect(
         cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
       ).toBe("FROZEN");
@@ -572,23 +511,18 @@ describe("cardManagementApi requests", () => {
   });
 
   describe("unfreezeCard", () => {
-    it("posts the unfreeze with the session bearer token and the client key", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+    it("unfreezes the card", async () => {
+      provider.post("/v1/card/unfreeze", () => jsonResponse({ success: true }));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/unfreeze");
-      expect(request(fetchSpy).method).toBe("POST");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expectSessionRequest("POST", "/v1/card/unfreeze");
       expect(result.data).toEqual({ success: true });
     });
 
-    it("surfaces a card that is not frozen as a 400", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(errorResponse(400, "Card is not frozen"));
+    it("fails with 400 when the card is not frozen", async () => {
+      provider.post("/v1/card/unfreeze", () => errorResponse(400, "Card is not frozen"));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
@@ -597,16 +531,10 @@ describe("cardManagementApi requests", () => {
       expect(result.error).toMatchObject({ status: 400, data: { message: "Card is not frozen" } });
     });
 
-    it("optimistically shares ACTIVE through the status cache and rolls back on failure", async () => {
-      const unfreezeResponse = deferred<Response>();
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) => {
-          if (new URL((input as Request).url).pathname === "/v1/card/unfreeze") {
-            return unfreezeResponse.promise;
-          }
-          return jsonResponse({ ...cardStatus, status: "FROZEN" });
-        });
+    it("shows ACTIVE in the status cache while in flight, and rolls back when it fails", async () => {
+      const unfreeze = deferred<Response>();
+      provider.get("/v1/card/status", () => jsonResponse({ ...cardStatus, status: "FROZEN" }));
+      provider.post("/v1/card/unfreeze", () => unfreeze.promise);
 
       const store = makeStore("session-token");
       const subscription = store.dispatch(
@@ -620,7 +548,7 @@ describe("cardManagementApi requests", () => {
         cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
       ).toBe("ACTIVE");
 
-      unfreezeResponse.resolve(errorResponse(500, "Unfreeze failed"));
+      unfreeze.resolve(errorResponse(500, "Unfreeze failed"));
       await mutation;
       expect(
         cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
@@ -629,17 +557,13 @@ describe("cardManagementApi requests", () => {
       subscription.unsubscribe();
     });
 
-    it("refetches the card status, because unfreezing moves it back to ACTIVE", async () => {
+    it("refetches the card status, which then reads ACTIVE", async () => {
       let cardState = "FROZEN";
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) => {
-          if (new URL((input as Request).url).pathname === "/v1/card/unfreeze") {
-            cardState = "ACTIVE";
-            return jsonResponse({ success: true });
-          }
-          return jsonResponse({ ...cardStatus, status: cardState });
-        });
+      provider.get("/v1/card/status", () => jsonResponse({ ...cardStatus, status: cardState }));
+      provider.post("/v1/card/unfreeze", () => {
+        cardState = "ACTIVE";
+        return jsonResponse({ success: true });
+      });
 
       const store = makeStore("session-token");
       const subscription = store.dispatch(
@@ -649,10 +573,7 @@ describe("cardManagementApi requests", () => {
       await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
       await flushPendingRequests();
 
-      const statusRequests = fetchSpy.mock.calls.filter(
-        ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
-      );
-      expect(statusRequests).toHaveLength(2);
+      expect(provider.sentTo("/v1/card/status")).toHaveLength(2);
       expect(
         cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
       ).toBe("ACTIVE");
@@ -662,86 +583,64 @@ describe("cardManagementApi requests", () => {
   });
 
   describe("getInternalWallets", () => {
-    it("reads every custodial wallet with the bearer token and the client key", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse(internalWalletsOnTheWire));
+    const INTERNAL_WALLETS_PATH = "/v1/wallet/internal";
 
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
+    const readWallets = () =>
+      makeStore("session-token").dispatch(
         cardManagementApi.endpoints.getInternalWallets.initiate(),
       );
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/wallet/internal");
-      expect(request(fetchSpy).method).toBe("GET");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+    it("reads every custodial wallet", async () => {
+      provider.get(INTERNAL_WALLETS_PATH, () => jsonResponse(internalWalletsOnTheWire));
+
+      const result = await readWallets();
+
+      expectSessionRequest("GET", INTERNAL_WALLETS_PATH);
       expect(result.data).toEqual(internalWallets);
     });
 
-    it("keeps the balance a string, so the provider's precision survives", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(
-          jsonResponse([{ ...internalWallets[0], balance: "9007199254740993.000001" }]),
-        );
-
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getInternalWallets.initiate(),
+    it("keeps the balance a string, so its precision survives", async () => {
+      provider.get(INTERNAL_WALLETS_PATH, () =>
+        jsonResponse([{ ...internalWallets[0], balance: "9007199254740993.000001" }]),
       );
+
+      const result = await readWallets();
 
       expect(result.data?.[0].balance).toBe("9007199254740993.000001");
     });
 
     it("drops the keys the wire contract does not declare", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse([internalWalletsOnTheWire[0]]));
+      provider.get(INTERNAL_WALLETS_PATH, () => jsonResponse([internalWalletsOnTheWire[0]]));
 
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getInternalWallets.initiate(),
-      );
+      const result = await readWallets();
 
       expect(result.data).toEqual([internalWallets[0]]);
     });
 
-    it("accepts a user with no wallets as an empty list, not an error", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse([]));
+    it("returns an empty list when the user has no wallet", async () => {
+      provider.get(INTERNAL_WALLETS_PATH, () => jsonResponse([]));
 
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getInternalWallets.initiate(),
-      );
+      const result = await readWallets();
 
       expect(result.data).toEqual([]);
       expect(result.error).toBeUndefined();
     });
 
-    it("rejects a balance the provider sent as a number", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse([{ ...internalWallets[0], balance: 125.4 }]));
-
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getInternalWallets.initiate(),
+    it("rejects a balance sent as a number", async () => {
+      provider.get(INTERNAL_WALLETS_PATH, () =>
+        jsonResponse([{ ...internalWallets[0], balance: 125.4 }]),
       );
+
+      const result = await readWallets();
 
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
     });
 
     it("rejects an envelope where the contract promises a bare array", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse({ wallets: internalWallets }));
+      provider.get(INTERNAL_WALLETS_PATH, () => jsonResponse({ wallets: internalWallets }));
 
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getInternalWallets.initiate(),
-      );
+      const result = await readWallets();
 
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
@@ -749,31 +648,29 @@ describe("cardManagementApi requests", () => {
   });
 
   describe("createCardDetailsToken", () => {
-    // The provider's example, with an all-zero token: a real-looking one trips secret scanning.
+    const DETAILS_TOKEN_PATH = "/v1/card/details/token";
+
+    // An all-zero token: a real-looking one trips secret scanning.
     const detailsToken = {
       token: "00000000-0000-4000-8000-000000000000",
       imageUrl: "https://card.test/details-image?token=00000000-0000-4000-8000-000000000000",
     };
 
-    it("asks for a token with the bearer token and the client key, and sends no body by default", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(detailsToken));
+    it("mints a token, and sends no body when no colour is asked for", async () => {
+      provider.post(DETAILS_TOKEN_PATH, () => jsonResponse(detailsToken));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
         cardManagementApi.endpoints.createCardDetailsToken.initiate(),
       );
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/details/token");
-      expect(request(fetchSpy).method).toBe("POST");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
-      // No colours asked for: the provider paints its own defaults.
-      expect(await request(fetchSpy).clone().text()).toBe("");
+      expectSessionRequest("POST", DETAILS_TOKEN_PATH);
+      expect(provider.sent().body).toBe("");
       expect(result.data).toEqual(detailsToken);
     });
 
     it("sends the colours the host asked for", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(detailsToken));
+      provider.post(DETAILS_TOKEN_PATH, () => jsonResponse(detailsToken));
 
       const store = makeStore("session-token");
       await store
@@ -782,15 +679,13 @@ describe("cardManagementApi requests", () => {
         )
         .unwrap();
 
-      expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
+      expect(JSON.parse(provider.sent().body)).toEqual({
         customCss: { panTextColor: "#000000" },
       });
     });
 
-    it("rejects a colour that is not a hex value before the request goes out", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async () => jsonResponse(detailsToken));
+    it("rejects a colour that is not a hex value, and sends no request", async () => {
+      provider.post(DETAILS_TOKEN_PATH, () => jsonResponse(detailsToken));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
@@ -800,16 +695,13 @@ describe("cardManagementApi requests", () => {
       );
 
       expect(result.error).toBeDefined();
-      // The point of validating the argument: the provider never sees it.
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(provider.requests()).toEqual([]);
     });
 
     it("rejects an image url that is not https, which is loaded straight into an image", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async () =>
-          jsonResponse({ ...detailsToken, imageUrl: "javascript:alert(1)" }),
-        );
+      provider.post(DETAILS_TOKEN_PATH, () =>
+        jsonResponse({ ...detailsToken, imageUrl: "javascript:alert(1)" }),
+      );
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
@@ -820,10 +712,8 @@ describe("cardManagementApi requests", () => {
       expect(result.error).toBeDefined();
     });
 
-    it("reaches no part of the store when the caller does not track it", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async () => jsonResponse(detailsToken));
+    it("stores neither the token nor the image url when the caller does not track it", async () => {
+      provider.post(DETAILS_TOKEN_PATH, () => jsonResponse(detailsToken));
 
       const store = makeStore("session-token");
       await store
@@ -834,76 +724,63 @@ describe("cardManagementApi requests", () => {
         )
         .unwrap();
 
-      // Both halves: a query result lands under `queries`, a mutation result under `mutations`.
       const state = JSON.stringify(store.getState().cardApi);
       expect(state).not.toContain(detailsToken.token);
       expect(state).not.toContain("details-image");
     });
 
-    it("is held in the store when the caller does track it, which is why callers must not", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockImplementation(async () => jsonResponse(detailsToken));
+    it("leaves the token in redux when the caller tracks it, which is why callers must not", async () => {
+      provider.post(DETAILS_TOKEN_PATH, () => jsonResponse(detailsToken));
 
       const store = makeStore("session-token");
       await store.dispatch(cardManagementApi.endpoints.createCardDetailsToken.initiate()).unwrap();
 
-      // Pinned deliberately: RTK Query retains a tracked mutation result, so a caller that drops
-      // `track: false` leaves the PAN image URL in Redux. This failing would mean that changed.
       expect(JSON.stringify(store.getState().cardApi.mutations)).toContain(detailsToken.token);
     });
   });
 
   describe("getCardLinkedWallets", () => {
-    it("reads the linked wallets with the bearer token and the client key", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(linkedWallets));
+    const LINKED_WALLETS_PATH = "/v1/wallet/internal/card_linked";
 
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
+    const readLinkedWallets = () =>
+      makeStore("session-token").dispatch(
         cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
       );
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/wallet/internal/card_linked");
-      expect(request(fetchSpy).method).toBe("GET");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+    it("reads the wallets funding the card", async () => {
+      provider.get(LINKED_WALLETS_PATH, () => jsonResponse(linkedWallets));
+
+      const result = await readLinkedWallets();
+
+      expectSessionRequest("GET", LINKED_WALLETS_PATH);
       expect(result.data).toEqual(linkedWallets);
     });
 
     it("keeps a priority of zero, which is the first wallet charged", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse([{ ...linkedWallets[0], priority: 0 }]));
-
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+      provider.get(LINKED_WALLETS_PATH, () =>
+        jsonResponse([{ ...linkedWallets[0], priority: 0 }]),
       );
+
+      const result = await readLinkedWallets();
 
       expect(result.data?.[0].priority).toBe(0);
     });
 
-    it("accepts a card with nothing linked to it as an empty list", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse([]));
+    it("returns an empty list when nothing is linked to the card", async () => {
+      provider.get(LINKED_WALLETS_PATH, () => jsonResponse([]));
 
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
-      );
+      const result = await readLinkedWallets();
 
       expect(result.data).toEqual([]);
       expect(result.error).toBeUndefined();
     });
 
-    it("rejects a wallet whose priority is not a number", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse([{ ...linkedWallets[0], priority: "1" }]));
-
-      const store = makeStore("session-token");
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+    it("rejects a priority that is not a number", async () => {
+      provider.get(LINKED_WALLETS_PATH, () =>
+        jsonResponse([{ ...linkedWallets[0], priority: "1" }]),
       );
+
+      const result = await readLinkedWallets();
 
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
@@ -911,6 +788,8 @@ describe("cardManagementApi requests", () => {
   });
 
   describe("getCardOnboardingStatus", () => {
+    const ONBOARDING_STATUS_PATH = "/v1/card/onboarding-status";
+
     const onboardingStatus = {
       steps: [
         {
@@ -928,26 +807,21 @@ describe("cardManagementApi requests", () => {
       ],
     };
 
-    it("reads the onboarding steps with the bearer token and the client key", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(onboardingStatus));
+    it("reads the onboarding steps", async () => {
+      provider.get(ONBOARDING_STATUS_PATH, () => jsonResponse(onboardingStatus));
 
       const store = makeStore("session-token");
       const result = await store.dispatch(
         cardManagementApi.endpoints.getCardOnboardingStatus.initiate(),
       );
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/onboarding-status");
-      expect(request(fetchSpy).method).toBe("GET");
-      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expectSessionRequest("GET", ONBOARDING_STATUS_PATH);
       expect(result.data).toEqual(onboardingStatus);
     });
 
     it("rejects a step whose done flag is not a boolean", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
-        jsonResponse({
-          steps: [{ ...onboardingStatus.steps[0], isDone: "yes" }],
-        }),
+      provider.get(ONBOARDING_STATUS_PATH, () =>
+        jsonResponse({ steps: [{ ...onboardingStatus.steps[0], isDone: "yes" }] }),
       );
 
       const store = makeStore("session-token");
@@ -958,17 +832,5 @@ describe("cardManagementApi requests", () => {
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
     });
-  });
-
-  it("rejects a response that does not match the wire contract", async () => {
-    fetchSpy = jest
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(jsonResponse({ id: "not-a-uuid", verification_state: "VERIFIED" }));
-
-    const store = makeStore("session-token");
-    const result = await store.dispatch(cardManagementApi.endpoints.getUser.initiate());
-
-    expect(result.data).toBeUndefined();
-    expect(result.error).toBeDefined();
   });
 });

--- a/domain/api/card-management/src/cardProvider.mock.ts
+++ b/domain/api/card-management/src/cardProvider.mock.ts
@@ -1,0 +1,80 @@
+import { http, HttpResponse, type JsonBodyType } from "msw";
+import { setupServer } from "msw/node";
+import { PayCardErrorResponseSchema } from "./schema";
+
+export const CARD_API_BASE_URL = "https://card.test";
+
+export type SentRequest = {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: string;
+};
+
+type Answer = () => Response | Promise<Response>;
+
+export type CardProvider = {
+  get: (path: string, answer: Answer) => void;
+  post: (path: string, answer: Answer) => void;
+  sent: () => SentRequest;
+  sentTo: (path: string) => SentRequest[];
+  requests: () => SentRequest[];
+};
+
+export function mockCardProvider(): CardProvider {
+  const server = setupServer();
+  const sentRequests: SentRequest[] = [];
+
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+  afterEach(() => {
+    server.resetHandlers();
+    sentRequests.length = 0;
+  });
+
+  afterAll(() => server.close());
+
+  const route =
+    (method: typeof http.get) =>
+    (path: string, answer: Answer): void => {
+      server.use(
+        method(`${CARD_API_BASE_URL}${path}`, async ({ request }) => {
+          sentRequests.push({
+            url: request.url,
+            method: request.method,
+            headers: request.headers,
+            body: await request.clone().text(),
+          });
+          return answer();
+        }),
+      );
+    };
+
+  return {
+    get: route(http.get),
+    post: route(http.post),
+    sent: () => sentRequests[0],
+    sentTo: path => sentRequests.filter(({ url }) => new URL(url).pathname === path),
+    requests: () => [...sentRequests],
+  };
+}
+
+export function jsonResponse(body: JsonBodyType): Response {
+  return HttpResponse.json(body);
+}
+
+export function errorResponse(status: number, message: string): Response {
+  return HttpResponse.json(PayCardErrorResponseSchema.parse({ message }), { status });
+}
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+export function flushPendingRequests(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4393,6 +4393,9 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.5.0(@types/node@24.12.0)
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       react:
         specifier: 19.1.4
         version: 19.1.4
@@ -38863,10 +38866,6 @@ packages:
     resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
     engines: {node: '>= 10'}
 
-  socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -58123,7 +58122,7 @@ snapshots:
       lru-cache: 6.0.0
       minipass: 3.3.6
       minipass-collect: 1.0.2
-      minipass-flush: 1.0.5
+      minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
@@ -70420,7 +70419,7 @@ snapshots:
     dependencies:
       agent-base: 6.0.2
       debug: 4.4.3
-      socks: 2.8.7
+      socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -70432,12 +70431,6 @@ snapshots:
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
-
-  socks@2.8.7:
-    dependencies:
-      ip-address: 10.7.0
-      smart-buffer: 4.2.0
-    optional: true
 
   socks@2.8.9:
     dependencies:


### PR DESCRIPTION
### 📝 Description

Card management API tests spied on `fetch` and branched on pathnames. The apps and packages such as `swap-quotes` already mock HTTP with MSW.

This PR routes each endpoint through an MSW Card provider (`cardProvider.mock.ts`), records the request that went out, and keeps the same assertions on headers, bodies, optimistic freeze patches, and status refetches.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37119](https://ledgerhq.atlassian.net/browse/LIVE-37119)
- **ADR** (if any): n/a

[LIVE-37119]: https://ledgerhq.atlassian.net/browse/LIVE-37119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ