### PR TITLE
feat(device-onboarding): scaffold session ports and listener

### DIFF
--- a/.changeset/device-onboarding-scaffold.md
+++ b/.changeset/device-onboarding-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-onboarding": minor
+---
+
+Scaffold the shared device onboarding package with ports, events and a session listener

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -415,6 +415,7 @@ libs/ledger-live-common/src/device/                                @ledgerhq/liv
 libs/ledger-live-common/src/deviceSDK/                             @ledgerhq/live-devices
 libs/device-core/                                                  @ledgerhq/live-devices
 libs/device-intent/                                                @ledgerhq/live-devices
+libs/device-onboarding/                                            @ledgerhq/engagement
 features/platform/device-intent/                                   @ledgerhq/live-devices
 features/platform/device-action-content/                           @ledgerhq/live-devices
 features/platform/contacts/src/device/                             @ledgerhq/live-devices

--- a/libs/device-onboarding/README.md
+++ b/libs/device-onboarding/README.md
@@ -1,0 +1,35 @@
+# @ledgerhq/device-onboarding
+
+> [!CAUTION]
+> **Status: UNSTABLE** — The shared onboarding API is under active development.
+
+Headless device-onboarding contracts and state-machine actors shared by Ledger Wallet Desktop
+and Ledger Wallet Mobile.
+
+## Boundaries
+
+The package owns device interactions and routing decisions. It contains no React, screens,
+navigation, analytics, or platform transport implementation. Each app supplies
+`DeviceOnboardingPorts`; the package never imports `live-dmk-desktop`, `live-dmk-mobile`, or a
+legacy onboarding flow.
+
+The app owns the DMK session lifecycle. It opens the session before starting the machine,
+passes the DMK instance into the machine, reconnects after a transport loss, and keeps the
+session open when the machine exits.
+
+## Public API
+
+- `DeviceOnboardingPorts` defines session lifecycle and legacy firmware-update boundaries.
+- `OnboardingEvent`, `DeviceOnboardingInput`, and `DeviceOnboardingContext` define the language
+  used by the future state machine.
+- `DeviceOnboardingOutput` identifies the connected device and the reason the machine exited.
+- `sessionListener` maps DMK session status changes to onboarding events.
+
+## Validation
+
+```sh
+pnpm nx run @ledgerhq/device-onboarding:build
+pnpm nx run @ledgerhq/device-onboarding:typecheck
+pnpm nx run @ledgerhq/device-onboarding:test
+pnpm nx run @ledgerhq/device-onboarding:lint
+```

--- a/libs/device-onboarding/jest.config.js
+++ b/libs/device-onboarding/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["lib/", "lib-es/"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
+  ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
+};

--- a/libs/device-onboarding/package.json
+++ b/libs/device-onboarding/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@ledgerhq/device-onboarding",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared DMK-native device onboarding state machine",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "lib-es/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint -c ../oxc-live-libs/.oxlintrc.json ./src",
+    "lint:fix": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src && oxlint -c ../oxc-live-libs/.oxlintrc.json ./src --fix --quiet",
+    "format": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src",
+    "format:check": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "test": "jest",
+    "coverage": "jest --coverage",
+    "knip-check": "pnpm knip --directory ../.. -W libs/device-onboarding"
+  },
+  "dependencies": {
+    "xstate": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/device-management-kit": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "rxjs": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "@ledgerhq/device-management-kit": "catalog:",
+    "rxjs": "catalog:"
+  },
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/index.ts",
+      "import": "./lib-es/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./package.json": "./package.json"
+  }
+}

--- a/libs/device-onboarding/src/actors/session.test.ts
+++ b/libs/device-onboarding/src/actors/session.test.ts
@@ -1,0 +1,142 @@
+import {
+  DeviceStatus,
+  type DeviceManagementKit,
+  type DeviceSessionState,
+} from "@ledgerhq/device-management-kit";
+import { Subject } from "rxjs";
+import { createActor, setup } from "xstate";
+import { mapSession, sessionListener, type SessionEvent } from "./session";
+
+describe("mapSession", () => {
+  it.each([
+    [DeviceStatus.CONNECTED, DeviceStatus.LOCKED, "LOCKED"],
+    [DeviceStatus.LOCKED, DeviceStatus.CONNECTED, "UNLOCKED"],
+    [DeviceStatus.CONNECTED, DeviceStatus.NOT_CONNECTED, "TRANSPORT_LOST"],
+    [DeviceStatus.LOCKED, DeviceStatus.NOT_CONNECTED, "TRANSPORT_LOST"],
+  ])("maps %s to %s as %s", (previous, next, type) => {
+    expect(mapSession(previous, next)).toEqual({ type });
+  });
+
+  it.each([
+    [undefined, DeviceStatus.CONNECTED],
+    [undefined, DeviceStatus.LOCKED],
+    [DeviceStatus.CONNECTED, DeviceStatus.CONNECTED],
+    [DeviceStatus.LOCKED, DeviceStatus.LOCKED],
+    [DeviceStatus.CONNECTED, DeviceStatus.BUSY],
+    [DeviceStatus.BUSY, DeviceStatus.CONNECTED],
+    [DeviceStatus.LOCKED, DeviceStatus.BUSY],
+    [DeviceStatus.BUSY, DeviceStatus.LOCKED],
+  ])("does not map %s to %s", (previous, next) => {
+    expect(mapSession(previous, next)).toBeUndefined();
+  });
+
+  it("treats an initial disconnected status as transport loss", () => {
+    expect(mapSession(undefined, DeviceStatus.NOT_CONNECTED)).toEqual({
+      type: "TRANSPORT_LOST",
+    });
+  });
+});
+
+describe("sessionListener", () => {
+  it("compares statuses against the last non-BUSY status", () => {
+    const states = new Subject<DeviceSessionState>();
+    const received: SessionEvent[] = [];
+    const actor = createListenerActor(states, received);
+
+    states.next(sessionState(DeviceStatus.CONNECTED));
+    states.next(sessionState(DeviceStatus.BUSY));
+    states.next(sessionState(DeviceStatus.LOCKED));
+    states.next(sessionState(DeviceStatus.BUSY));
+    states.next(sessionState(DeviceStatus.CONNECTED));
+
+    expect(received).toEqual([{ type: "LOCKED" }, { type: "UNLOCKED" }]);
+    actor.stop();
+  });
+
+  it.each(["completion", "error"] as const)("maps observable %s to transport loss", ending => {
+    const states = new Subject<DeviceSessionState>();
+    const received: SessionEvent[] = [];
+    const actor = createListenerActor(states, received);
+
+    if (ending === "completion") {
+      states.complete();
+    } else {
+      states.error(new Error("transport failed"));
+    }
+
+    expect(received).toEqual([{ type: "TRANSPORT_LOST" }]);
+    actor.stop();
+  });
+
+  it("reports transport loss once when disconnection is followed by completion", () => {
+    const states = new Subject<DeviceSessionState>();
+    const received: SessionEvent[] = [];
+    const actor = createListenerActor(states, received);
+
+    states.next(sessionState(DeviceStatus.CONNECTED));
+    states.next(sessionState(DeviceStatus.NOT_CONNECTED));
+    states.complete();
+
+    expect(received).toEqual([{ type: "TRANSPORT_LOST" }]);
+    actor.stop();
+  });
+
+  it("maps a synchronous subscription failure to transport loss", () => {
+    const states = new Subject<DeviceSessionState>();
+    const received: SessionEvent[] = [];
+    const dmk = {
+      getDeviceSessionState: jest.fn(() => {
+        throw new Error("session not found");
+      }),
+    } as unknown as DeviceManagementKit;
+    const actor = createListenerActor(states, received, dmk);
+
+    expect(received).toEqual([{ type: "TRANSPORT_LOST" }]);
+    actor.stop();
+  });
+
+  it("unsubscribes when the actor stops", () => {
+    const states = new Subject<DeviceSessionState>();
+    const actor = createListenerActor(states, []);
+
+    expect(states.observed).toBe(true);
+    actor.stop();
+    expect(states.observed).toBe(false);
+  });
+});
+
+function createListenerActor(
+  states: Subject<DeviceSessionState>,
+  received: SessionEvent[],
+  dmk: DeviceManagementKit = {
+    getDeviceSessionState: jest.fn(() => states.asObservable()),
+  } as unknown as DeviceManagementKit,
+) {
+  const machine = setup({
+    types: {
+      events: {} as SessionEvent,
+    },
+    actors: {
+      sessionListener,
+    },
+    actions: {
+      capture: ({ event }) => received.push(event),
+    },
+  }).createMachine({
+    invoke: {
+      src: "sessionListener",
+      input: { dmk, sessionId: "session" },
+    },
+    on: {
+      LOCKED: { actions: "capture" },
+      UNLOCKED: { actions: "capture" },
+      TRANSPORT_LOST: { actions: "capture" },
+    },
+  });
+
+  return createActor(machine).start();
+}
+
+function sessionState(deviceStatus: DeviceStatus): DeviceSessionState {
+  return { deviceStatus } as DeviceSessionState;
+}

--- a/libs/device-onboarding/src/actors/session.ts
+++ b/libs/device-onboarding/src/actors/session.ts
@@ -1,0 +1,85 @@
+import {
+  DeviceStatus,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+import { fromCallback } from "xstate";
+import type { OnboardingEvent } from "../types";
+
+export type SessionEvent = Extract<
+  OnboardingEvent,
+  { type: "LOCKED" | "UNLOCKED" | "TRANSPORT_LOST" }
+>;
+
+export type SessionListenerInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+};
+
+export function mapSession(
+  previous: DeviceStatus | undefined,
+  next: DeviceStatus,
+): SessionEvent | undefined {
+  if (previous === DeviceStatus.BUSY || next === DeviceStatus.BUSY) {
+    return undefined;
+  }
+
+  if (next === DeviceStatus.NOT_CONNECTED) {
+    return { type: "TRANSPORT_LOST" };
+  }
+
+  if (previous === undefined) {
+    return undefined;
+  }
+
+  if (previous === DeviceStatus.LOCKED && next === DeviceStatus.CONNECTED) {
+    return { type: "UNLOCKED" };
+  }
+
+  if (previous !== DeviceStatus.LOCKED && next === DeviceStatus.LOCKED) {
+    return { type: "LOCKED" };
+  }
+
+  return undefined;
+}
+
+export const sessionListener = fromCallback<SessionEvent, SessionListenerInput>(
+  ({ input, sendBack }) => {
+    let previous: DeviceStatus | undefined;
+    let transportLost = false;
+
+    const sendTransportLost = () => {
+      if (!transportLost) {
+        transportLost = true;
+        sendBack({ type: "TRANSPORT_LOST" });
+      }
+    };
+
+    let subscription: { unsubscribe(): void } | undefined;
+
+    try {
+      subscription = input.dmk.getDeviceSessionState({ sessionId: input.sessionId }).subscribe({
+        next: state => {
+          const next = state.deviceStatus;
+          const event = mapSession(previous, next);
+
+          if (next !== DeviceStatus.BUSY) {
+            previous = next;
+          }
+
+          if (event?.type === "TRANSPORT_LOST") {
+            sendTransportLost();
+          } else if (event !== undefined) {
+            sendBack(event);
+          }
+        },
+        error: sendTransportLost,
+        complete: sendTransportLost,
+      });
+    } catch {
+      sendTransportLost();
+    }
+
+    return () => subscription?.unsubscribe();
+  },
+);

--- a/libs/device-onboarding/src/index.ts
+++ b/libs/device-onboarding/src/index.ts
@@ -1,0 +1,26 @@
+export type {
+  DeviceOnboardingPorts,
+  DeviceOnboardingSession,
+  FirmwareUpdateFailure,
+  FirmwareUpdateInput,
+  FirmwareUpdateProgress,
+  FirmwareUpdateResult,
+  FirmwareUpdateStep,
+} from "./ports";
+export {
+  OnboardingStep,
+  type AvailableFirmwareUpdate,
+  type DeviceOnboardingContext,
+  type DeviceOnboardingExitReason,
+  type DeviceOnboardingInput,
+  type DeviceOnboardingOutput,
+  type DeviceOnboardingState,
+  type OnboardingEvent,
+  type SeedPhraseWordCount,
+} from "./types";
+export {
+  mapSession,
+  sessionListener,
+  type SessionEvent,
+  type SessionListenerInput,
+} from "./actors/session";

--- a/libs/device-onboarding/src/ports.ts
+++ b/libs/device-onboarding/src/ports.ts
@@ -1,0 +1,60 @@
+import type {
+  DeviceManagementKit,
+  DeviceModelId,
+  DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+
+export type DeviceOnboardingSession = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  deviceModelId: DeviceModelId;
+};
+
+export type FirmwareUpdateStep =
+  | "preparingUpdate"
+  | "allowSecureChannelRequested"
+  | "allowSecureChannelDenied"
+  | "installingOsu"
+  | "installOsuDevicePermissionRequested"
+  | "installOsuDevicePermissionGranted"
+  | "installOsuDevicePermissionDenied"
+  | "flashingMcu"
+  | "flashingBootloader"
+  | "firmwareUpdateCompleted";
+
+export type FirmwareUpdateProgress = {
+  step: FirmwareUpdateStep;
+  progress: number;
+};
+
+export type FirmwareUpdateInput = {
+  deviceId: string;
+  deviceName: string | null;
+  onProgress: (progress: FirmwareUpdateProgress) => void;
+};
+
+export type FirmwareUpdateFailure = {
+  source: "updater" | "runtime";
+  name: string;
+  message?: string;
+};
+
+export type FirmwareUpdateResult =
+  | { status: "completed" }
+  | { status: "userRefused" }
+  | { status: "failed"; error: FirmwareUpdateFailure };
+
+/**
+ * Implemented by each app without exposing its live-dmk transport types to this package.
+ *
+ * The app owns the session lifecycle. The machine reads the current id but never opens or closes
+ * a session. `openSession` is the composition boundary that supplies the app's existing DMK
+ * instance. `applyFirmwareUpdate` must resolve on a refusal event without waiting for the updater
+ * observable to complete.
+ */
+export type DeviceOnboardingPorts = {
+  openSession(): Promise<DeviceOnboardingSession>;
+  currentSessionId(): DeviceSessionId;
+  closeSession(): Promise<void>;
+  applyFirmwareUpdate(input: FirmwareUpdateInput): Promise<FirmwareUpdateResult>;
+};

--- a/libs/device-onboarding/src/types.ts
+++ b/libs/device-onboarding/src/types.ts
@@ -1,0 +1,87 @@
+import type {
+  DeviceManagementKit,
+  DeviceModelId,
+  DeviceSessionId,
+  FirmwareUpdateContext,
+} from "@ledgerhq/device-management-kit";
+
+export const OnboardingStep = {
+  WelcomeScreen1: "WELCOME_SCREEN_1",
+  WelcomeScreen2: "WELCOME_SCREEN_2",
+  WelcomeScreen3: "WELCOME_SCREEN_3",
+  WelcomeScreen4: "WELCOME_SCREEN_4",
+  WelcomeScreenReminder: "WELCOME_SCREEN_REMINDER",
+  OnboardingEarlyCheck: "ONBOARDING_EARLY_CHECK",
+  ChooseName: "CHOOSE_NAME",
+  Pin: "PIN",
+  SetupChoice: "SETUP_CHOICE",
+  SetupChoiceRestore: "SETUP_CHOICE_RESTORE",
+  NewDevice: "NEW_DEVICE",
+  NewDeviceConfirming: "NEW_DEVICE_CONFIRMING",
+  RestoreSeed: "RESTORE_SEED",
+  RecoverRestore: "RECOVER_RESTORE",
+  RestoreCharon: "RESTORE_CHARON",
+  SafetyWarning: "SAFETY_WARNING",
+  Ready: "READY",
+} as const;
+
+export type OnboardingStep = (typeof OnboardingStep)[keyof typeof OnboardingStep];
+
+export type SeedPhraseWordCount = 12 | 18 | 24;
+
+export type DeviceOnboardingState = {
+  isOnboarded: boolean;
+  isInRecoveryMode: boolean;
+  managerAllowed: boolean;
+  currentOnboardingStep: OnboardingStep;
+  seedWordIndex: number;
+  seedPhraseWordCount: SeedPhraseWordCount;
+};
+
+export type OnboardingEvent =
+  | { type: "SESSION_READY" }
+  | { type: "LOCKED" }
+  | { type: "UNLOCKED" }
+  | { type: "TRANSPORT_LOST" }
+  | { type: "STEP_CHANGED"; state: DeviceOnboardingState }
+  | { type: "START" }
+  | { type: "RETRY" }
+  | { type: "SKIP" }
+  | { type: "CLOSE" }
+  | { type: "QUIT" }
+  | { type: "USER_ACCEPT" }
+  | { type: "USER_DECLINE" };
+
+export type DeviceOnboardingInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  deviceModelId: DeviceModelId;
+  offerSync: boolean;
+};
+
+export type AvailableFirmwareUpdate = NonNullable<FirmwareUpdateContext["availableUpdate"]>;
+
+export type DeviceOnboardingContext = DeviceOnboardingInput & {
+  lastDeviceState: DeviceOnboardingState | null;
+  genuineChecked: boolean;
+  escEntered: boolean;
+  forcedVersion: boolean;
+  availableFirmwareUpdate: AvailableFirmwareUpdate | null;
+  currentSetupStep: OnboardingStep | null;
+};
+
+export type DeviceOnboardingExitReason =
+  | "completed"
+  | "offerLedgerSync"
+  | "resumeFirmwareUpdate"
+  | "legacyFallback"
+  | "userQuit";
+
+export type DeviceOnboardingOutput = {
+  sessionId: DeviceSessionId;
+  device: {
+    id: string;
+    modelId: DeviceModelId;
+  };
+  reason: DeviceOnboardingExitReason;
+};

--- a/libs/device-onboarding/tsconfig.build.json
+++ b/libs/device-onboarding/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "types": ["node"]
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*"
+  ]
+}

--- a/libs/device-onboarding/tsconfig.json
+++ b/libs/device-onboarding/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12374,6 +12374,46 @@ importers:
         specifier: 'catalog:'
         version: 1.79.0
 
+  libs/device-onboarding:
+    dependencies:
+      xstate:
+        specifier: 'catalog:'
+        version: 5.19.2
+    devDependencies:
+      '@ledgerhq/device-management-kit':
+        specifier: 'catalog:'
+        version: 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.5.0(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.79.0
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   libs/device-react:
     dependencies:
       '@ledgerhq/device-core':


### PR DESCRIPTION
…(LIVE-36058)

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Scaffold `@ledgerhq/device-onboarding`, the shared headless package for the onboarding revamp (LIVE-36058).
- Expose the app ports (session + firmware update), the machine event/context/exit types, and a DMK session listener that reports lock, unlock, and disconnect.


<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36058]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36058]: https://ledgerhq.atlassian.net/browse/LIVE-36058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ