### PR TITLE
[LWDM] fix(concordium): file fee errors under the amount key (LIVE-37061)

### DIFF
--- a/.changeset/concordium-fee-error-key.md
+++ b/.changeset/concordium-fee-error-key.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-concordium": patch
+---
+
+Report Concordium fee errors under a key the send flow renders
+
+`getTransactionStatus` filed fee errors under `errors.fee`, which no file in the
+desktop `modals/Send/` tree reads, so an unpriced transfer greyed out Continue with
+no message. They are now reported under `amount`, after the checks for the states
+that leave a PLT fee unset, so the specific cause still wins.

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
@@ -1,5 +1,6 @@
 import {
   AmountRequired,
+  FeeNotLoaded,
   FeeRequired,
   FeeTooHigh,
   InvalidAddress,
@@ -7,7 +8,7 @@ import {
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
-import { MAX_MEMO_LENGTH, PLT_MAX_MEMO_SIZE } from "@ledgerhq/concordium-core";
+import { MAX_MEMO_LENGTH, PLT_MAX_DECIMALS, PLT_MAX_MEMO_SIZE } from "@ledgerhq/concordium-core";
 import {
   createFixtureAccount,
   createFixtureTokenAccount,
@@ -99,7 +100,7 @@ describe("getTransactionStatus", () => {
       const result = await getTransactionStatus(account, transaction);
 
       // THEN
-      expect(result.errors.fee).toBeInstanceOf(FeeRequired);
+      expect(result.errors.amount).toBeInstanceOf(FeeRequired);
     });
 
     it("should return FeeRequired error when fee is zero", async () => {
@@ -111,7 +112,47 @@ describe("getTransactionStatus", () => {
       const result = await getTransactionStatus(account, transaction);
 
       // THEN
-      expect(result.errors.fee).toBeInstanceOf(FeeRequired);
+      expect(result.errors.amount).toBeInstanceOf(FeeRequired);
+    });
+
+    // The key matters as much as the error: nothing under the desktop
+    // `modals/Send/` tree reads `errors.fee`, so filing it there greys out
+    // Continue with no message. See LIVE-37061.
+    it("files the fee error under a key the desktop send flow renders", async () => {
+      // GIVEN
+      const account = createFixtureAccount();
+      const transaction = createFixtureTransaction({ fee: null });
+
+      // WHEN
+      const result = await getTransactionStatus(account, transaction);
+
+      // THEN
+      expect(result.errors.fee).toBeUndefined();
+      expect(result.errors.amount).toBeInstanceOf(FeeRequired);
+    });
+
+    it("reports a NaN fee as not loaded", async () => {
+      // GIVEN - `fromTransactionRaw` yields NaN for a corrupt persisted fee
+      const account = createFixtureAccount();
+      const transaction = createFixtureTransaction({ fee: new BigNumber(NaN) });
+
+      // WHEN
+      const result = await getTransactionStatus(account, transaction);
+
+      // THEN
+      expect(result.errors.amount).toBeInstanceOf(FeeNotLoaded);
+    });
+
+    it("prefers the amount error over the missing fee", async () => {
+      // GIVEN - both would fire; the amount is the one the user can act on
+      const account = createFixtureAccount();
+      const transaction = createFixtureTransaction({ amount: new BigNumber(0), fee: null });
+
+      // WHEN
+      const result = await getTransactionStatus(account, transaction);
+
+      // THEN
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
     });
 
     it("should return FeeTooHigh warning when fee exceeds 10x the amount", async () => {
@@ -710,12 +751,35 @@ describe("getTransactionStatus", () => {
       expect(status.errors.recipient).toBeInstanceOf(InvalidAddress);
     });
 
-    it("reports a missing fee, as the native path does", async () => {
+    it("reports a missing fee under `amount`, as the native path does", async () => {
       const { account, subAccount } = withToken();
 
       const status = await getTransactionStatus(account, tokenTx(subAccount.id, { fee: null }));
 
-      expect(status.errors.fee).toBeInstanceOf(FeeRequired);
+      expect(status.errors.fee).toBeUndefined();
+      expect(status.errors.amount).toBeInstanceOf(FeeRequired);
+    });
+
+    // Each state that leaves the fee unset has its own error, so the bare
+    // "fee missing" must not mask the reason the fee could not be priced.
+    it("prefers the unsupported-decimals error over the missing fee it caused", async () => {
+      const { account, subAccount } = withToken({ magnitude: PLT_MAX_DECIMALS + 1 });
+
+      const status = await getTransactionStatus(account, tokenTx(subAccount.id, { fee: null }));
+
+      expect(status.errors.amount).toBeInstanceOf(ConcordiumUnsupportedTokenDecimals);
+    });
+
+    it("prefers the over-long memo over the missing fee it caused", async () => {
+      const { account, subAccount } = withToken();
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { fee: null, memo: "a".repeat(PLT_MAX_MEMO_SIZE + 1) }),
+      );
+
+      expect(status.errors.memo).toBeInstanceOf(ConcordiumMemoTooLong);
+      expect(status.errors.amount).toBeUndefined();
     });
 
     it("requires a non-zero amount", async () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
@@ -57,6 +57,19 @@ function validateAmount(
   }
 }
 
+/**
+ * Reported under `amount`, not `fee`.
+ *
+ * No file under the desktop `modals/Send/` tree reads `errors.fee`, so a fee
+ * error filed there disables Continue with nothing on screen to explain it.
+ * `amount` is rendered by `AmountField`, and mobile shows the first error under
+ * any key either way. `coin-algorand` files `NotEnoughBalanceInParentAccount`
+ * under `amount` for the same reason. See LIVE-37061.
+ *
+ * The `isNaN` branch is a fail-closed guard, not dead code: `fromTransactionRaw`
+ * builds the fee with `new BigNumber(tr.fee)`, and a `BigNumber` holding NaN is
+ * a truthy object, so it survives the `transaction.fee || 0` default.
+ */
 function validateFee(estimatedFees: BigNumber): Error | undefined {
   if (estimatedFees.isNaN()) {
     return new FeeNotLoaded();
@@ -236,17 +249,24 @@ function getTokenTransactionStatus(
       ? undefined
       : validatePayloadSize(subAccount, transaction, decimals);
 
+  // An over-long memo leaves the fee unset and is filed under `memo`, not in
+  // the `amount` chain, so checking the fee here would add a bare "fee missing"
+  // beside the message that names the real cause. `sizeError` is skipped alike.
+  const feeError = memoError ? undefined : validateFee(estimatedFees);
+
   Object.assign(errors, {
     sender: validateTokenPolicy(tokenState),
+    // The other two states that leave the fee unset — an absent magnitude, too
+    // many decimals — have their own error above, so a bare "fee missing" only
+    // surfaces once neither applies. It precedes `validateCcdForFee`, which
+    // cannot judge coverage of an unset fee.
     amount:
       validateTokenDecimals(decimals) ??
       validateTokenId(tokenId) ??
       validateTokenAmount(transaction, subAccount, amount) ??
+      feeError ??
       validateCcdForFee(account, estimatedFees, reserveAmount) ??
       sizeError,
-    // Filed under `fee` to match the native path. It does not render in the
-    // desktop send flow — see LIVE-37061, which covers both paths.
-    fee: validateFee(estimatedFees),
     recipient: recipientError,
   });
 
@@ -353,8 +373,9 @@ export const getTransactionStatus: AccountBridge<
   }
 
   Object.assign(errors, {
-    amount: validateAmount(transaction, account, amount, totalSpent, reserveAmount),
-    fee: validateFee(estimatedFees),
+    amount:
+      validateAmount(transaction, account, amount, totalSpent, reserveAmount) ??
+      validateFee(estimatedFees),
     recipient: validateRecipient(transaction, account),
   });
 


### PR DESCRIPTION
### 📝 Description

`getTransactionStatus` filed fee errors under `errors.fee`. No file under the desktop
`modals/Send/` tree reads that key, so an unpriced transfer greyed out Continue with no
message. Mobile was unaffected — it renders the first error under any key.

Reachable via PLT: `estimatePltFees` returns no estimate for an absent magnitude, decimals
over the ceiling, or an over-long memo, and `prepareTransaction` then leaves the fee unset.

Fee errors now go under `amount`, which `AmountField` renders, matching `coin-algorand`'s
handling of `NotEnoughBalanceInParentAccount`. On the PLT path `validateFee` joins the
existing `amount` chain after the three checks whose failure causes the unset fee, so the
specific cause still wins, and before `validateCcdForFee`, which cannot judge coverage of
an unset fee. On the native path `AmountRequired` keeps precedence.

Coin-module only — no shared UI change, no new error type, no new strings.

Regression cover in `getTransactionStatus.test.ts`: the key itself (`errors.fee` unset,
`errors.amount` set) on both paths, plus the three precedence cases.

The ticket's note that `FeeNotLoaded` is dead code is wrong, so the branch stays. A
`BigNumber` holding NaN is a truthy object, so `transaction.fee || 0` does not default it,
and `fromTransactionRaw` builds the fee with `new BigNumber(tr.fee)` — a corrupt persisted
fee reaches `validateFee` as NaN. Documented as a fail-closed guard, with a test.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37061](https://ledgerhq.atlassian.net/browse/LIVE-37061)
- **ADR** (if any): n/a


[LIVE-37061]: https://ledgerhq.atlassian.net/browse/LIVE-37061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ