### PR TITLE
[LWM] fix(mobile): crossfade welcome stories to remove flicker (LIVE-36099)

### DIFF
--- a/.changeset/LIVE-36099-welcome-story-crossfade.md
+++ b/.changeset/LIVE-36099-welcome-story-crossfade.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix welcome screen flicker on mobile: crossfade between onboarding stories instead of a hard `display:none`/`flex` swap, which detached the off-stage video player and repainted a black frame when a story was revealed. Off-stage stories now stay composited and fade with opacity, removing the flicker during story transitions.

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet } from "react-native";
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 import { useTranslation } from "~/context/Locale";
 import Video, { OnLoadData, ReactVideoSource, VideoRef } from "react-native-video";
@@ -8,9 +8,6 @@ import { VideoTitleText } from "./WelcomePage.styles";
 
 // Stories crossfade rather than cut, so a revealed player never flashes its first frame in.
 const CROSSFADE_DURATION_MS = 250;
-
-// DIAGNOSTIC (LIVE-36099): one color per story so the crossfade is visible without the video.
-const DIAGNOSTIC_COLORS = ["#E11D48", "#2563EB", "#16A34A"];
 
 type VideoBackgroundProps = {
   videoSource: ReactVideoSource;
@@ -95,20 +92,6 @@ export function VideoBackground({
           paused={!isOnStage}
         />
       )}
-      {/* DIAGNOSTIC (LIVE-36099): colored overlay on top of the video, driven by the same
-          crossfade opacity. If you see these colors fading between stories, the crossfade
-          layer renders fine and the black is react-native-video on the simulator. If it stays
-          black, the opacity change is at fault. REVERT before merge. */}
-      <View
-        pointerEvents="none"
-        style={[
-          StyleSheet.absoluteFill,
-          {
-            backgroundColor:
-              DIAGNOSTIC_COLORS[Number(titleKey.slice(-1)) % DIAGNOSTIC_COLORS.length],
-          },
-        ]}
-      />
       <VideoTitleText>{t(titleKey)}</VideoTitleText>
     </Animated.View>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
@@ -1,9 +1,13 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 import { useTranslation } from "~/context/Locale";
 import Video, { OnLoadData, ReactVideoSource, VideoRef } from "react-native-video";
 import useIsAppInBackground from "~/components/useIsAppInBackground";
 import { VideoTitleText } from "./WelcomePage.styles";
+
+// Stories crossfade rather than cut, so a revealed player never flashes its first frame in.
+const CROSSFADE_DURATION_MS = 250;
 
 type VideoBackgroundProps = {
   videoSource: ReactVideoSource;
@@ -31,6 +35,15 @@ export function VideoBackground({
   const videoRef = useRef<VideoRef | null>(null);
   const hasLoadedRef = useRef(false);
   const videoMounted = !useIsAppInBackground();
+
+  // Off-stage stories stay mounted at zero opacity instead of display:none. A player detached
+  // by display:none repaints a black frame when it is shown again, which reads as a flicker
+  // during the story transition; keeping the layer composited and crossfading avoids it.
+  const opacity = useSharedValue(isOnStage ? 1 : 0);
+  useEffect(() => {
+    opacity.value = withTiming(isOnStage ? 1 : 0, { duration: CROSSFADE_DURATION_MS });
+  }, [isOnStage, opacity]);
+  const animatedContainerStyle = useAnimatedStyle(() => ({ opacity: opacity.value }), [opacity]);
 
   const handleLoad = useCallback(
     (data: OnLoadData) => {
@@ -64,7 +77,7 @@ export function VideoBackground({
   }, [isOnStage, onVideoEnd]);
 
   return (
-    <View style={[styles.container, { display: isOnStage ? "flex" : "none" }]}>
+    <Animated.View style={[styles.container, animatedContainerStyle]} pointerEvents="none">
       {videoMounted && (
         <Video
           ref={videoRef}
@@ -80,7 +93,7 @@ export function VideoBackground({
         />
       )}
       <VideoTitleText>{t(titleKey)}</VideoTitleText>
-    </View>
+    </Animated.View>
   );
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import { StyleSheet } from "react-native";
+import { StyleSheet, View } from "react-native";
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 import { useTranslation } from "~/context/Locale";
 import Video, { OnLoadData, ReactVideoSource, VideoRef } from "react-native-video";
@@ -8,6 +8,9 @@ import { VideoTitleText } from "./WelcomePage.styles";
 
 // Stories crossfade rather than cut, so a revealed player never flashes its first frame in.
 const CROSSFADE_DURATION_MS = 250;
+
+// DIAGNOSTIC (LIVE-36099): one color per story so the crossfade is visible without the video.
+const DIAGNOSTIC_COLORS = ["#E11D48", "#2563EB", "#16A34A"];
 
 type VideoBackgroundProps = {
   videoSource: ReactVideoSource;
@@ -92,6 +95,20 @@ export function VideoBackground({
           paused={!isOnStage}
         />
       )}
+      {/* DIAGNOSTIC (LIVE-36099): colored overlay on top of the video, driven by the same
+          crossfade opacity. If you see these colors fading between stories, the crossfade
+          layer renders fine and the black is react-native-video on the simulator. If it stays
+          black, the opacity change is at fault. REVERT before merge. */}
+      <View
+        pointerEvents="none"
+        style={[
+          StyleSheet.absoluteFill,
+          {
+            backgroundColor:
+              DIAGNOSTIC_COLORS[Number(titleKey.slice(-1)) % DIAGNOSTIC_COLORS.length],
+          },
+        ]}
+      />
       <VideoTitleText>{t(titleKey)}</VideoTitleText>
     </Animated.View>
   );


### PR DESCRIPTION
### 📝 Description

Follow-up to [#21130](https://github.com/LedgerHQ/ledger-live/pull/21130), which fixed the **stepper** duration-snap flicker on the mobile welcome screen but left the **story-to-story video transition** untouched. The PM confirmed the flicker is still visible on mobile.

Root cause: off-stage stories were hidden with `display: none`. A player detached by `display:none` repaints a **black frame** when it is shown again, which reads as a flicker during the story transition. Desktop already avoids this by crossfading opacity; mobile did a hard cut.

**Fix** (`VideoBackground.tsx`): keep every story composited and **crossfade opacity** (250ms) instead of toggling `display`. The layer stays "warm", so there is no black frame on reveal. Reduced-motion users fall back to Reanimated's default instant swap — no worse than today.

### 🔗 Context

- **JIRA**: [LIVE-36099](https://ledgerhq.atlassian.net/browse/LIVE-36099)
- **Follows**: [#21130](https://github.com/LedgerHQ/ledger-live/pull/21130) — stepper duration-snap fix (mobile-only)

### ⚠️ Needs manual visual verification

This is a visual bug; it was **not** reproduced/verified on a device in this change — only static analysis + unit tests. Please verify on a simulator/device before merging:
- [ ] Cold-start onto the welcome screen; watch transitions between stories 1 → 2 → 3 — no black flash / flicker
- [ ] Tap forward/back through stories — smooth crossfade, correct story shown
- [ ] Loop past the last story back to the first — no flash
- [ ] Background → foreground the app on the welcome screen — resets to story 1 cleanly
- [ ] Reduced-motion enabled — transition is an instant swap (acceptable), no flicker

### Test plan

- [x] `jest src/mvvm/features/WelcomePage` — 22/22 pass (seek/lifecycle contracts unchanged)
- [ ] Manual visual verification on device (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-36099]: https://ledgerhq.atlassian.net/browse/LIVE-36099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ