### PR TITLE
[LWD] fix(pay): put the paid amount under the You paid title

### DIFF
--- a/.changeset/calm-pay-success-desktop-hero.md
+++ b/.changeset/calm-pay-success-desktop-hero.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Put the paid amount under the You paid title on the Pay success dialog.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -955,7 +955,7 @@
         "addAddress": "Add address"
       },
       "paySuccess": {
-        "title": "You paid ({{recipient}}) {{amount}}",
+        "title": "You paid ({{recipient}})",
         "amount": "Amount",
         "estimatedTime": "Est. time",
         "from": "From",

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.web.tsx
@@ -38,12 +38,12 @@ export function PaySuccessHero({
       ) : (
         <Avatar size={AVATAR_SIZE} aria-hidden />
       )}
-      <p className="heading-3-semi-bold text-center">
-        {t("payTab.contacts.paySuccess.title", {
-          recipient: recipientLabel,
-          amount: amountFormatted,
-        })}
-      </p>
+      <div className="flex flex-col items-center gap-8">
+        <p className="text-center heading-3-semi-bold">
+          {t("payTab.contacts.paySuccess.title", { recipient: recipientLabel })}
+        </p>
+        <p className="text-center heading-2-semi-bold">{amountFormatted}</p>
+      </div>
     </div>
   );
 }

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.web.tsx
@@ -39,10 +39,10 @@ export function PaySuccessHero({
         <Avatar size={AVATAR_SIZE} aria-hidden />
       )}
       <div className="flex flex-col items-center gap-8">
-        <p className="text-center heading-3-semi-bold">
+        <h3 className="text-center heading-3-semi-bold">
           {t("payTab.contacts.paySuccess.title", { recipient: recipientLabel })}
-        </p>
-        <p className="text-center heading-2-semi-bold">{amountFormatted}</p>
+        </h3>
+        <h3 className="text-center heading-3-semi-bold">{amountFormatted}</h3>
       </div>
     </div>
   );

--- a/features/flow/pay-contact/src/components/PaySuccess/__tests__/PaySuccess.web.test.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/__tests__/PaySuccess.web.test.tsx
@@ -23,7 +23,8 @@ describe("PaySuccess (Web)", () => {
     renderStep();
 
     expect(screen.getByTestId("pay-success-step")).toBeVisible();
-    expect(screen.getByText(/You paid/)).toHaveTextContent("You paid (Ada) 100 USDC");
+    expect(screen.getByText("You paid (Ada)")).toBeVisible();
+    expect(screen.getAllByText("100 USDC")[0]).toBeVisible();
     expect(screen.getByText("Ethereum 1")).toBeVisible();
   });
 
@@ -50,7 +51,8 @@ describe("PaySuccess (Web)", () => {
     renderStep({ recipient: undefined, recipientLabel: "0x1ad2...c53034" });
 
     expect(screen.getByTestId("pay-success-step")).toBeVisible();
-    expect(screen.getByText(/You paid/)).toHaveTextContent("You paid (0x1ad2...c53034) 100 USDC");
+    expect(screen.getByText("You paid (0x1ad2...c53034)")).toBeVisible();
+    expect(screen.getAllByText("100 USDC")[0]).toBeVisible();
   });
 
   it("calls onViewTransaction when the primary CTA is clicked", () => {

--- a/features/flow/pay-contact/src/components/PaySuccess/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/__tests__/shared.web.tsx
@@ -9,7 +9,7 @@ export const PAY_SUCCESS_RESOURCES: I18nTestProviderProps["resources"] = {
       payTab: {
         contacts: {
           paySuccess: {
-            title: "You paid ({{recipient}}) {{amount}}",
+            title: "You paid ({{recipient}})",
             amount: "Amount",
             estimatedTime: "Est. time",
             from: "From",


### PR DESCRIPTION
## Summary
- Stack the paid amount under **You paid (Name)** on the desktop Pay success dialog
- Match Figma `7870:52525` (dialog + overlay already comes from the Send `Dialog`)

## Test plan
- [ ] Pay send on desktop → success shows title, then amount on the next line
- [ ] Unknown recipient still shows truncated address + amount below
- [ ] View transaction and Close still work