### PR TITLE
[LWDM] fix(tezos): name the too-small stake amount error (LIVE-37117)

### DIFF
--- a/.changeset/brisk-otters-wander.md
+++ b/.changeset/brisk-otters-wander.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add the error message shown when the protocol refuses a Tezos stake amount as too small

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7566,6 +7566,9 @@
     "TezosStakeBlockedByPendingUnstake": {
       "title": "Unstaking from your previous validator must finish first"
     },
+    "TezosStakeAmountTooSmall": {
+      "title": "This amount is too small to stake"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -996,6 +996,9 @@
     "TezosStakeBlockedByPendingUnstake": {
       "title": "Unstaking from your previous validator must finish first"
     },
+    "TezosStakeAmountTooSmall": {
+      "title": "This amount is too small to stake"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`@ledgerhq/coin-tezos` now reports a typed `TezosStakeAmountTooSmall` when the protocol refuses a stake too small to mint a staking pseudotoken (companion PR in LedgerHQ/coin-modules). Without a matching key `TranslatedError` falls back to the generic "Something went wrong", so this adds the copy to both apps.

Nothing in the repo pins locale keys, so there is no regression test to add here. Verified by hand on desktop with the companion branch built into `node_modules`: `0.000001` XTZ shows the message under the amount field with Continue disabled, `0.000002` XTZ estimates normally.

**Not complete on its own.** The error only reaches the apps once coin-tezos publishes and `pnpm-workspace.yaml` pins the new version. That bump lands here as a second commit with its own changeset; until then the stake flow stays broken on develop.

<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37117](https://ledgerhq.atlassian.net/browse/LIVE-37117)
- **ADR** (if any): none — error copy only, no architectural decision involved.

[LIVE-37117]: https://ledgerhq.atlassian.net/browse/LIVE-37117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ