### PR TITLE
[LWD] fix(perps): render the add-account drawer on the fullscreen route

### DIFF
--- a/.changeset/perps-add-account-drawer.md
+++ b/.changeset/perps-add-account-drawer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Render the add-account drawer on the fullscreen Perps route, where the main shell and its drawer are hidden (LIVE-35326).

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/index.tsx
@@ -1,14 +1,20 @@
 import React from "react";
 import { Routes, Route } from "react-router";
 import { PerpsApp } from "LLD/features/Perps/screens/PerpsApp";
+import Drawer from "~/renderer/drawers/Drawer";
 
 const Perps = () => {
   return (
-    <div className="absolute inset-0 z-20 flex h-screen w-screen flex-col">
-      <Routes>
-        <Route path="/" element={<PerpsApp />} />
-      </Routes>
-    </div>
+    <>
+      <div className="absolute inset-0 z-20 flex h-screen w-screen flex-col">
+        <Routes>
+          <Route path="/" element={<PerpsApp />} />
+        </Routes>
+      </div>
+      {/* This route hides the main shell, so setDrawer callers such as
+          add-account have no renderer without this. */}
+      <Drawer />
+    </>
   );
 };
 


### PR DESCRIPTION
`/perps` hides the main shell, and with it the `<Drawer />` that renders `setDrawer` callers, so Add account opened a drawer nothing rendered until the user left Perps. Mount `<Drawer />` alongside the Perps overlay.

Old

https://github.com/user-attachments/assets/305b8b4e-7310-48f7-b684-762193fdd396

New

https://github.com/user-attachments/assets/942c351d-34af-4f49-bc41-c50000d9bd08
