### PR TITLE
[LWM] fix(contacts): close add address drawer before DIE (LIVE-37146)

### DIFF
--- a/.changeset/olive-moons-brush.md
+++ b/.changeset/olive-moons-brush.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Close the contacts add address drawer before the device intent executor runs

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.test.ts
@@ -1,12 +1,20 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { mockMeContact } from "@domain/entity-contact/schema.mock";
-import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { act, renderHook, waitFor, withFlagOverrides } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import { useContactsLedgerSyncStatus } from "../../hooks/useContactsLedgerSyncStatus";
 import { useContactDetailScreenViewModel } from "./useContactDetailScreenViewModel";
 
 const mockGoBack = jest.fn();
 const mockReplace = jest.fn();
+const mockRegisterExternalAddress = jest.fn(() => new Promise(() => {}));
+
+jest.mock("@features/platform-contacts/device", () => ({
+  useContactsIntentsOrchestrator: () => ({
+    deviceIntents: { registerExternalAddress: mockRegisterExternalAddress },
+    dieProps: undefined,
+  }),
+}));
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual<typeof import("@react-navigation/native")>("@react-navigation/native"),
@@ -69,5 +77,63 @@ describe("useContactDetailScreenViewModel", () => {
 
     expect(result.current.status).toBe("redirecting");
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("should close the add address flow when the device registration starts", async () => {
+    const contact = mockMeContact();
+    mockedUseRoute.mockReturnValue({
+      key: ScreenName.MyWalletContactDetail,
+      name: ScreenName.MyWalletContactDetail,
+      params: { contactId: contact.id },
+    });
+    mockedUseNavigation.mockReturnValue({
+      navigate: jest.fn(),
+      goBack: mockGoBack,
+      replace: mockReplace,
+      canGoBack: jest.fn(() => true),
+    } as never);
+
+    const { result } = renderHook(() => useContactDetailScreenViewModel(), {
+      overrideInitialState: withFlagOverrides(
+        {
+          lwmContacts: {
+            enabled: true,
+            params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+          },
+        },
+        state => ({ ...state, contacts: { contacts: [contact] } }),
+      ),
+    });
+
+    const viewModel = () => {
+      if (result.current.status !== "ready") throw new Error("view model is not ready");
+      return result.current;
+    };
+
+    act(() => viewModel().pageProps.onAddAddress());
+    act(() =>
+      viewModel().addAddressFlowProps.onCurrencySelected({
+        currencyId: mockContactAddress().currencyId,
+        assetDisplayName: "Ethereum",
+      }),
+    );
+    act(() =>
+      viewModel().addAddressFlowProps.onAddressChange(
+        "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        "manual",
+      ),
+    );
+    await waitFor(() => {
+      expect(viewModel().addAddressFlowState).toMatchObject({
+        status: "enteringAddress",
+        addressEntry: { status: "valid" },
+      });
+    });
+
+    act(() => viewModel().addAddressFlowProps.onAddressConfirm());
+    act(() => viewModel().addAddressFlowProps.onContinueFromName());
+
+    expect(mockRegisterExternalAddress).toHaveBeenCalledTimes(1);
+    expect(viewModel().addAddressFlowState.status).toBe("closed");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -287,20 +287,29 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
         });
     }
 
-    continueFromName();
     if (
       addAddressFlowState.status === "namingAddress" &&
       addAddressFlowState.entryMode === "mad" &&
       addAddressFlowState.addressLabel.status === "valid"
     ) {
+      closeAddAddress();
       void completeAddressConfirmation({
         ...addAddressFlowState,
         addressEntry: addAddressFlowState.addressEntry,
         addressLabel: addAddressFlowState.addressLabel,
         status: "confirmationRequired",
       });
+      return;
     }
-  }, [addAddressFlowState, analytics, completeAddressConfirmation, continueFromName]);
+
+    continueFromName();
+  }, [
+    addAddressFlowState,
+    analytics,
+    closeAddAddress,
+    completeAddressConfirmation,
+    continueFromName,
+  ]);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),


### PR DESCRIPTION
### 📝 Description

**Previous behaviour**: Adding an address to a contact left the "Name address" bottom sheet open after pressing Continue. The Device Intent Executor is another queued bottom sheet, so it stayed behind in the queue and the device step only appeared once the naming sheet was closed manually.

**Fix**: `onContinueFromName` now closes the add address flow before handing the registration to the device, which frees the queue slot for the executor. This mirrors what the rename address / rename contact dialogs and the Send "add contact" flow already do. The address is still saved once signed: `completeAddressConfirmation` works on its own snapshot of the flow state, and a device rejection was already closing the flow.

**Regression check**: new unit test in `useContactDetailScreenViewModel.test.ts` — with a pending device registration, the flow state must be `closed`. It fails on `develop` with `confirmationRequired`.

BEFORE

https://github.com/user-attachments/assets/d8e770b8-929a-46df-b564-466a05171ec9



AFTER

https://github.com/user-attachments/assets/52c3ce99-6aed-4432-9adf-56d4ea4c622e


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37146](https://ledgerhq.atlassian.net/browse/LIVE-37146)
- **ADR** (if any): n/a

[LIVE-37146]: https://ledgerhq.atlassian.net/browse/LIVE-37146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ