### PR TITLE
[LWDM] test(concordium): cover 2-decimal PLT amounts

### DIFF
--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
@@ -624,6 +624,22 @@ describe("getTransactionStatus", () => {
       expect(status.errors.sender).toBeInstanceOf(ConcordiumTokenTransferNotPermitted);
     });
 
+    // The funded testnet tokens declare 2 decimals, not the usual 6.
+    // `validatePayloadSize` encodes with the token's own magnitude, so this runs
+    // the PLT path at that width.
+    it("accepts a 2-decimal token transfer", async () => {
+      const { account, subAccount } = withToken({ magnitude: 2, balance: new BigNumber(60000) });
+
+      const status = await getTransactionStatus(
+        account,
+        tokenTx(subAccount.id, { amount: new BigNumber(30000) }),
+      );
+
+      expect(status.errors).toEqual({});
+      expect(status.amount).toEqual(new BigNumber(30000));
+      expect(status.totalSpent).toEqual(new BigNumber(30000));
+    });
+
     it("rejects a token declaring more decimals than the device signs", async () => {
       const { account, subAccount } = withToken({ magnitude: 19 });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
@@ -128,6 +128,19 @@ describe("resolveTokenSubAccounts", () => {
     expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
   });
 
+  // `Token1` and `tokmet` on testnet declare 2 decimals, not the 6 every other
+  // PLT uses, so this covers the agreeing-magnitude path at the second width.
+  it("builds a sub-account for a 2-decimal token", async () => {
+    useStore({ [TOKEN_ID]: makeToken(TOKEN_ID, 2) });
+
+    const result = await resolve({ accountTokens: [makeEntry({ balance: "60000", decimals: 2 })] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    const [sub] = result.subAccounts;
+    expect(sub.token.units[0].magnitude).toBe(2);
+    expect(sub.balance).toEqual(new BigNumber("60000"));
+  });
+
   it("publishes no balance for a token whose CAL magnitude disagrees with the chain", async () => {
     useStore({ [TOKEN_ID]: makeToken(TOKEN_ID, 8) });
 

--- a/libs/concordium-core/src/plt.test.ts
+++ b/libs/concordium-core/src/plt.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./plt";
 
 // The expected byte strings below were derived independently of this
-// implementation, from the device and chain CBOR encoders, so they catch an
-// encoder that is merely self-consistent.
+// implementation — from the device and chain CBOR encoders, or by hand from
+// RFC 8949 — so they catch an encoder that is merely self-consistent.
 const ZERO_ADDRESS = AccountAddress.fromBuffer(Buffer.alloc(32));
 const SEQ_ADDRESS = AccountAddress.fromBuffer(Buffer.from(Array.from({ length: 32 }, (_, i) => i)));
 
@@ -22,6 +22,12 @@ describe("plt/encodePltAmount", () => {
 
   it("encodes a zero amount with zero decimals", () => {
     expect(encodePltAmount(0n, 0).toString("hex")).toBe("c4820000");
+  });
+
+  // Every live PLT declares 6 decimals except the two the Concordium team funded
+  // for testing, which declare 2. 60000 is one account's real balance: 600.00.
+  it("encodes a 2-decimal amount, the width the test tokens use", () => {
+    expect(encodePltAmount(60_000n, 2).toString("hex")).toBe("c4822119ea60");
   });
 
   it("encodes the maximum unsigned 64-bit significand", () => {
@@ -122,6 +128,18 @@ describe("plt/encodePltTransferOperations", () => {
 
     expect(encoded.toString("hex")).toBe(
       "81a1687472616e73666572a266616d6f756e74c482251a000f424069726563697069656e74d99d73a10358200000000000000000000000000000000000000000000000000000000000000000",
+    );
+  });
+
+  it("matches the reference encoding for a 2-decimal transfer", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: ZERO_ADDRESS,
+      amount: 60_000n,
+      decimals: 2,
+    });
+
+    expect(encoded.toString("hex")).toBe(
+      "81a1687472616e73666572a266616d6f756e74c4822119ea6069726563697069656e74d99d73a10358200000000000000000000000000000000000000000000000000000000000000000",
     );
   });
 


### PR DESCRIPTION
### 📝 Description

Test-only. No production code changes, so no changeset.

Every live PLT declares 6 decimals except `Token1` and `tokmet` on testnet, which declare 2
and are the tokens the Concordium team funded for our PLT testing. Existing coverage asserted
reference bytes at 6, 0 and 18 decimals, and built sub-accounts at 6 only.

Added:

- `concordium-core` — reference encodings for a 2-decimal amount and for a full 2-decimal
  transfer blob. Both expected byte strings were derived by hand from RFC 8949 and verified by
  decoding them with a separate decoder, not produced by the encoder under test. The file's
  provenance comment is widened to say so.
- `coin-concordium` — `resolveTokenSubAccounts` builds a sub-account for a 2-decimal token
  (the agreeing-magnitude path previously ran at one width; the disagreeing path was already
  covered).
- `coin-concordium` — `getTransactionStatus` accepts a 2-decimal PLT transfer, which runs
  `validatePayloadSize` at that magnitude.

Values mirror the funded accounts: raw `60000` at 2 decimals is 600.00.

### 🔗 Context

- **JIRA / GitHub issue**: none — coverage gap found while validating PLT behaviour against
  testnet on-chain data
- **ADR** (if any): n/a
