### PR TITLE
feat(pay): add card numbers reveal view-model (LIVE-35436)

### DIFF
--- a/.changeset/LIVE-35436-pay-card-numbers-reveal.md
+++ b/.changeset/LIVE-35436-pay-card-numbers-reveal.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-details": minor
+---
+
+Add a card-numbers reveal view-model that unlocks via Ledger Wallet password or biometrics, then mints the secure details image URL

--- a/features/flow/pay-card-details/package.json
+++ b/features/flow/pay-card-details/package.json
@@ -28,6 +28,7 @@
     "unimported": "pnpm knip --directory ../../.. -c features/flow/pay-card-details/knip.web.config.mjs -W features/flow/pay-card-details --tsConfig tsconfig.web.json && pnpm knip --directory ../../.. -c features/flow/pay-card-details/knip.native.config.mjs -W features/flow/pay-card-details --tsConfig tsconfig.native.json"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
     "@domain/api-card-management": "workspace:*",
     "@features/flow-pay-card-auth": "workspace:*",
     "@ledgerhq/lumen-utils-shared": "catalog:",
@@ -35,6 +36,7 @@
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {
+    "@shared/api-services": "workspace:*",
     "@features/platform-style": "workspace:*",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
@@ -55,6 +57,8 @@
     "eslint-plugin-better-tailwindcss": "catalog:",
     "jest": "catalog:",
     "jest-environment-jsdom": "catalog:",
+    "msw": "catalog:",
+    "react-redux": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "react": "catalog:",
@@ -75,7 +79,8 @@
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "react": "catalog:",
-    "react-native": "catalog:"
+    "react-native": "catalog:",
+    "react-redux": "catalog:"
   },
   "peerDependenciesMeta": {
     "react-native": {

--- a/features/flow/pay-card-details/src/__tests__/cardApiStore.tsx
+++ b/features/flow/pay-card-details/src/__tests__/cardApiStore.tsx
@@ -1,0 +1,42 @@
+import React, { type PropsWithChildren } from "react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { cardManagementApi } from "@domain/api-card-management";
+import { cardApi, cardApiExtra } from "@shared/api-services";
+
+export const CARD_API_BASE_URL = "https://card.test";
+export const CARD_DETAILS_TOKEN = "00000000-0000-4000-8000-000000000000";
+export const CARD_DETAILS_IMAGE_URL = `${CARD_API_BASE_URL}/details-image?token=${CARD_DETAILS_TOKEN}`;
+export const CARD_DETAILS = {
+  token: CARD_DETAILS_TOKEN,
+  imageUrl: CARD_DETAILS_IMAGE_URL,
+};
+export const CARD_DETAILS_TOKEN_URL = `${CARD_API_BASE_URL}/v1/card/details/token`;
+
+export function makeCardApiStore() {
+  return configureStore({
+    reducer: {
+      [cardManagementApi.reducerPath]: cardManagementApi.reducer,
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        thunk: {
+          extraArgument: cardApiExtra({
+            getCardApiBaseUrl: () => CARD_API_BASE_URL,
+            getCardBaanxClientKey: () => "client-key",
+            readCardSession: () => Promise.resolve({ token: "session-token", sessionId: 1 }),
+            isCardSessionCurrent: () => true,
+            refreshCardSession: () => Promise.resolve({ kind: "session-replaced" as const }),
+          }),
+        },
+      }).concat(cardApi.middleware),
+  });
+}
+
+export function CardApiStoreProvider({
+  store,
+  children,
+}: PropsWithChildren<{ store: ReturnType<typeof makeCardApiStore> }>) {
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.native.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { CardApiStoreProvider, makeCardApiStore } from "../../__tests__/cardApiStore";
+import { CardNumbers } from "./CardNumbers";
+
+describe("CardNumbers (native)", () => {
+  it("should render nothing when the mobile reveal UI has not shipped", () => {
+    const store = makeCardApiStore();
+
+    render(
+      <CardApiStoreProvider store={store}>
+        <CardNumbers unlock={() => Promise.resolve(false)} />
+      </CardApiStoreProvider>,
+    );
+
+    expect(screen.queryByTestId("card-numbers")).not.toBeOnTheScreen();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { CardNumbersView } from "./CardNumbersView";
+import { useCardNumbersViewModel } from "./useCardNumbersViewModel";
+import type { CardNumbersProps } from "../../types";
+
+export function CardNumbers({ unlock, cardFace }: CardNumbersProps) {
+  return <CardNumbersView {...useCardNumbersViewModel({ unlock })} cardFace={cardFace} />;
+}

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.web.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CardApiStoreProvider, makeCardApiStore } from "../../__tests__/cardApiStore";
+import { CardNumbers } from "./CardNumbers";
+
+describe("CardNumbers (web)", () => {
+  it("should render nothing when the desktop reveal UI has not shipped", () => {
+    const store = makeCardApiStore();
+
+    render(
+      <CardApiStoreProvider store={store}>
+        <CardNumbers unlock={() => Promise.resolve(false)} />
+      </CardApiStoreProvider>,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.native.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { CardNumbersView } from "./CardNumbersView.native";
+import type { CardNumbersViewProps } from "../../types";
+
+const props: CardNumbersViewProps = {
+  status: "idle",
+  imageUrl: undefined,
+  onReveal: jest.fn(),
+  onHide: jest.fn(),
+  onImageError: jest.fn(),
+};
+
+describe("CardNumbersView (native)", () => {
+  it("should render nothing when the mobile reveal UI has not shipped", () => {
+    render(<CardNumbersView {...props} />);
+
+    expect(screen.queryByTestId("card-numbers")).not.toBeOnTheScreen();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.native.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.native.tsx
@@ -1,0 +1,5 @@
+import type { CardNumbersViewProps } from "../../types";
+
+export function CardNumbersView(_props: CardNumbersViewProps): null {
+  return null;
+}

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.web.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CardNumbersView } from "./CardNumbersView";
+import type { CardNumbersViewProps } from "../../types";
+
+const props: CardNumbersViewProps = {
+  status: "idle",
+  imageUrl: undefined,
+  onReveal: jest.fn(),
+  onHide: jest.fn(),
+  onImageError: jest.fn(),
+};
+
+describe("CardNumbersView (web)", () => {
+  it("renders nothing until the desktop reveal UI ships", () => {
+    render(<CardNumbersView {...props} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.web.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbersView.web.tsx
@@ -1,0 +1,6 @@
+import type { CardNumbersViewProps } from "../../types";
+
+// LIVE-35438 owns the desktop reveal UI.
+export function CardNumbersView(_props: CardNumbersViewProps): null {
+  return null;
+}

--- a/features/flow/pay-card-details/src/components/CardNumbers/useCardNumbersViewModel.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/useCardNumbersViewModel.native.test.tsx
@@ -1,0 +1,155 @@
+import React, { type PropsWithChildren } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  CARD_DETAILS,
+  CARD_DETAILS_IMAGE_URL,
+  CARD_DETAILS_TOKEN,
+  CARD_DETAILS_TOKEN_URL,
+  CardApiStoreProvider,
+  makeCardApiStore,
+} from "../../__tests__/cardApiStore";
+import { useCardNumbersViewModel } from "./useCardNumbersViewModel";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
+beforeEach(() => {
+  server.use(http.post(CARD_DETAILS_TOKEN_URL, () => HttpResponse.json(CARD_DETAILS)));
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(next => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function renderNumbers(unlock: () => Promise<boolean>) {
+  const store = makeCardApiStore();
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return <CardApiStoreProvider store={store}>{children}</CardApiStoreProvider>;
+  }
+
+  return {
+    store,
+    ...renderHook(() => useCardNumbersViewModel({ unlock }), { wrapper: Wrapper }),
+  };
+}
+
+async function reveal(unlock: () => Promise<boolean> = () => Promise.resolve(true)) {
+  const rendered = renderNumbers(unlock);
+  await act(async () => {
+    await rendered.result.current.onReveal();
+  });
+  return rendered;
+}
+
+describe("useCardNumbersViewModel", () => {
+  it("reveals the image after unlock succeeds", async () => {
+    const { result, store } = await reveal();
+
+    await waitFor(() => expect(result.current.status).toBe("revealed"));
+    expect(result.current.imageUrl).toBe(CARD_DETAILS_IMAGE_URL);
+    const state = JSON.stringify(store.getState());
+    expect(state).not.toContain(CARD_DETAILS_TOKEN);
+    expect(state).not.toContain("details-image");
+  });
+
+  it("stays idle when unlock is cancelled", async () => {
+    const { result } = await reveal(() => Promise.resolve(false));
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.imageUrl).toBeUndefined();
+  });
+
+  it("shows loading while unlock is pending", async () => {
+    const unlockWait = deferred<boolean>();
+    const { result } = renderNumbers(() => unlockWait.promise);
+
+    act(() => {
+      void result.current.onReveal();
+    });
+
+    expect(result.current.status).toBe("loading");
+
+    await act(async () => {
+      unlockWait.resolve(true);
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("revealed"));
+    expect(result.current.imageUrl).toBe(CARD_DETAILS_IMAGE_URL);
+  });
+
+  it("sets failed when the token request fails", async () => {
+    server.use(
+      http.post(CARD_DETAILS_TOKEN_URL, () =>
+        HttpResponse.json({ message: "mint failed" }, { status: 500 }),
+      ),
+    );
+    const { result } = await reveal();
+
+    await waitFor(() => expect(result.current.status).toBe("failed"));
+    expect(result.current.imageUrl).toBeUndefined();
+  });
+
+  it("hides the numbers", async () => {
+    const { result } = await reveal();
+    await waitFor(() => expect(result.current.status).toBe("revealed"));
+
+    act(() => {
+      result.current.onHide();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.imageUrl).toBeUndefined();
+  });
+
+  it("stays hidden if hide happens before the image arrives", async () => {
+    const tokenWait = deferred<void>();
+    server.use(
+      http.post(CARD_DETAILS_TOKEN_URL, async () => {
+        await tokenWait.promise;
+        return HttpResponse.json(CARD_DETAILS);
+      }),
+    );
+    const { result } = renderNumbers(() => Promise.resolve(true));
+
+    act(() => {
+      void result.current.onReveal();
+    });
+    await waitFor(() => expect(result.current.status).toBe("loading"));
+
+    act(() => {
+      result.current.onHide();
+    });
+
+    await act(async () => {
+      tokenWait.resolve();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.imageUrl).toBeUndefined();
+  });
+
+  it("sets failed when the details image errors", async () => {
+    const { result } = await reveal();
+    await waitFor(() => expect(result.current.status).toBe("revealed"));
+
+    act(() => {
+      result.current.onImageError();
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.imageUrl).toBeUndefined();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardNumbers/useCardNumbersViewModel.ts
+++ b/features/flow/pay-card-details/src/components/CardNumbers/useCardNumbersViewModel.ts
@@ -1,0 +1,82 @@
+import { useRef, useState } from "react";
+import type { ThunkDispatch, UnknownAction } from "@reduxjs/toolkit";
+import { useDispatch } from "react-redux";
+import { cardManagementApi } from "@domain/api-card-management";
+import type { CardNumbersProps, CardNumbersStatus, CardNumbersViewProps } from "../../types";
+
+type CardApiState = {
+  [cardManagementApi.reducerPath]: ReturnType<typeof cardManagementApi.reducer>;
+};
+
+const useCardApiDispatch =
+  useDispatch.withTypes<ThunkDispatch<CardApiState, unknown, UnknownAction>>();
+
+export function useCardNumbersViewModel({ unlock }: CardNumbersProps): CardNumbersViewProps {
+  const dispatch = useCardApiDispatch();
+  const [status, setStatus] = useState<CardNumbersStatus>("idle");
+  const [imageUrl, setImageUrl] = useState<string>();
+  const inFlight = useRef(false);
+  const generation = useRef(0);
+
+  async function onReveal() {
+    if (inFlight.current) {
+      return;
+    }
+
+    inFlight.current = true;
+    const generationAtStart = generation.current;
+    const isStale = () => generation.current !== generationAtStart;
+    setStatus("loading");
+    setImageUrl(undefined);
+
+    try {
+      const unlocked = await unlock();
+      if (isStale()) {
+        return;
+      }
+      if (!unlocked) {
+        setStatus("idle");
+        return;
+      }
+
+      const details = await dispatch(
+        cardManagementApi.endpoints.createCardDetailsToken.initiate(undefined, { track: false }),
+      ).unwrap();
+      if (isStale()) {
+        return;
+      }
+      setImageUrl(details.imageUrl);
+      setStatus("revealed");
+    } catch {
+      if (isStale()) {
+        return;
+      }
+      setImageUrl(undefined);
+      setStatus("failed");
+    } finally {
+      if (!isStale()) {
+        inFlight.current = false;
+      }
+    }
+  }
+
+  function onHide() {
+    generation.current += 1;
+    inFlight.current = false;
+    setImageUrl(undefined);
+    setStatus("idle");
+  }
+
+  function onImageError() {
+    setImageUrl(undefined);
+    setStatus("failed");
+  }
+
+  return {
+    status,
+    imageUrl,
+    onReveal,
+    onHide,
+    onImageError,
+  };
+}

--- a/features/flow/pay-card-details/src/exports.ts
+++ b/features/flow/pay-card-details/src/exports.ts
@@ -1,5 +1,7 @@
 export * from "./components/CardArtwork/CardArtwork";
 export * from "./components/CardActions/CardActions";
+export * from "./components/CardNumbers/CardNumbers";
+export * from "./components/CardNumbers/useCardNumbersViewModel";
 export * from "./components/Freeze/Freeze";
 export * from "./components/CardVisual/CardVisual";
 export * from "./components/Freeze/useFreezeCardViewModel";

--- a/features/flow/pay-card-details/src/types.ts
+++ b/features/flow/pay-card-details/src/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { PayCardStatus } from "@domain/api-card-management";
 import type { FormattedValue } from "@ledgerhq/lumen-utils-shared";
 
@@ -51,3 +52,21 @@ export type TileProps = ConfirmSheetProps &
     isActionDisabled: boolean;
     onOpenConfirm: () => void;
   }>;
+
+export type UnlockForCardNumbers = () => Promise<boolean>;
+
+export type CardNumbersProps = Readonly<{
+  unlock: UnlockForCardNumbers;
+  cardFace?: ReactNode;
+}>;
+
+export type CardNumbersStatus = "idle" | "loading" | "revealed" | "failed";
+
+export type CardNumbersViewProps = Readonly<{
+  status: CardNumbersStatus;
+  imageUrl: string | undefined;
+  onReveal: () => Promise<void>;
+  onHide: () => void;
+  onImageError: () => void;
+  cardFace?: ReactNode;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2462,7 +2462,7 @@ importers:
         version: 18.0.1
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6(@babel/core@7.28.5)
+        version: 0.81.6
       '@react-native/codegen':
         specifier: 'catalog:'
         version: 0.81.6(@babel/core@7.28.5)
@@ -6941,6 +6941,9 @@ importers:
       '@ledgerhq/lumen-utils-shared':
         specifier: 'catalog:'
         version: 0.1.11(react@19.1.4)
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@shared/i18n':
         specifier: workspace:*
         version: link:../../../shared/i18n
@@ -6960,6 +6963,9 @@ importers:
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/api-services':
+        specifier: workspace:*
+        version: link:../../../shared/api-services
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
@@ -7008,6 +7014,9 @@ importers:
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 30.5.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.64.0
@@ -7023,6 +7032,9 @@ importers:
       react-native:
         specifier: 'catalog:'
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer:
         specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)
@@ -16784,7 +16796,7 @@ importers:
         version: 0.81.6
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6(@babel/core@7.28.5)
+        version: 0.81.6
       '@svgr/core':
         specifier: ^5.5.0
         version: 5.5.0(@svgr/plugin-svgo@5.5.0)
@@ -24526,8 +24538,6 @@ packages:
   '@react-native/babel-preset@0.81.6':
     resolution: {integrity: sha512-RtIr82ccPoyMLmIC3/vCG96MzRmIT+IzQkjCgTS5b93uAxiER9BS7+d1l7+zD00VanClt6CTBM4K4n6RCnAykg==}
     engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
 
   '@react-native/codegen@0.77.3':
     resolution: {integrity: sha512-Q6ZJCE7h6Z3v3DiEZUnqzHbgwF3ZILN+ACTx6qu/x2X1cL96AatKwdX92e0+7J9RFg6gdoFYJgRrW8Q6VnWZsQ==}
@@ -42499,16 +42509,6 @@ snapshots:
       regexpu-core: 6.2.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3
-      lodash.debounce: 4.0.8
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42578,14 +42578,6 @@ snapshots:
       '@babel/types': 7.29.8
 
   '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-remap-async-to-generator@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42716,10 +42708,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-default-from@7.25.9':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-proposal-export-default-from@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42770,26 +42758,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-export-default-from@7.25.9':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-syntax-export-default-from@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-flow@7.27.1':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5)':
@@ -42934,28 +42910,12 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
       '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-to-generator@7.27.1':
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -42971,10 +42931,6 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-block-scoping@7.28.5':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
@@ -43028,23 +42984,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.28.6
-
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.28.6
-
-  '@babel/plugin-transform-destructuring@7.28.5':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -43098,37 +43042,17 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-flow': 7.27.1
-
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5)
 
-  '@babel/plugin-transform-for-of@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-function-name@7.27.1':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -43146,17 +43070,9 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-literals@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
@@ -43210,11 +43126,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43235,24 +43146,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-numeric-separator@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-object-rest-spread@7.28.4':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5
-      '@babel/plugin-transform-parameters': 7.27.7
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
     dependencies:
@@ -43272,10 +43169,6 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-optional-catch-binding@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -43297,34 +43190,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-methods@7.27.1':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -43343,10 +43217,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-display-name@7.28.0':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43359,33 +43229,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx-source@7.25.9':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -43404,10 +43256,6 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regenerator@7.28.4':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43423,17 +43271,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-runtime@7.25.9':
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.14
-      babel-plugin-polyfill-corejs3: 0.10.6
-      babel-plugin-polyfill-regenerator: 0.6.5
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-runtime@7.25.9(@babel/core@7.28.5)':
     dependencies:
@@ -43456,13 +43293,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-spread@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43470,10 +43300,6 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-sticky-regex@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -51005,55 +50831,6 @@ snapshots:
 
   '@react-native/babel-preset@0.81.6':
     dependencies:
-      '@babel/plugin-proposal-export-default-from': 7.25.9
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
-      '@babel/plugin-syntax-export-default-from': 7.25.9
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
-      '@babel/plugin-transform-arrow-functions': 7.27.1
-      '@babel/plugin-transform-async-generator-functions': 7.28.0
-      '@babel/plugin-transform-async-to-generator': 7.27.1
-      '@babel/plugin-transform-block-scoping': 7.28.5
-      '@babel/plugin-transform-class-properties': 7.27.1
-      '@babel/plugin-transform-classes': 7.28.4
-      '@babel/plugin-transform-computed-properties': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5
-      '@babel/plugin-transform-flow-strip-types': 7.27.1
-      '@babel/plugin-transform-for-of': 7.27.1
-      '@babel/plugin-transform-function-name': 7.27.1
-      '@babel/plugin-transform-literals': 7.27.1
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.5
-      '@babel/plugin-transform-modules-commonjs': 7.27.1
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1
-      '@babel/plugin-transform-numeric-separator': 7.27.1
-      '@babel/plugin-transform-object-rest-spread': 7.28.4
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.5
-      '@babel/plugin-transform-parameters': 7.27.7
-      '@babel/plugin-transform-private-methods': 7.27.1
-      '@babel/plugin-transform-private-property-in-object': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0
-      '@babel/plugin-transform-react-jsx': 7.27.1
-      '@babel/plugin-transform-react-jsx-self': 7.25.9
-      '@babel/plugin-transform-react-jsx-source': 7.25.9
-      '@babel/plugin-transform-regenerator': 7.28.4
-      '@babel/plugin-transform-runtime': 7.25.9
-      '@babel/plugin-transform-shorthand-properties': 7.27.1
-      '@babel/plugin-transform-spread': 7.27.1
-      '@babel/plugin-transform-sticky-regex': 7.27.1
-      '@babel/plugin-transform-typescript': 7.28.5
-      '@babel/plugin-transform-unicode-regex': 7.27.1
-      '@babel/template': 7.29.7
-      '@react-native/babel-plugin-codegen': 0.81.6
-      babel-plugin-syntax-hermes-parser: 0.29.1
-      babel-plugin-transform-flow-enums: 0.0.2
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@react-native/babel-preset@0.81.6(@babel/core@7.28.5)':
-    dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.28.5)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
@@ -57209,27 +56986,12 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.8
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-corejs3@0.10.6:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.5
-      core-js-compat: 3.43.0
     transitivePeerDependencies:
       - supports-color
 
@@ -57246,12 +57008,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       core-js-compat: 3.43.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.6.5:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.5
     transitivePeerDependencies:
       - supports-color
 
@@ -57294,12 +57050,6 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.29.1:
     dependencies:
       hermes-parser: 0.29.1
-
-  babel-plugin-transform-flow-enums@0.0.2:
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.27.1
-    transitivePeerDependencies:
-      - '@babel/core'
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.28.5):
     dependencies:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Signed-in cardholders need to reveal PAN/CVV behind Ledger Wallet unlock, using the secure image from `POST /v1/card/details/token`. Platform UI ships in follow-up PRs.

**Problem:** There was no shared view-model to gate reveal, mint the details token, and hold the image URL locally.

**Solution:** Shared `CardNumbers` view-model in `@features/flow-pay-card-details`:

- Host injects `unlock()` (create password if none; password or biometrics counts)
- After unlock, mint the details token with `initiate(undefined, { track: false }).unwrap()` so Redux does not keep the credential
- Keep `status` (`idle` | `loading` | `revealed` | `failed`) and `imageUrl` in local state
- Token TTL is not handled yet (API sends none)
- Tests cover reveal, cancel, loading, hide, and failure through `status` / `imageUrl`

```ts
<CardNumbers unlock={unlock} />
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35436](https://ledgerhq.atlassian.net/browse/LIVE-35436)
- **Follow-ups**: [LIVE-35437](https://ledgerhq.atlassian.net/browse/LIVE-35437) (LWM), [LIVE-35438](https://ledgerhq.atlassian.net/browse/LIVE-35438) (LWD)

### 🧪 QA

No app UI in this PR. Native and web views are stubs.

1. `pnpm --filter @features/flow-pay-card-details test src/components/CardNumbers/`

[LIVE-35436]: https://ledgerhq.atlassian.net/browse/LIVE-35436