### PR TITLE
fix(e2e): surface the swap-init error on mobile (QAA-1521)

### DIFF
--- a/.changeset/mobile-swap-init-attachment.md
+++ b/.changeset/mobile-swap-init-attachment.md
@@ -1,0 +1,17 @@
+---
+"@ledgerhq/live-e2e-shared": patch
+"ledger-live-mobile-e2e-tests": patch
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Surface the swap-init root cause on mobile E2E failures
+
+When the device stalls on "Exchange app is ready", `waitForReviewTransaction` appends a hint telling
+the reader to open the "⚠️ Swap-init error" attachment. That hint lives in shared code and is
+emitted on both platforms, but the attachment was produced by the desktop harness only, so on
+mobile it pointed at something that never existed.
+
+The extraction now lives in `@ledgerhq/live-e2e-shared/swapInitError` and both harnesses use it.
+Mobile attaches the result first, scanning the app logs and the webview console together, because
+the failure can surface on either side of the wallet-api call. Desktop delegates to the shared
+function and keeps its previous output.

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -1,4 +1,5 @@
 import { ElectronApplication, Page, ConsoleMessage, Request, Response } from "@playwright/test";
+import { extractSwapInitError } from "@ledgerhq/live-e2e-shared/swapInitError";
 
 interface ConsoleLog {
   timestamp: string;
@@ -110,15 +111,6 @@ export class PageLogCollector {
   // in `consoleLogs` so getSwapInitError() can match on any level (QAA-1433).
   private static readonly CONSOLE_KEEP_LEVELS = new Set(["warning", "error"]);
 
-  // Swap-init failure signatures (QAA-1326): used to surface the root cause when swap-init stalls.
-  private static readonly SWAP_INIT_ERROR_SIGNATURES = [
-    "custom.exchange.swap",
-    "CompleteExchangeError",
-    "PayloadStepError",
-    "FeeNotLoaded",
-    "SWAP_NOT_CREATED_ERROR",
-  ];
-
   private readonly onConsole = (msg: ConsoleMessage) => {
     this.consoleLogs.push({
       timestamp: new Date().toISOString(),
@@ -224,75 +216,11 @@ export class PageLogCollector {
   }
 
   /**
-   * Extract the swap-init failure (custom.exchange.swap request/response) from the captured
-   * webview console, formatted for readability: `%c` console styling stripped, the embedded
-   * JSON payload pretty-printed, and the noisy minified renderer stacks dropped. Null when none.
+   * Extract the swap-init failure from the captured webview console. Shared with mobile, which
+   * mines the same signatures out of its own bridge logs — see `swapInitError.ts`.
    */
   getSwapInitError(): string | null {
-    const matches = this.consoleLogs.filter(entry =>
-      PageLogCollector.SWAP_INIT_ERROR_SIGNATURES.some(sig => entry.text.includes(sig)),
-    );
-    if (matches.length === 0) return null;
-
-    const step = PageLogCollector.deriveSwapInitStep(matches);
-    const body = matches.map(entry => PageLogCollector.formatSwapInitEntry(entry)).join("\n\n");
-    return step ? `Step: ${step}\n\n${body}` : body;
-  }
-
-  private static deriveSwapInitStep(matches: ConsoleLog[]): string | null {
-    const text = matches.map(entry => entry.text).join(" ");
-    if (text.includes("PayloadStepError") || text.includes("swap002")) {
-      return "PAYLOAD (Backend Swap Payload Retrieval)";
-    }
-    if (text.includes("CompleteExchangeError")) {
-      const deviceStep = /"step"\s*:\s*"([^"]+)"/.exec(text)?.[1] ?? "INIT";
-      return `device Exchange app (${deviceStep})`;
-    }
-    return null;
-  }
-
-  private static formatSwapInitEntry(entry: ConsoleLog): string {
-    const header = `[${entry.timestamp}] [${entry.level.toUpperCase()}]`;
-    const jsonStart = entry.text.indexOf("{");
-    if (jsonStart === -1) {
-      return `${header} ${PageLogCollector.stripConsoleStyling(entry.text)}`;
-    }
-
-    const label = PageLogCollector.stripConsoleStyling(entry.text.slice(0, jsonStart));
-    const rawJson = entry.text.slice(jsonStart);
-    try {
-      const pretty = JSON.stringify(PageLogCollector.dropStacks(JSON.parse(rawJson)), null, 2);
-      return `${header} ${label}\n${pretty}`;
-    } catch {
-      // Not valid JSON (e.g. a plain log line) — keep the cleaned text as-is.
-      return `${header} ${label} ${rawJson}`;
-    }
-  }
-
-  /** Remove `%c` console format tokens and their CSS style arguments, keeping the label text. */
-  private static stripConsoleStyling(text: string): string {
-    return text
-      .replaceAll("%c", "")
-      .replace(/background:[^;]*;?/gi, "")
-      .replace(/color:\s*#[0-9a-f]{3,8};?/gi, "")
-      .replace(/\s+/g, " ")
-      .trim();
-  }
-
-  /** Recursively drop `stack` properties — the minified renderer stacks are noise for triage. */
-  private static dropStacks(value: unknown): unknown {
-    if (Array.isArray(value)) {
-      return value.map(item => PageLogCollector.dropStacks(item));
-    }
-    if (value !== null && typeof value === "object") {
-      const result: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(value)) {
-        if (key === "stack") continue;
-        result[key] = PageLogCollector.dropStacks(val);
-      }
-      return result;
-    }
-    return value;
+    return extractSwapInitError(this.consoleLogs);
   }
 
   getFormattedNetworkLogs(): string {

--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -1,4 +1,8 @@
 import { allure } from "jest-allure2-reporter/api";
+import {
+  extractSwapInitError,
+  type SwapInitLogEntry,
+} from "@ledgerhq/live-e2e-shared/swapInitError";
 
 const stderrChunks: string[] = [];
 const originalStderrWrite = process.stderr.write.bind(process.stderr);
@@ -124,6 +128,21 @@ function formatWebviewConsoleLogs(entries: WebviewConsoleEntry[]): string {
   return lines.join("\n");
 }
 
+/** The fields of `@ledgerhq/logs`' `Log` that survive the bridge's JSON round-trip. */
+type AppLogRecord = { type?: string; message?: string; data?: unknown; date?: string };
+
+/** `data` is folded into the text so a signature nested inside it still matches. */
+function appLogsAsEntries(appLogs: unknown): SwapInitLogEntry[] {
+  if (typeof appLogs === "string") {
+    return appLogs.split("\n").map(line => ({ text: line }));
+  }
+  if (!Array.isArray(appLogs)) return [];
+  return appLogs.map((entry: AppLogRecord | null | undefined) => {
+    const data = entry?.data === undefined ? "" : ` ${JSON.stringify(entry.data)}`;
+    return { timestamp: entry?.date, level: entry?.type, text: `${entry?.message ?? ""}${data}` };
+  });
+}
+
 type ParsedLogsPayload = {
   appLogs?: unknown;
   appNetworkLogs?: unknown[];
@@ -145,6 +164,17 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
   // A raw (non-JSON) payload renders legibly as text/plain, not as one escaped JSON line.
   const appLogsValue = parsed.appLogs ?? logsPayload;
   const appLogsIsString = typeof appLogsValue === "string";
+
+  // Attached first: the failure message names this attachment (QAA-1521). Both sources are scanned
+  // because either side of the wallet-api call can be the one that breaks.
+  const swapInitError = extractSwapInitError([
+    ...appLogsAsEntries(appLogsValue),
+    ...(parsed.webviewConsoleLogs ?? []),
+  ]);
+  if (swapInitError) {
+    await allure.attachment("⚠️ Swap-init error", swapInitError, "text/plain");
+  }
+
   await allure.attachment(
     "App Logs",
     appLogsIsString ? appLogsValue : JSON.stringify(appLogsValue, null, 2),

--- a/libs/live-e2e-shared/src/swapInitError.ts
+++ b/libs/live-e2e-shared/src/swapInitError.ts
@@ -1,0 +1,87 @@
+export type SwapInitLogEntry = { timestamp?: string; level?: string; text?: string };
+
+/** Signatures of a failed swap initialization (QAA-1326). */
+export const SWAP_INIT_ERROR_SIGNATURES = [
+  "custom.exchange.swap",
+  "CompleteExchangeError",
+  "PayloadStepError",
+  "FeeNotLoaded",
+  "SWAP_NOT_CREATED_ERROR",
+];
+
+/**
+ * Pull the swap-init failure out of captured logs, formatted for triage. Null when no entry carries
+ * a signature. Backs the "⚠️ Swap-init error" attachment on both desktop and mobile.
+ */
+export function extractSwapInitError(entries: SwapInitLogEntry[]): string | null {
+  const matches = entries.filter(entry =>
+    SWAP_INIT_ERROR_SIGNATURES.some(signature => (entry.text ?? "").includes(signature)),
+  );
+  if (matches.length === 0) return null;
+
+  const step = deriveSwapInitStep(matches);
+  const body = inChronologicalOrder(matches).map(formatSwapInitEntry).join("\n\n");
+  return step ? `Step: ${step}\n\n${body}` : body;
+}
+
+/** Desktop appends, mobile's webview store prepends, and two sources can be merged into one list. */
+function inChronologicalOrder(matches: SwapInitLogEntry[]): SwapInitLogEntry[] {
+  if (!matches.every(entry => entry.timestamp)) return matches;
+  return [...matches].sort((a, b) => (a.timestamp ?? "").localeCompare(b.timestamp ?? ""));
+}
+
+function deriveSwapInitStep(matches: SwapInitLogEntry[]): string | null {
+  const text = matches.map(entry => entry.text ?? "").join(" ");
+  if (text.includes("PayloadStepError") || text.includes("swap002")) {
+    return "PAYLOAD (Backend Swap Payload Retrieval)";
+  }
+  if (text.includes("CompleteExchangeError")) {
+    const deviceStep = /"step"\s*:\s*"([^"]+)"/.exec(text)?.[1] ?? "INIT";
+    return `device Exchange app (${deviceStep})`;
+  }
+  return null;
+}
+
+function formatSwapInitEntry(entry: SwapInitLogEntry): string {
+  const text = entry.text ?? "";
+  const header = `[${entry.timestamp ?? ""}] [${(entry.level ?? "log").toUpperCase()}]`;
+  const jsonStart = text.indexOf("{");
+  if (jsonStart === -1) {
+    return `${header} ${stripConsoleStyling(text)}`;
+  }
+
+  const label = stripConsoleStyling(text.slice(0, jsonStart));
+  const rawJson = text.slice(jsonStart);
+  try {
+    const pretty = JSON.stringify(dropStacks(JSON.parse(rawJson)), null, 2);
+    return `${header} ${label}\n${pretty}`;
+  } catch {
+    return `${header} ${label} ${rawJson}`;
+  }
+}
+
+/** Remove `%c` console format tokens and their CSS style arguments, keeping the label text. */
+function stripConsoleStyling(text: string): string {
+  return text
+    .replaceAll("%c", "")
+    .replace(/background:[^;]*;?/gi, "")
+    .replace(/color:\s*#[0-9a-f]{3,8};?/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Minified renderer stacks are noise for triage. */
+function dropStacks(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(dropStacks);
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (key === "stack") continue;
+      result[key] = dropStacks(val);
+    }
+    return result;
+  }
+  return value;
+}


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _`libs/live-e2e-shared` has no `test` target, so the extractor was verified by a scripted harness instead of a committed test file — 41 assertions, all passing (see Verification). Adding a unit-test target to that package is a follow-up and is deliberately not bundled here._
- [x] **Impact of the changes:**
      - Mobile E2E failure reports: a new `⚠️ Swap-init error` attachment appears, first in the list, on any mobile test whose logs carry a swap-init signature. Nothing is attached when no signature is present, so passing tests and unrelated failures are untouched.
      - Desktop E2E failure reports: the existing `⚠️ Swap-init error` attachment must read exactly as before. Its content is now produced by shared code.
      - No test outcome changes. This only adds diagnostics to reports; it does not change a wait, a locator, an assertion or a timeout.

### Description

**Problem.** When the device stalls on `"Exchange app is ready"`, `waitForReviewTransaction` appends a hint to the failure message:

> Hint: The device Exchange app is ready but Ledger Live never delivered the swap payload, so "Review transaction" was never reached. See the "⚠️ Swap-init error" attachment.

That hint lives in shared code (`libs/live-e2e-shared/src/speculos.ts`) and fires on both platforms, but the attachment it names was produced by the desktop harness only, added under QAA-1326. `e2e/mobile` had **zero** references to it. Every mobile swap stall therefore sent the reader to an attachment that was never created, while QAA-1521's own instruction is to diagnose from the Allure attachments. That is why the ticket has not moved since 2026-09-03.

**Before / after**, for a mobile swap stall:

| | Failure message | Attachments |
| --- | --- | --- |
| Before | names the `⚠️ Swap-init error` attachment | App Logs, Webview Console Logs, network logs — **no swap-init attachment** |
| After | unchanged | `⚠️ Swap-init error` first, then the same sections as before |

**Solution.** The extraction moves into `libs/live-e2e-shared/src/swapInitError.ts` as `extractSwapInitError()`, pure over `{ timestamp?, level?, text? }` — the shape both harnesses already hold. Mobile attaches its result; desktop delegates to it and keeps its previous output.

Mobile scans the app logs and the webview console **together**, because the failure can surface in the swap live-app's console or in the host app's own logs depending on which side of the `custom.exchange.swap` wallet-api call breaks. `appLogs` entries are `Log` objects from `@ledgerhq/logs`, so `data` is folded into the matched text to catch a signature nested inside it.

Entries are ordered chronologically before formatting. Desktop appends to its buffer, mobile's webview store prepends, and two sources are now merged into one attachment, so the order is normalised in one place rather than per caller. It is left untouched unless every match carries a timestamp, so a partial set is never shuffled.

**Why the wait budget is not the fix.** QAA-1521 points at QAA-1322 as the fix to transfer, and QAA-1322's prescription was to raise the budget to ~90–120s. That is already done and already shared:

```ts
// libs/live-e2e-shared/src/speculos.ts
const SWAP_REVIEW_TRANSACTION_TIMEOUT_MS = 120_000; // 240 attempts × 500 ms
```

raised from 30s by `a71d90ab19` and `5a64d39ac8`. Both of the 2026-09-09 failures report `after 240 attempts`, so they happen *with* the raised budget. Raising it again would re-run a hypothesis that has already lost and would push genuine swap-init stalls further out of sight.

**What this does not do.** This does not fix the flake, and QAA-1521 should stay open. The cause of the stall is still unknown and cannot be established from the current artifacts, which is exactly the gap this closes. The next nightly that hits the stall will carry the upstream error, and the ticket becomes diagnosable then. The stall is not reproducible locally — it depends on live provider and device state — so no local reproduction is claimed.

### Verification

- `tsc --noEmit --strict` clean on the new module. `oxfmt --check` and `oxlint` clean on all three files.
- **Desktop output proven unchanged.** The pre-refactor implementation was extracted from `origin/develop` and run against the new shared function on 9 inputs: no signature, each of the five signatures, `PayloadStepError` with `%c` styling and nested stacks, `CompleteExchangeError` with and without a `step`, several entries at once, and malformed JSON after the opening brace. **9 of 9 byte-identical.**
- 21 assertions on the extractor (step derivation, stack dropping, console-styling strip, ordering, optional-field tolerance) and 11 on the mobile adapter (error in app logs only, in the webview console only, in both, clean run attaches nothing, degenerate payloads do not throw).
- The full typecheck of the two edited harness files needs the workspace installed and is left to CI. The import specifier follows the same `@ledgerhq/live-e2e-shared/<module>` form as the 18 existing `@ledgerhq/live-e2e-shared/speculos` imports.

Evidence for the defect itself: mobile run [34296557656](https://github.com/LedgerHQ/ledger-live/actions/runs/34296557656) (2026-09-09) failed `swapWithSendMaxUSDTtoBTC.spec.ts` with the hint and no such attachment — a fourth Android spec beyond the three QAA-1521 lists. Desktop hit the same message the same night on `send.swap.spec.ts` [HBAR-XRP].

### Context

- **JIRA or GitHub link**: [QAA-1521](https://ledgerhq.atlassian.net/browse/QAA-1521)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1521]: https://ledgerhq.atlassian.net/browse/QAA-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ