### PR TITLE
[LWDM] fix(coin-hedera): read countervalues URL lazily via getEnv

### DIFF
--- a/.changeset/hedera-countervalues-lazy-getenv.md
+++ b/.changeset/hedera-countervalues-lazy-getenv.md
@@ -1,0 +1,16 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+Restore lazy runtime read of the countervalues API endpoint.
+
+PR #21659 dropped the live-countervalues dependency and inlined the CVS spot-price call.
+In doing so it replaced the per-call `getEnv("LEDGER_COUNTERVALUES_API")` with a
+module-level `process.env` constant evaluated once at import time. The default URL was
+always correct, but the mobile debug staging toggle (`CountervaluesStagingRow`) calls
+`setEnv("LEDGER_COUNTERVALUES_API", ...)` at runtime; with a const that write is silently
+ignored and Hedera fee estimation stays on production rates while every other CVS caller
+follows the toggle.
+
+Fix: read `getEnv("LEDGER_COUNTERVALUES_API")` inline at request time and re-add
+`@ledgerhq/live-env` as a runtime dependency.

--- a/libs/coin-modules/coin-hedera/package.json
+++ b/libs/coin-modules/coin-hedera/package.json
@@ -92,6 +92,7 @@
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/logs": "catalog:",
     "@ledgerhq/types-live": "workspace:^",

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@hashgraph/sdk";
 import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
 import { NotEnoughBalance, RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { getEnv } from "@ledgerhq/live-env";
 import invariant from "invariant";
 import { createApi } from "../api";
 import {
@@ -32,17 +33,13 @@ import { rpcClient } from "../network/rpc";
 import { MAINNET_TEST_ACCOUNTS } from "../test/fixtures/account.fixture";
 import { getMockedConfig, getMockedContext } from "../test/fixtures/config.fixture";
 
-const HEDERA_MIRROR = process.env.API_HEDERA_MIRROR ?? "https://hedera.coin.ledger.com";
-const HEDERA_HGRAPH =
-  process.env.API_HEDERA_HGRAPH ?? "https://hedera-indexer-mainnet.coin.ledger.com/v1/graphql";
-
 describe("createApi", () => {
   const apiConfig = {
     ...getMockedConfig(),
     useNetworkTimestamp: true,
     apiUrls: {
-      mirrorNode: HEDERA_MIRROR,
-      hgraph: HEDERA_HGRAPH,
+      mirrorNode: getEnv("API_HEDERA_MIRROR"),
+      hgraph: getEnv("API_HEDERA_HGRAPH"),
     },
   };
   const api = createApi("hedera");

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -1,3 +1,4 @@
+import { getEnv, setEnv } from "@ledgerhq/live-env";
 import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { STAKING_REWARD_ACCOUNT_ID } from "../constants";
@@ -19,6 +20,7 @@ import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockedMirrorNode } from "../test/fixtures/validator.fixture";
 import hederaCoinConfig from "../config";
 import type { HederaMirrorCoinTransfer, HederaMirrorTransaction } from "../types";
+import network from "@ledgerhq/live-network";
 import { apiClient } from "./api";
 import { hgraphClient } from "./hgraph";
 import { rpcClient } from "./rpc";
@@ -29,12 +31,17 @@ import {
   createTransactionId,
   enrichERC20Transfers,
   getERC20BalancesForAccountV2,
+  getCurrencyToUSDRate,
   getHederaValidators,
   parseTransfers,
   safeParseAccountId,
   toEVMAddress,
 } from "./utils";
 
+jest.mock("@ledgerhq/live-network", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 jest.mock("./api");
 jest.mock("./hgraph");
 jest.mock("./rpc", () => ({
@@ -1049,6 +1056,29 @@ describe("network utils", () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("getCurrencyToUSDRate", () => {
+    beforeEach(() => {
+      getCurrencyToUSDRate.reset();
+    });
+
+    it("reads LEDGER_COUNTERVALUES_API lazily, so setEnv at runtime is honoured", async () => {
+      const original = getEnv("LEDGER_COUNTERVALUES_API");
+      setEnv("LEDGER_COUNTERVALUES_API", "https://example.test");
+
+      (network as jest.Mock).mockResolvedValueOnce({ data: { hedera: 0.07 } });
+
+      await getCurrencyToUSDRate(mockCurrency);
+
+      expect(network).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("https://example.test"),
+        }),
+      );
+
+      setEnv("LEDGER_COUNTERVALUES_API", original);
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -1,5 +1,6 @@
 import invariant from "invariant";
 import { AccountId, TransactionId } from "@hashgraph/sdk";
+import { getEnv } from "@ledgerhq/live-env";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import network from "@ledgerhq/live-network";
@@ -31,9 +32,6 @@ import type {
 import { apiClient } from "./api";
 import { hgraphClient } from "./hgraph";
 import { rpcClient } from "./rpc";
-
-const COUNTERVALUES_API =
-  process.env.LEDGER_COUNTERVALUES_API ?? "https://countervalues.live.ledger.com";
 
 const USD_FIAT: FiatCurrency = {
   type: "FiatCurrency",
@@ -207,6 +205,14 @@ export const enrichERC20Transfers = async ({
   return enrichedTransfers;
 };
 
+// getEnv("LEDGER_COUNTERVALUES_API") must be read lazily, per call — not cached in a
+// module-level const. The mobile debug toggle calls setEnv("LEDGER_COUNTERVALUES_API", ...)
+// at runtime; a const or process.env read at import time pins hedera to whatever was
+// configured at startup and ignores the toggle.
+//
+// Dropping @ledgerhq/live-env from this package is blocked: the intended replacement
+// (shared/api-services/countervalues/) is unreachable from a published package as a runtime
+// dep. Unblock shared/* access first, then migrate the endpoint.
 // note: this is currently called frequently by getTransactionStatus; LRU cache prevents duplicated requests
 export const getCurrencyToUSDRate = makeLRUCache(
   async (currency: Currency) => {
@@ -219,7 +225,7 @@ export const getCurrencyToUSDRate = makeLRUCache(
       const params = new URLSearchParams({ to: USD_FIAT.ticker, froms: fromId });
       const { data } = await network<Record<string, number>>({
         method: "GET",
-        url: `${COUNTERVALUES_API}/v3/spot/simple?${params.toString()}`,
+        url: `${getEnv("LEDGER_COUNTERVALUES_API")}/v3/spot/simple?${params.toString()}`,
       });
       const rate = data[fromId];
       invariant(rate, "no value returned from cvs api");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9546,6 +9546,9 @@ importers:
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../../env
       '@ledgerhq/live-network':
         specifier: workspace:^
         version: link:../../live-network
@@ -22943,6 +22946,7 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28415,7 +28419,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:


### PR DESCRIPTION
## What regressed

PR #21659 dropped `@ledgerhq/live-countervalues` from coin-hedera and inlined the CVS spot-price call. It replaced `getEnv("LEDGER_COUNTERVALUES_API")` with a module-level constant:

```ts
const COUNTERVALUES_API =
  process.env.LEDGER_COUNTERVALUES_API ?? "https://countervalues.live.ledger.com";
```

The default URL is correct — that hardcoded value is the registry default. Nothing breaks in the default case.

What broke is the **runtime override**. The mobile debug staging toggle:

```
apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/CountervaluesStagingRow.tsx:18
  setEnv("LEDGER_COUNTERVALUES_API", enableStaging ? STAGING_URL : PRODUCTION_URL);
```

Every other CVS caller reads through `getEnv` per request and follows this toggle (`live-countervalues/api/api.ts`, `sortByMarketcap`, `marketApi`, `counterValuesApi`, `fetchSpotPrices`). A module-level const or `process.env` read evaluates once at import time, so flipping the staging toggle leaves hedera alone on production rates.

## Fix

Call `getEnv("LEDGER_COUNTERVALUES_API")` inline at the request site inside `getCurrencyToUSDRate`. The value is read per-call, matching the `() => getEnv(...)` pattern used by all other CVS callers.

This imports `@ledgerhq/live-env` in `src/network/utils.ts`, which triggers the warn-level `no-restricted-imports` lint rule for `network/**` (only four `@ledgerhq/*` packages are allowed there). The warning is accepted over creating a thin wrapper file.

## Deprecation ordering note

Dropping `@ledgerhq/live-env` from this package is not a free mechanical change. The intended replacement (`shared/api-services/countervalues/`) already exists but is unreachable from a published package as a runtime dependency. The correct order is: unblock `shared/*` access first, then migrate the endpoint. Doing the reverse silently breaks the staging toggle again.

## Test

Added a discriminating unit test that calls `setEnv("LEDGER_COUNTERVALUES_API", "https://example.test")` before calling `getCurrencyToUSDRate` and asserts the network mock received a URL containing `"https://example.test"`. Verified the test **fails** against the module-level const version (receives `"https://countervalues.live.ledger.com"` instead).

Also reverted the `process.env.API_HEDERA_MIRROR / API_HEDERA_HGRAPH` change in the integration test setup back to `getEnv(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)