### PR TITLE
feat(contacts): add excludedCurrencyIds to feature flags (LIVE-37156)

### DIFF
--- a/.changeset/LIVE-37156-contacts-excluded-currency-ids.md
+++ b/.changeset/LIVE-37156-contacts-excluded-currency-ids.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@features/platform-contacts": minor
+"@features/flow-contacts-add-address": minor
+"@shared/feature-flags": minor
+---
+
+Add excludedCurrencyIds param to lwdContacts and lwmContacts feature flags to exclude specific currencies from Contacts

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -112,8 +112,11 @@ export function useSendHeaderModel({
   const { selectedContact, clearSelectedContact } = useRecipientContactSelection();
   const { recipientType, setInputMethod } = useSendFlowTracking();
   const addNewContactHeader = useAddNewContactHeaderState();
-  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
-    useContactsFeature("desktop");
+  const {
+    isEnabled: isContactsFeatureEnabled,
+    eligibleAddressFamilies,
+    excludedCurrencyIds,
+  } = useContactsFeature("desktop");
   const contacts = useSelector(selectContacts);
 
   const currencyName = state.account.currency?.ticker ?? "";
@@ -357,7 +360,11 @@ export function useSendHeaderModel({
 
   const canSearchContacts =
     isContactsFeatureEnabled &&
-    isEligibleAddressCurrency(eligibleAddressFamilies, state.account.currency ?? undefined);
+    isEligibleAddressCurrency(
+      eligibleAddressFamilies,
+      state.account.currency ?? undefined,
+      excludedCurrencyIds,
+    );
   const recipientPlaceholder = t(
     getRecipientPlaceholderKey({
       supportsDomain: uiConfig.recipientSupportsDomain,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -133,6 +133,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: false,
       showNewBadge: false,
       eligibleAddressFamilies: [],
+      excludedCurrencyIds: [],
     });
     mockedUseRecipientContactSelection.mockReturnValue({
       selectedContact: undefined,
@@ -187,6 +188,7 @@ describe("useRecipientAddressModalViewModel", () => {
         isEnabled,
         showNewBadge: false,
         eligibleAddressFamilies: families,
+        excludedCurrencyIds: [],
       });
 
       renderHook(() =>
@@ -264,6 +266,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([
       mockContact({
@@ -301,6 +304,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
 
     const { result } = renderHook(() =>
@@ -325,6 +329,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([
       mockContact({
@@ -360,6 +365,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([
       mockContact({
@@ -456,6 +462,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([contact]);
     mockedUseRecipientContactSelection.mockReturnValue({

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
@@ -53,14 +53,21 @@ export function useRecipientAddressModalViewModel({
   const { recipientSearch, state } = useSendFlowData();
   const contacts = useContacts();
   const [doNotAskAgainSkipMemo] = useDoNotAskAgainSkipMemo();
-  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
-    useContactsFeature("desktop");
+  const {
+    isEnabled: isContactsFeatureEnabled,
+    eligibleAddressFamilies,
+    excludedCurrencyIds,
+  } = useContactsFeature("desktop");
   const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
   const { inputMethod, setRecipientResolution } = useSendFlowTracking();
   const { navigation } = useFlowWizard<SendFlowStep>();
 
   const mainAccount = getMainAccount(account, parentAccount);
-  const hasAddressBook = isEligibleAddressCurrency(eligibleAddressFamilies, currency);
+  const hasAddressBook = isEligibleAddressCurrency(
+    eligibleAddressFamilies,
+    currency,
+    excludedCurrencyIds,
+  );
   const sendFlowTrackingProperties = useMemo(
     () => getSendFlowTrackingProperties(account, parentAccount),
     [account, parentAccount],

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
@@ -42,8 +42,11 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
   const { navigation } = useFlowWizard();
   const { isScannerOpen } = useRecipientScanner();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
-    useContactsFeature("desktop");
+  const {
+    isEnabled: isContactsFeatureEnabled,
+    eligibleAddressFamilies,
+    excludedCurrencyIds,
+  } = useContactsFeature("desktop");
 
   const account = state.account.account;
   const parentAccount = state.account.parentAccount ?? undefined;
@@ -54,7 +57,7 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
   const trackingProperties = useMemo(() => {
     const contactsOnNetwork =
       isContactsFeatureEnabled &&
-      isEligibleAddressCurrency(eligibleAddressFamilies, currency ?? undefined)
+      isEligibleAddressCurrency(eligibleAddressFamilies, currency ?? undefined, excludedCurrencyIds)
         ? filterContactsByNetwork(contacts, currency?.id ?? "")
         : [];
 
@@ -68,6 +71,7 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
     contacts,
     currency,
     eligibleAddressFamilies,
+    excludedCurrencyIds,
     isContactsFeatureEnabled,
     state.account.parentAccount,
   ]);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Divider, Switch } from "@ledgerhq/lumen-ui-react";
+import { Button, Divider, Switch, TextInput } from "@ledgerhq/lumen-ui-react";
 import {
   FeatureFlagPreview,
   FeatureParamRow,
@@ -29,6 +29,9 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
     handleResetOverride,
     hasDismissedFeatureIntroduction,
     handleToggleFeatureIntroductionDismissed,
+    excludedCurrencyIdsInput,
+    setExcludedCurrencyIdsInput,
+    handleApplyExcludedCurrencyIds,
   } = useContactsDevToolViewModel();
 
   return (
@@ -74,6 +77,30 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
                 onCustomFamiliesInputChange={setCustomFamiliesInput}
                 onApplyCustomFamilies={handleApplyCustomFamilies}
               />
+              <div
+                className={`flex flex-col gap-4 rounded-md bg-surface p-10 transition-opacity ${
+                  isEnabled ? "opacity-100" : "opacity-50"
+                }`}
+              >
+                <span className="body-3">Excluded currency IDs</span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <TextInput
+                    aria-label="Excluded currency IDs"
+                    value={excludedCurrencyIdsInput}
+                    onChange={event => setExcludedCurrencyIdsInput(event.target.value)}
+                    placeholder="e.g. ethereum, bitcoin"
+                    disabled={!isEnabled}
+                  />
+                  <Button
+                    appearance="base"
+                    size="sm"
+                    onClick={handleApplyExcludedCurrencyIds}
+                    disabled={!isEnabled}
+                  >
+                    Apply
+                  </Button>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
@@ -10,6 +10,7 @@ describe("useContactsDevToolViewModel", () => {
     expect(result.current.params).toEqual({
       newBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     expect(result.current.customFamiliesInput).toBe("evm");
   });
@@ -30,7 +31,7 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
       enabled: true,
-      params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+      params: { newBadge: false, eligibleAddressFamilies: ["evm"], excludedCurrencyIds: [] },
     });
   });
 
@@ -50,7 +51,7 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
       enabled: true,
-      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"], excludedCurrencyIds: [] },
     });
   });
 
@@ -74,7 +75,11 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
       enabled: true,
-      params: { newBadge: false, eligibleAddressFamilies: ["evm", "stellar", "aptos"] },
+      params: {
+        newBadge: false,
+        eligibleAddressFamilies: ["evm", "stellar", "aptos"],
+        excludedCurrencyIds: [],
+      },
     });
     expect(result.current.customFamiliesInput).toBe("evm, stellar, aptos");
   });
@@ -99,7 +104,39 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
       enabled: true,
-      params: { newBadge: false, eligibleAddressFamilies: ["evm", "stellar"] },
+      params: {
+        newBadge: false,
+        eligibleAddressFamilies: ["evm", "stellar"],
+        excludedCurrencyIds: [],
+      },
+    });
+  });
+
+  it("should apply excludedCurrencyIds, deduplicating entries", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel(), {
+      initialState: withFlagOverrides({
+        lwdContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+        },
+      }),
+    });
+
+    act(() => {
+      result.current.setExcludedCurrencyIdsInput("ethereum, bitcoin, ethereum");
+    });
+
+    act(() => {
+      result.current.handleApplyExcludedCurrencyIds();
+    });
+
+    expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
+      enabled: true,
+      params: {
+        newBadge: false,
+        eligibleAddressFamilies: ["evm"],
+        excludedCurrencyIds: ["ethereum", "bitcoin"],
+      },
     });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
@@ -25,6 +25,7 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     hasDismissedContactsFeatureIntroductionSelector,
   );
   const [customFamiliesInput, setCustomFamiliesInput] = useState("");
+  const [excludedCurrencyIdsInput, setExcludedCurrencyIdsInput] = useState("");
 
   const isEnabled = featureFlag?.enabled === true;
   const params = useMemo(
@@ -32,10 +33,15 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     [featureFlag?.params],
   );
   const familiesInput = params.eligibleAddressFamilies.join(", ");
+  const excludedCurrencyIdsString = params.excludedCurrencyIds.join(", ");
 
   useEffect(() => {
     setCustomFamiliesInput(familiesInput);
   }, [familiesInput]);
+
+  useEffect(() => {
+    setExcludedCurrencyIdsInput(excludedCurrencyIdsString);
+  }, [excludedCurrencyIdsString]);
 
   const setContactsOverride = useCallback(
     (patch: ContactsFeatureValuePatch) =>
@@ -66,6 +72,14 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
   const handleApplyCustomFamilies = useCallback(() => {
     handleSetEligibleAddressFamilies(parseEligibleAddressFamiliesInput(customFamiliesInput));
   }, [customFamiliesInput, handleSetEligibleAddressFamilies]);
+
+  const handleApplyExcludedCurrencyIds = useCallback(() => {
+    const ids = excludedCurrencyIdsInput
+      .split(",")
+      .map(id => id.trim())
+      .filter(Boolean);
+    setContactsOverride({ params: { excludedCurrencyIds: ids } });
+  }, [excludedCurrencyIdsInput, setContactsOverride]);
 
   const handleLoadPopulatedContacts = useCallback(() => {
     dispatch(setContacts(mockPopulatedContacts()));
@@ -99,6 +113,9 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     handleSetEligibleAddressFamilies,
     setCustomFamiliesInput,
     handleApplyCustomFamilies,
+    excludedCurrencyIdsInput,
+    setExcludedCurrencyIdsInput,
+    handleApplyExcludedCurrencyIds,
     handleLoadPopulatedContacts,
     handleLoadFromSendHistory,
     handleResetContacts,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
@@ -16,6 +16,9 @@ export interface ContactsDevToolViewModel {
   readonly handleSetEligibleAddressFamilies: (families: readonly string[]) => void;
   readonly setCustomFamiliesInput: (value: string) => void;
   readonly handleApplyCustomFamilies: () => void;
+  readonly excludedCurrencyIdsInput: string;
+  readonly setExcludedCurrencyIdsInput: (value: string) => void;
+  readonly handleApplyExcludedCurrencyIds: () => void;
   readonly handleLoadPopulatedContacts: () => void;
   readonly handleLoadFromSendHistory: () => void;
   readonly handleResetContacts: () => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -95,7 +95,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const navigation = useNavigation<NavigationProp>();
   const route =
     useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWalletContactDetail>>();
-  const { isEnabled, eligibleAddressFamilies } = useContactsFeature("mobile");
+  const { isEnabled, eligibleAddressFamilies, excludedCurrencyIds } = useContactsFeature("mobile");
   const ledgerSyncStatus = useContactsLedgerSyncStatus();
   const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
   const { ledgerSyncActivationDrawer, openLedgerSyncActivationDrawer } =
@@ -117,8 +117,9 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const contact = populatedContactDetail?.contact ?? emptyContact;
   const addressValidation = useContactsAddressValidationAdapter();
   const eligibleNetworkIds = useMemo(
-    () => resolveEligibleAddressCurrencyIds(eligibleAddressFamilies),
-    [eligibleAddressFamilies],
+    () =>
+      resolveEligibleAddressCurrencyIds(eligibleAddressFamilies, undefined, excludedCurrencyIds),
+    [eligibleAddressFamilies, excludedCurrencyIds],
   );
   const {
     state: addAddressFlowState,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -77,8 +77,11 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   const { close, transaction, setRecipientSearchValue, clearRecipientSearch } =
     useSendFlowActions();
   const { displayMode } = useSendAmountDisplayMode();
-  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
-    useContactsFeature("mobile");
+  const {
+    isEnabled: isContactsFeatureEnabled,
+    eligibleAddressFamilies,
+    excludedCurrencyIds,
+  } = useContactsFeature("mobile");
   const contacts = useSelector(selectContacts);
   const { selectedContact, clearSelectedContact } = useRecipientContactSelection();
   const { recipientType, setInputMethod } = useSendFlowTracking();
@@ -292,7 +295,11 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
 
   const canSearchContacts =
     isContactsFeatureEnabled &&
-    isEligibleAddressCurrency(eligibleAddressFamilies, state.account.currency ?? undefined);
+    isEligibleAddressCurrency(
+      eligibleAddressFamilies,
+      state.account.currency ?? undefined,
+      excludedCurrencyIds,
+    );
   const recipientPlaceholder = t(
     getRecipientPlaceholderKey({
       supportsDomain: uiConfig.recipientSupportsDomain,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -106,6 +106,7 @@ describe("useRecipientScreenView", () => {
       isEnabled: false,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseRecipientContactSelection.mockReturnValue({
       selectedContact: undefined,
@@ -143,6 +144,7 @@ describe("useRecipientScreenView", () => {
         isEnabled,
         showNewBadge: false,
         eligibleAddressFamilies: families,
+        excludedCurrencyIds: [],
       });
 
       renderHook(() =>
@@ -252,6 +254,7 @@ describe("useRecipientScreenView", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([
       mockContact({
@@ -289,6 +292,7 @@ describe("useRecipientScreenView", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
 
     const { result } = renderHook(() =>
@@ -313,6 +317,7 @@ describe("useRecipientScreenView", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([
       mockContact({
@@ -348,6 +353,7 @@ describe("useRecipientScreenView", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([
       mockContact({
@@ -500,6 +506,7 @@ describe("useRecipientScreenView", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     mockedUseContacts.mockReturnValue([contact]);
     mockedUseSendFlowData.mockReturnValue({

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenViewModel.test.ts
@@ -21,7 +21,11 @@ jest.mock("@features/platform-contacts", () => ({
     "@features/platform-contacts",
   ).isEligibleAddressCurrency,
   useContacts: jest.fn(() => []),
-  useContactsFeature: jest.fn(() => ({ isEnabled: false, eligibleAddressFamilies: [] })),
+  useContactsFeature: jest.fn(() => ({
+    isEnabled: false,
+    eligibleAddressFamilies: [],
+    excludedCurrencyIds: [],
+  })),
 }));
 
 const mockedGetAccountCurrency = jest.mocked(getAccountCurrency);
@@ -92,6 +96,7 @@ describe("useRecipientScreenViewModel", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
     jest.mocked(useContacts).mockReturnValue([
       mockContact({

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -43,14 +43,21 @@ export function useRecipientScreenView({
 }: UseRecipientScreenViewProps) {
   const { recipientSearch } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
-    useContactsFeature("mobile");
+  const {
+    isEnabled: isContactsFeatureEnabled,
+    eligibleAddressFamilies,
+    excludedCurrencyIds,
+  } = useContactsFeature("mobile");
   const { selectedContact } = useRecipientContactSelection();
   const { inputMethod, setInputMethod, setRecipientResolution, resetRecipientResolution } =
     useSendFlowTracking();
 
   const mainAccount = getMainAccount(account, parentAccount);
-  const hasAddressBook = isEligibleAddressCurrency(eligibleAddressFamilies, currency);
+  const hasAddressBook = isEligibleAddressCurrency(
+    eligibleAddressFamilies,
+    currency,
+    excludedCurrencyIds,
+  );
   const sendFlowTrackingProperties = useMemo(
     () => getSendFlowTrackingProperties(account, parentAccount),
     [account, parentAccount],

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenViewModel.ts
@@ -38,8 +38,11 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
   const { transaction } = useSendFlowActions();
   const navigation = useNavigation<SendFlowNavigationProp>();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
-    useContactsFeature("mobile");
+  const {
+    isEnabled: isContactsFeatureEnabled,
+    eligibleAddressFamilies,
+    excludedCurrencyIds,
+  } = useContactsFeature("mobile");
 
   const account = state.account.account;
   const parentAccount = state.account.parentAccount ?? null;
@@ -50,7 +53,7 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
   const trackingProperties = useMemo(() => {
     const contactsOnNetwork =
       isContactsFeatureEnabled &&
-      isEligibleAddressCurrency(eligibleAddressFamilies, currency ?? undefined)
+      isEligibleAddressCurrency(eligibleAddressFamilies, currency ?? undefined, excludedCurrencyIds)
         ? filterContactsByNetwork(contacts, currency?.id ?? "")
         : [];
 
@@ -64,6 +67,7 @@ export function useRecipientScreenViewModel(): RecipientScreenViewModel {
     contacts,
     currency,
     eligibleAddressFamilies,
+    excludedCurrencyIds,
     isContactsFeatureEnabled,
     parentAccount,
   ]);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
@@ -19,6 +19,7 @@ describe("useContactsDevToolViewModel", () => {
       params: {
         newBadge: false,
         eligibleAddressFamilies: ["evm"],
+        excludedCurrencyIds: [],
       },
     });
   });
@@ -39,6 +40,7 @@ describe("useContactsDevToolViewModel", () => {
       params: {
         newBadge: true,
         eligibleAddressFamilies: ["evm"],
+        excludedCurrencyIds: [],
       },
     });
   });
@@ -54,6 +56,7 @@ describe("useContactsDevToolViewModel", () => {
     expect(store.getState().featureFlags.overrides[CONTACTS_FLAG]?.params).toEqual({
       newBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
   });
 

--- a/features/flow/flow-contacts-add-address/src/state/useAddAddressCurrencySelectionViewModel.ts
+++ b/features/flow/flow-contacts-add-address/src/state/useAddAddressCurrencySelectionViewModel.ts
@@ -30,10 +30,11 @@ export function useAddAddressCurrencySelectionViewModel({
   platform,
   currencySelection,
 }: UseAddAddressCurrencySelectionViewModelOptions): AddAddressCurrencySelectionViewModel {
-  const { eligibleAddressFamilies } = useContactsFeature(platform);
+  const { eligibleAddressFamilies, excludedCurrencyIds } = useContactsFeature(platform);
   const eligibleNetworkIds = useMemo(
-    () => resolveEligibleAddressCurrencyIds(eligibleAddressFamilies),
-    [eligibleAddressFamilies],
+    () =>
+      resolveEligibleAddressCurrencyIds(eligibleAddressFamilies, undefined, excludedCurrencyIds),
+    [eligibleAddressFamilies, excludedCurrencyIds],
   );
   const isSelectingRef = useRef(false);
   const [selectedCurrency, setSelectedCurrency] = useState<AddAddressCurrencySelection | null>(

--- a/features/platform/contacts/src/featureFlags.ts
+++ b/features/platform/contacts/src/featureFlags.ts
@@ -15,6 +15,7 @@ export type ContactsFeatureConfig = Readonly<{
   isEnabled: boolean;
   showNewBadge: boolean;
   eligibleAddressFamilies: readonly string[];
+  excludedCurrencyIds: readonly string[];
 }>;
 
 export type ContactsFeatureValue = Features["lwdContacts"] | Features["lwmContacts"];
@@ -22,12 +23,20 @@ export type ContactsFeatureValue = Features["lwdContacts"] | Features["lwmContac
 export type ContactsFeatureParams = Readonly<{
   newBadge: boolean;
   eligibleAddressFamilies: string[];
+  excludedCurrencyIds: string[];
 }>;
 
 export type ContactsFeatureValuePatch = Readonly<{
   enabled?: boolean;
   params?: Partial<ContactsFeatureParams>;
 }>;
+
+export function isContactsEnabledForCurrency(
+  config: ContactsFeatureConfig,
+  currencyId: string,
+): boolean {
+  return config.isEnabled && !config.excludedCurrencyIds.includes(currencyId);
+}
 
 export function resolveContactsFeatureConfig(
   feature: ContactsFeatureValue | null | undefined,
@@ -39,6 +48,7 @@ export function resolveContactsFeatureConfig(
     isEnabled,
     showNewBadge: isEnabled && params.newBadge,
     eligibleAddressFamilies: params.eligibleAddressFamilies,
+    excludedCurrencyIds: params.excludedCurrencyIds,
   };
 }
 
@@ -48,6 +58,7 @@ export function resolveContactsFeatureParams(params: unknown): ContactsFeaturePa
   return {
     newBadge: input?.newBadge === true,
     eligibleAddressFamilies: normalizeEligibleAddressFamilies(input?.eligibleAddressFamilies),
+    excludedCurrencyIds: normalizeExcludedCurrencyIds(input?.excludedCurrencyIds),
   };
 }
 
@@ -73,6 +84,10 @@ export function updateContactsFeatureValue(
         patchParams?.eligibleAddressFamilies === undefined
           ? params.eligibleAddressFamilies
           : normalizeEligibleAddressFamilies(patchParams.eligibleAddressFamilies),
+      excludedCurrencyIds:
+        patchParams?.excludedCurrencyIds === undefined
+          ? params.excludedCurrencyIds
+          : normalizeExcludedCurrencyIds(patchParams.excludedCurrencyIds),
     },
   };
 }
@@ -93,9 +108,13 @@ function normalizeEligibleAddressFamilies(value: unknown): string[] {
   return families.length > 0 ? families : [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES];
 }
 
-function toContactsFeatureParamsInput(
-  value: unknown,
-): Readonly<{ newBadge?: unknown; eligibleAddressFamilies?: unknown }> | undefined {
+function toContactsFeatureParamsInput(value: unknown):
+  | Readonly<{
+      newBadge?: unknown;
+      eligibleAddressFamilies?: unknown;
+      excludedCurrencyIds?: unknown;
+    }>
+  | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
@@ -103,7 +122,16 @@ function toContactsFeatureParamsInput(
   return {
     newBadge: value.newBadge,
     eligibleAddressFamilies: value.eligibleAddressFamilies,
+    excludedCurrencyIds: value.excludedCurrencyIds,
   };
+}
+
+function normalizeExcludedCurrencyIds(value: unknown): string[] {
+  if (!Array.isArray(value) || !value.every(id => typeof id === "string")) {
+    return [];
+  }
+
+  return [...new Set(value.filter(Boolean))];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/features/platform/contacts/src/featureFlags.web.test.tsx
+++ b/features/platform/contacts/src/featureFlags.web.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   CONTACTS_FEATURE_FLAG_KEYS,
   DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+  isContactsEnabledForCurrency,
   parseEligibleAddressFamiliesInput,
   resolveContactsFeatureConfig,
   resolveContactsFeatureParams,
@@ -27,6 +28,7 @@ const DEFAULT_CONFIG: ContactsFeatureConfig = {
   isEnabled: false,
   showNewBadge: false,
   eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+  excludedCurrencyIds: [],
 };
 
 function makeContactsFeatureValue(enabled: boolean, newBadge: boolean): ContactsFeatureValue {
@@ -78,6 +80,7 @@ describe("resolveContactsFeatureConfig", () => {
       isEnabled: true,
       showNewBadge: true,
       eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+      excludedCurrencyIds: [],
     });
   });
 
@@ -91,6 +94,25 @@ describe("resolveContactsFeatureConfig", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm", "bitcoin"],
+      excludedCurrencyIds: [],
+    });
+  });
+
+  it("passes through excludedCurrencyIds from the feature value", () => {
+    expect(
+      resolveContactsFeatureConfig({
+        enabled: true,
+        params: {
+          newBadge: false,
+          eligibleAddressFamilies: ["evm"],
+          excludedCurrencyIds: ["ethereum", "bitcoin"],
+        },
+      }),
+    ).toEqual({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+      excludedCurrencyIds: ["ethereum", "bitcoin"],
     });
   });
 });
@@ -100,6 +122,7 @@ describe("resolveContactsFeatureParams", () => {
     expect(resolveContactsFeatureParams({ eligibleAddressFamilies: ["evm", 1] })).toEqual({
       newBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
   });
 
@@ -107,7 +130,47 @@ describe("resolveContactsFeatureParams", () => {
     expect(resolveContactsFeatureParams({ eligibleAddressFamilies: [] })).toEqual({
       newBadge: false,
       eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
     });
+  });
+
+  it("normalizes excludedCurrencyIds, deduplicating entries", () => {
+    expect(
+      resolveContactsFeatureParams({ excludedCurrencyIds: ["ethereum", "ethereum", "bitcoin"] }),
+    ).toEqual({
+      newBadge: false,
+      eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: ["ethereum", "bitcoin"],
+    });
+  });
+
+  it("falls back to an empty array when excludedCurrencyIds contains non-strings", () => {
+    expect(resolveContactsFeatureParams({ excludedCurrencyIds: ["ethereum", 42] })).toEqual({
+      newBadge: false,
+      eligibleAddressFamilies: ["evm"],
+      excludedCurrencyIds: [],
+    });
+  });
+});
+
+describe("isContactsEnabledForCurrency", () => {
+  const enabledConfig: ContactsFeatureConfig = {
+    isEnabled: true,
+    showNewBadge: false,
+    eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+    excludedCurrencyIds: ["ethereum"],
+  };
+
+  it("returns true when the feature is enabled and the currency is not excluded", () => {
+    expect(isContactsEnabledForCurrency(enabledConfig, "bitcoin")).toBe(true);
+  });
+
+  it("returns false when the currency is in excludedCurrencyIds", () => {
+    expect(isContactsEnabledForCurrency(enabledConfig, "ethereum")).toBe(false);
+  });
+
+  it("returns false when the feature is disabled, even if the currency is not excluded", () => {
+    expect(isContactsEnabledForCurrency(DEFAULT_CONFIG, "bitcoin")).toBe(false);
   });
 });
 
@@ -136,7 +199,7 @@ describe("updateContactsFeatureValue", () => {
       enabled: true,
       desktop_version: "1.0.0",
       languages_whitelisted: ["fr"],
-      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"], excludedCurrencyIds: [] },
     });
   });
 
@@ -147,7 +210,7 @@ describe("updateContactsFeatureValue", () => {
       }),
     ).toEqual({
       enabled: true,
-      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"], excludedCurrencyIds: [] },
     });
   });
 
@@ -158,7 +221,11 @@ describe("updateContactsFeatureValue", () => {
       }),
     ).toEqual({
       enabled: true,
-      params: { newBadge: false, eligibleAddressFamilies: ["evm", "bitcoin"] },
+      params: {
+        newBadge: false,
+        eligibleAddressFamilies: ["evm", "bitcoin"],
+        excludedCurrencyIds: [],
+      },
     });
   });
 
@@ -170,7 +237,7 @@ describe("updateContactsFeatureValue", () => {
       ),
     ).toEqual({
       enabled: true,
-      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"], excludedCurrencyIds: [] },
     });
   });
 });
@@ -195,6 +262,7 @@ describe("useContactsFeature", () => {
       isEnabled: true,
       showNewBadge: false,
       eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+      excludedCurrencyIds: [],
     });
   });
 
@@ -205,6 +273,7 @@ describe("useContactsFeature", () => {
       isEnabled: true,
       showNewBadge: true,
       eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+      excludedCurrencyIds: [],
     });
   });
 

--- a/features/platform/contacts/src/utils/isEligibleAddressCurrency.ts
+++ b/features/platform/contacts/src/utils/isEligibleAddressCurrency.ts
@@ -7,6 +7,7 @@ import { isContactDeviceCurrencySupported } from "../device/resolveContactDevice
 export function isEligibleAddressCurrency(
   eligibleFamilies: readonly string[],
   currency: CryptoCurrency | TokenCurrency | null | undefined,
+  excludedCurrencyIds: readonly string[] = [],
 ): boolean {
   if (!currency) {
     return false;
@@ -20,6 +21,7 @@ export function isEligibleAddressCurrency(
   return (
     network !== undefined &&
     eligibleFamilies.includes(network.family) &&
-    isContactDeviceCurrencySupported(network.id)
+    isContactDeviceCurrencySupported(network.id) &&
+    !excludedCurrencyIds.includes(network.id)
   );
 }

--- a/features/platform/contacts/src/utils/isEligibleAddressCurrency.web.test.ts
+++ b/features/platform/contacts/src/utils/isEligibleAddressCurrency.web.test.ts
@@ -40,4 +40,21 @@ describe("isEligibleAddressCurrency", () => {
     expect(isEligibleAddressCurrency(["evm"], undefined)).toBe(false);
     expect(isEligibleAddressCurrency([], ETHEREUM)).toBe(false);
   });
+
+  it("rejects an explicitly excluded network", () => {
+    expect(isEligibleAddressCurrency(["evm"], ETHEREUM, ["ethereum"])).toBe(false);
+    expect(isEligibleAddressCurrency(["evm"], SEI, ["sei_evm"])).toBe(false);
+  });
+
+  it("still accepts non-excluded networks when an exclusion list is present", () => {
+    expect(isEligibleAddressCurrency(["evm"], ETHEREUM, ["sei_evm"])).toBe(true);
+  });
+
+  it("rejects a token whose parent network is excluded", () => {
+    expect(
+      isEligibleAddressCurrency(["evm"], mockTokenCurrency({ parentCurrencyId: ETHEREUM.id }), [
+        "ethereum",
+      ]),
+    ).toBe(false);
+  });
 });

--- a/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.ts
+++ b/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.ts
@@ -7,12 +7,18 @@ export type EligibleAddressNetwork = Readonly<Pick<CryptoCurrency, "id" | "famil
 export function resolveEligibleAddressCurrencyIds(
   eligibleFamilies: readonly string[],
   networks: readonly EligibleAddressNetwork[] = listCryptoCurrencies(),
+  excludedCurrencyIds: readonly string[] = [],
 ): CryptoCurrency["id"][] {
   const families = new Set(eligibleFamilies);
+  const excluded = new Set(excludedCurrencyIds);
   const networkIds = new Set<CryptoCurrency["id"]>();
 
   for (const network of networks) {
-    if (families.has(network.family) && isContactDeviceCurrencySupported(network.id)) {
+    if (
+      families.has(network.family) &&
+      isContactDeviceCurrencySupported(network.id) &&
+      !excluded.has(network.id)
+    ) {
       networkIds.add(network.id);
     }
   }

--- a/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.web.test.ts
+++ b/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.web.test.ts
@@ -51,6 +51,16 @@ describe("resolveEligibleAddressCurrencyIds", () => {
     expect(resolveEligibleAddressCurrencyIds(["unknown"], NETWORKS)).toEqual([]);
   });
 
+  it("omits explicitly excluded currency ids from the result", () => {
+    expect(
+      resolveEligibleAddressCurrencyIds(["evm", "tron"], NETWORKS, ["ethereum", "tron"]),
+    ).toEqual(["base"]);
+  });
+
+  it("returns an empty array when all eligible networks are excluded", () => {
+    expect(resolveEligibleAddressCurrencyIds(["evm"], NETWORKS, ["ethereum", "base"])).toEqual([]);
+  });
+
   it("deduplicates network ids while preserving their first occurrence", () => {
     expect(
       resolveEligibleAddressCurrencyIds(

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdContacts.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdContacts.ts
@@ -9,12 +9,14 @@ export const lwdContacts = flagWith(
     eligibleAddressFamilies: z
       .array(z.string())
       .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
+    excludedCurrencyIds: z.array(z.string()).optional(),
   },
   {
     enabled: false,
     params: {
       newBadge: false,
       eligibleAddressFamilies: [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
+      excludedCurrencyIds: [],
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmContacts.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmContacts.ts
@@ -9,12 +9,14 @@ export const lwmContacts = flagWith(
     eligibleAddressFamilies: z
       .array(z.string())
       .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
+    excludedCurrencyIds: z.array(z.string()).optional(),
   },
   {
     enabled: false,
     params: {
       newBadge: false,
       eligibleAddressFamilies: [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
+      excludedCurrencyIds: [],
     },
   },
 );


### PR DESCRIPTION
### 📝 Description

The `lwdContacts` and `lwmContacts` feature flags had no way to exclude individual currencies — only whole address families could be controlled via `eligibleAddressFamilies`. This meant that if a specific network (e.g. `sei_evm`) needed to be disabled for safety, there was no surgical option.

This PR adds an `excludedCurrencyIds` parameter to both flags — the same pattern already used by `newSendFlow`. The exclusion is enforced in `resolveEligibleAddressCurrencyIds` (currency picker) and `isEligibleAddressCurrency` (send-flow entry point), so excluded currencies are disabled everywhere Contacts appears: the add-address flow, the contact detail screen, and the recipient step on both desktop and mobile.

The desktop DevTool panel exposes the new parameter via a text input so it can be tested without a remote-config deployment.

LWD 

https://github.com/user-attachments/assets/cf672958-4105-4fdc-b218-daa95672c8a2

LWM

https://github.com/user-attachments/assets/88a371c3-7e3c-4952-bbcd-17213896397d


### 🔗 Context

- **JIRA issue**: [LIVE-37156](https://ledgerhq.atlassian.net/browse/LIVE-37156)

[LIVE-37156]: https://ledgerhq.atlassian.net/browse/LIVE-37156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ