### PR TITLE
ci(e2e): fix title when only on platform is selected

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1432,7 +1432,12 @@ jobs:
     env:
       REF: ${{ inputs.ref || github.ref_name }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      HEADER_DEVICES: "iOS:${{ needs.determine-builds.outputs.ios_device }} / Android:${{ needs.determine-builds.outputs.android_device }}"
+      HEADER_DEVICES: >-
+        ${{ inputs.tests_type == 'Android Only'
+          && format('Android:{0}', needs.determine-builds.outputs.android_device)
+          || (inputs.tests_type == 'iOS Only'
+            && format('iOS:{0}', needs.determine-builds.outputs.ios_device)
+            || format('iOS:{0} / Android:{1}', needs.determine-builds.outputs.ios_device, needs.determine-builds.outputs.android_device)) }}
       # A platform's label is blanked out when tests_type excludes it; the e2e-slack-report
       # composite then drops that row entirely (and its status stops driving the color).
       IOS_LABEL: ${{ inputs.tests_type != 'Android Only' && 'iOS' || '' }}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adjusts the Slack report header in the mobile E2E reusable workflow so the “devices” portion of the title reflects the selected platform(s) (Android-only, iOS-only, or both), instead of always displaying both.

### 🔗 Context

<img width="674" height="584" alt="Screenshot 2026-09-09 at 12 01 17" src="https://github.com/user-attachments/assets/3e3f0c8b-704b-4295-98af-d9d77ff76c73" />

