### PR TITLE
ci(e2e): fix desktop test owners when cli fails

### DIFF
--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -63,6 +63,7 @@ type TestFixtures = {
   }[];
   localManifestOverride?: LiveAppManifest[];
   teamOwner?: Team;
+  teamOwnerLabel: void;
   speculos: SpeculosFixtureHandle;
   speculosForSetupOnly?: boolean;
 };
@@ -99,6 +100,16 @@ export const test = base.extend<TestFixtures>({
   localManifestOverride: undefined,
   teamOwner: undefined,
   speculosForSetupOnly: false,
+
+  teamOwnerLabel: [
+    async ({ teamOwner }, use) => {
+      if (teamOwner !== undefined) {
+        await addTeamOwner(teamOwner);
+      }
+      await use();
+    },
+    { auto: true },
+  ],
 
   app: async ({ page, electronApp }, use) => {
     const app = new Application(page, electronApp);
@@ -263,13 +274,10 @@ export const test = base.extend<TestFixtures>({
       // No lingering process (only Reset App reboots the main process into a new instance)
     }
   },
-  page: async ({ electronApp, speculos, cliCommandsOnApp, teamOwner }, use, testInfo) => {
+  page: async ({ electronApp, speculos, cliCommandsOnApp }, use, testInfo) => {
     // app is ready
     const page = await electronApp.firstWindow();
 
-    if (teamOwner !== undefined) {
-      await addTeamOwner(teamOwner);
-    }
     // we need to give enough time for the playwright app to start. when the CI is slow, 30s was apprently not enough.
     page.setDefaultTimeout(120000);
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adjusts the Playwright desktop E2E fixture setup so the Allure “team owner” metadata is applied via an auto fixture rather than during page initialization, aiming to keep test ownership information available even when earlier setup steps (e.g., CLI/speculos) fail.

### 🔗 Context

- Desktop E2E [run](https://github.com/LedgerHQ/ledger-live/actions/runs/34338379511)

Failed CLI were not under owners
<img width="676" height="515" alt="Screenshot 2026-09-09 at 11 34 00" src="https://github.com/user-attachments/assets/ebba581e-3d65-48dd-92e0-1c37fd26ad77" />
