### PR TITLE
[LWDM] fix(contacts): update copy to match latest version (LIVE-37130)

### DIFF
--- a/.changeset/contacts-copy-update-pt2.md
+++ b/.changeset/contacts-copy-update-pt2.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Fix Contacts feature copy to match latest version (remove contractions, update disclaimers)

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
@@ -113,7 +113,7 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     await user.click(bitcoinAsset);
 
     expect(mockOnAssetSelected).not.toHaveBeenCalled();
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("Bitcoin isn't supported yet.");
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Bitcoin is not supported yet");
 
     bitcoinAsset.parentElement?.focus();
 
@@ -142,7 +142,7 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
 
     expect(mockOnAssetSelected).not.toHaveBeenCalled();
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Arbitrum network isn't supported yet.",
+      "Arbitrum network is not supported yet",
     );
 
     arbitrumNetwork.parentElement?.focus();

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2683,7 +2683,7 @@
     "addressMatched": "Address matched",
     "addressNotFound": "Address not found",
     "alreadyUsed": "Already used · {{date}}",
-    "addressBookUnsupported": "{{family}} isn't supported yet",
+    "addressBookUnsupported": "{{family}} is not supported yet",
     "recentSendWillAppear": "Your recent send will appear here",
     "contactsWillAppear": "Contacts will appear here",
     "selectAddress": "Select address",
@@ -9042,8 +9042,8 @@
     "emptyAssetList": "No assets found",
     "selectAsset": "Select asset",
     "selectNetwork": "Select network",
-    "unsupportedAssetTooltip": "{{asset}} isn't supported yet.",
-    "unsupportedNetworkTooltip": "{{network}} network isn't supported yet.",
+    "unsupportedAssetTooltip": "{{asset}} is not supported yet",
+    "unsupportedNetworkTooltip": "{{network}} network is not supported yet",
     "notAvailableYet": "Not available yet",
     "selectAccount": "Select account",
     "selectAccountPerpsTitle": "Select Hyperliquid account",
@@ -9692,7 +9692,7 @@
     },
     "contacts": {
       "title": "Contacts",
-      "description": "Save and manage external wallet addresses."
+      "description": "Manage your contacts"
     },
     "explore": "Explore all Ledger devices"
   },
@@ -9772,7 +9772,7 @@
     },
     "addContactDrawer": {
       "namePlaceholder": "Contact name",
-      "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
+      "namingDisclaimer": "For privacy, avoid full names. Use a nickname or just a first name + initial, e.g. 'John S.'",
       "invalidNameError": "Special characters are not allowed.",
       "duplicateNameError": "This contact name is already in use."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4639,7 +4639,7 @@
       "alreadyUsed": "Already used · {{date}}",
       "notInRecentHistory": "Not in your recent history",
       "addressBookUnsupported": {
-        "title": "{{family}} isn't supported yet",
+        "title": "{{family}} is not supported yet",
         "description": "You can't add a {{family}} address to your contacts yet. We're adding more cryptos over time."
       },
       "relativeDate": {
@@ -9835,11 +9835,11 @@
     "emptyAccounts": "You don't have {{network}} accounts yet. Please add one to continue",
     "addAccount": "Add account",
     "unsupportedAssetExplanation": {
-      "title": "{{asset}} isn't supported yet",
+      "title": "{{asset}} is not supported yet",
       "description": "You can't add a {{asset}} address to your contacts yet. We're adding more cryptos over time."
     },
     "unsupportedNetworkExplanation": {
-      "title": "{{network}} Network isn't supported yet",
+      "title": "{{network}} Network is not supported yet",
       "description": "You can't select {{network}} network for {{asset}}. We're adding more networks over time."
     },
     "errors": {
@@ -10456,7 +10456,7 @@
     },
     "contacts": {
       "title": "Contacts",
-      "description": "Save and manage external wallet addresses."
+      "description": "Manage your contacts"
     },
     "backupHub": {
       "title": "Backups of your Secret Recovery Phrase",
@@ -10675,7 +10675,7 @@
     "searchNoResults": "No contact found",
     "addContactDrawer": {
       "namePlaceholder": "Contact name",
-      "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
+      "namingDisclaimer": "For privacy, avoid full names. Use a nickname or just a first name + initial, e.g. 'John S.'",
       "confirmName": "Confirm name",
       "invalidNameError": "Special characters are not allowed.",
       "duplicateNameError": "This contact name is already in use."
@@ -10700,7 +10700,7 @@
     "addAddressName": {
       "title": "Name address",
       "inputLabel": "Address name",
-      "namingDisclaimer": "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
+      "namingDisclaimer": "This name appears on your Ledger device when you send to this address. Give it a name that makes it easy to find.",
       "continueToReview": "Continue to review",
       "invalidLabel": "Special characters are not allowed.",
       "duplicateLabel": "This address name is already used for this contact.",
@@ -10749,7 +10749,7 @@
     "editContact": {
       "title": "Edit contact",
       "namePlaceholder": "Contact name",
-      "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S.'",
+      "namingDisclaimer": "For privacy, avoid full names. Use a nickname or just a first name + initial, e.g. 'John S.'",
       "confirmName": "Confirm name",
       "applyChanges": "Apply changes",
       "invalidNameError": "Special characters are not allowed."

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -853,7 +853,7 @@ describe("Contacts integration", () => {
     expect(screen.getByText("Name address")).toBeVisible();
     expect(
       screen.getByText(
-        "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
+        "This name appears on your Ledger device when you send to this address. Give it a name that makes it easy to find.",
       ),
     ).toBeVisible();
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
@@ -944,7 +944,7 @@ describe("Contacts integration", () => {
     await user.press(bitcoinAsset);
 
     await waitFor(() => {
-      expect(screen.getByText("Bitcoin isn't supported yet")).toBeVisible();
+      expect(screen.getByText("Bitcoin is not supported yet")).toBeVisible();
       expect(
         screen.getByText(
           "You can't add a Bitcoin address to your contacts yet. We're adding more cryptos over time.",
@@ -956,10 +956,10 @@ describe("Contacts integration", () => {
     await user.press(screen.getByRole("button", { name: "Got it" }));
 
     await waitFor(() => {
-      expect(screen.queryByText("Bitcoin isn't supported yet")).toBeNull();
+      expect(screen.queryByText("Bitcoin is not supported yet")).toBeNull();
     });
     expect(
-      screen.getByLabelText("Bitcoin isn't supported yet", {
+      screen.getByLabelText("Bitcoin is not supported yet", {
         exact: true,
       }),
     ).toBeVisible();
@@ -974,7 +974,7 @@ describe("Contacts integration", () => {
     await user.press(solanaNetwork);
 
     await waitFor(() => {
-      expect(screen.getByText("Solana Network isn't supported yet")).toBeVisible();
+      expect(screen.getByText("Solana Network is not supported yet")).toBeVisible();
       expect(
         screen.getByText(
           "You can't select Solana network for Tether USD. We're adding more networks over time.",
@@ -986,7 +986,7 @@ describe("Contacts integration", () => {
     await user.press(screen.getByRole("button", { name: "Got it" }));
 
     await waitFor(() => {
-      expect(screen.queryByText("Solana Network isn't supported yet")).toBeNull();
+      expect(screen.queryByText("Solana Network is not supported yet")).toBeNull();
     });
 
     await user.press(ethereumNetwork);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -534,7 +534,7 @@ describe("Send flow integration tests", () => {
 
     await user.press(await screen.findByRole("button", { name: "Add contact" }));
 
-    expect(await screen.findByText("Bitcoin isn't supported yet")).toBeVisible();
+    expect(await screen.findByText("Bitcoin is not supported yet")).toBeVisible();
     expect(
       screen.getByText(
         "You can't add a Bitcoin address to your contacts yet. We're adding more cryptos over time.",


### PR DESCRIPTION
### 📝 Description

Several copy strings across the Contacts feature were not aligned with the latest agreed wording.

**Problem**: Tooltips and UI strings used informal contractions ("isn't"), included inconsistent trailing periods, and had outdated disclaimer wording.

**Solution**: Aligned all copy with the latest version reviewed during Testing Session 13:
- Replaced "isn't supported yet" → "is not supported yet" in unsupported asset/network tooltips (LWM & LWD)
- Removed trailing periods from tooltip strings for consistency
- Updated contacts feature description to "Manage your contacts"
- Updated naming disclaimer copy (remove "and surnames", add period)
- Updated send address naming disclaimer to clarify the Ledger device display context

Tests updated to match the new strings.

### 🔗 Context

- **JIRA issue**: [LIVE-37130](https://ledgerhq.atlassian.net/browse/LIVE-37130)
- **Parent epic**: [LIVE-35771](https://ledgerhq.atlassian.net/browse/LIVE-35771)
- **Feature flags**: `lwd_contacts`, `lwm_contacts`

[LIVE-37130]: https://ledgerhq.atlassian.net/browse/LIVE-37130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35771]: https://ledgerhq.atlassian.net/browse/LIVE-35771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ