### PR TITLE
[LWM] fix(e2e): run mobile ledger sync against prod (QAA-1561)

### DIFF
--- a/.changeset/QAA-1561-ledger-sync-prod-env.md
+++ b/.changeset/QAA-1561-ledger-sync-prod-env.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+"live-mobile": patch
+---
+
+Let the mobile Ledger Sync e2e suites run against the PROD trustchain during a release validation. The environment now reaches the app as a Detox launch arg, which the e2e bridge applies before the app tree mounts — the only point where the trustchain SDK singleton can still be pinned — so it no longer has to be refused outright.

--- a/apps/ledger-live-mobile/scripts/e2e-ci.mjs
+++ b/apps/ledger-live-mobile/scripts/e2e-ci.mjs
@@ -150,6 +150,9 @@ for (const argName in argv) {
       break;
     case "production":
       target = "prerelease";
+      // The prerelease build ships the production Firebase project, so Ledger Sync follows it to
+      // PROD. CI already derives this in setup-e2e-env; this covers a local --production run.
+      process.env.LEDGER_SYNC_ENVIRONMENT ??= "PROD";
       break;
     case "filter":
       filter = argv[argName];

--- a/apps/ledger-live-mobile/scripts/e2e-ci.mjs
+++ b/apps/ledger-live-mobile/scripts/e2e-ci.mjs
@@ -150,8 +150,6 @@ for (const argName in argv) {
       break;
     case "production":
       target = "prerelease";
-      // The prerelease build ships the production Firebase project, so Ledger Sync follows it to
-      // PROD. CI already derives this in setup-e2e-env; this covers a local --production run.
       process.env.LEDGER_SYNC_ENVIRONMENT ??= "PROD";
       break;
     case "filter":

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -46,14 +46,6 @@ async function disconnectAllSpeculosSessions() {
   await DeviceManagementKitTransportSpeculos.disconnectAll();
 }
 
-/**
- * `useTrustchainSdk` builds the trustchain SDK on its first render and keeps it in a module
- * singleton, so the environment it reads then is the only one the SDK will ever use. `init()` runs
- * from `onInitFinished`, in the same tick as `setReady(true)` and therefore before the app tree
- * mounts — the last point where the environment can still be pinned. A local override also outranks
- * Firebase for the rest of the session, which keeps the reactive cloud-sync SDK on the same backend:
- * a trustchain and a cloud-sync from different environments produce a token the other rejects.
- */
 function overrideLedgerSyncEnvironment() {
   const launchArg = LaunchArguments.value()["ledger_sync_environment"];
   const environment =
@@ -64,8 +56,6 @@ function overrideLedgerSyncEnvironment() {
   store.dispatch(
     setOverride({
       key: "llmWalletSync",
-      // Left disabled, like the shipped default: this pins the backend without turning Ledger Sync
-      // on for suites that never asked for it. The suites that do send their own override later.
       value: {
         enabled: false,
         params: { environment, watchConfig: {}, learnMoreLink: "" },

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -46,6 +46,34 @@ async function disconnectAllSpeculosSessions() {
   await DeviceManagementKitTransportSpeculos.disconnectAll();
 }
 
+/**
+ * `useTrustchainSdk` builds the trustchain SDK on its first render and keeps it in a module
+ * singleton, so the environment it reads then is the only one the SDK will ever use. `init()` runs
+ * from `onInitFinished`, in the same tick as `setReady(true)` and therefore before the app tree
+ * mounts — the last point where the environment can still be pinned. A local override also outranks
+ * Firebase for the rest of the session, which keeps the reactive cloud-sync SDK on the same backend:
+ * a trustchain and a cloud-sync from different environments produce a token the other rejects.
+ */
+function overrideLedgerSyncEnvironment() {
+  const launchArg = LaunchArguments.value()["ledger_sync_environment"];
+  const environment =
+    launchArg === "PROD" ? "PROD" : launchArg === "STAGING" ? "STAGING" : undefined;
+  if (!environment) return;
+
+  log(`[E2E Bridge Client]: Ledger Sync environment=${environment}`);
+  store.dispatch(
+    setOverride({
+      key: "llmWalletSync",
+      // Left disabled, like the shipped default: this pins the backend without turning Ledger Sync
+      // on for suites that never asked for it. The suites that do send their own override later.
+      value: {
+        enabled: false,
+        params: { environment, watchConfig: {}, learnMoreLink: "" },
+      },
+    }),
+  );
+}
+
 export function init() {
   const wsPort = LaunchArguments.value()["wsPort"] || "8099";
   const mock = LaunchArguments.value()["mock"];
@@ -59,6 +87,7 @@ export function init() {
     Config.MOCK = "";
   }
   setEnv("DISABLE_TRANSACTION_BROADCAST", disable_broadcast != "0");
+  overrideLedgerSyncEnvironment();
 
   initAppNetworkLogging();
 

--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -78,9 +78,6 @@ export async function launchApp(customConfig: Detox.DeviceLaunchAppConfig = {}) 
       detoxURLBlacklistRegex: createDetoxURLBlacklistRegex(),
       mock: "0",
       disable_broadcast: getEnv("DISABLE_TRANSACTION_BROADCAST") ? 1 : 0,
-      // The app builds its trustchain SDK on first render and keeps it in a module singleton, so a
-      // flag pushed over the bridge afterwards moves the flag but not the SDK. Launch args are read
-      // before that first render, which is the only window where this value can still land.
       ledger_sync_environment: ledgerSyncEnvironment,
       IS_TEST: true,
     },

--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -7,6 +7,7 @@ import { Device } from "@ledgerhq/live-e2e-shared/enum/Device";
 import { readFile } from "fs/promises";
 import { NANO_APP_CATALOG_PATH } from "@e2e/utils/constants";
 import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
+import { ledgerSyncEnvironment } from "@ledgerhq/live-e2e-shared/ledgerSync/environment";
 
 const BASE_DEEPLINK = "ledgerlive://";
 
@@ -77,6 +78,10 @@ export async function launchApp(customConfig: Detox.DeviceLaunchAppConfig = {}) 
       detoxURLBlacklistRegex: createDetoxURLBlacklistRegex(),
       mock: "0",
       disable_broadcast: getEnv("DISABLE_TRANSACTION_BROADCAST") ? 1 : 0,
+      // The app builds its trustchain SDK on first render and keeps it in a module singleton, so a
+      // flag pushed over the bridge afterwards moves the flag but not the SDK. Launch args are read
+      // before that first render, which is the only window where this value can still land.
+      ledger_sync_environment: ledgerSyncEnvironment,
       IS_TEST: true,
     },
     languageAndLocale: {

--- a/e2e/mobile/helpers/ledgerSyncHelpers.ts
+++ b/e2e/mobile/helpers/ledgerSyncHelpers.ts
@@ -1,4 +1,6 @@
 import { ledgerSyncEnvironment } from "@ledgerhq/live-e2e-shared/ledgerSync/environment";
+import { parseExtraFeatureFlags } from "@ledgerhq/live-e2e-shared/featureFlagsJsonUtils";
+import { getFlags } from "@e2e/bridge/server";
 
 import type { PartialFeatures } from "@shared/feature-flags";
 
@@ -44,16 +46,43 @@ export const LEDGER_SYNC_ACTIVATION_FEATURE_FLAGS: PartialFeatures = {
 };
 
 /**
- * The app builds its trustchain SDK on first render and keeps it in a module singleton, so the
- * environment it boots with is the only one it will ever use — an override sent to a running app
- * moves the flag but not the SDK. Pointing the CLI elsewhere would leave the two on different
- * backends and surface as an empty trustchain rather than an error, so refuse it up front.
+ * `getFlags` resolves to an empty string when the bridge does not answer in time, and this is the
+ * first round-trip of the run: on Android the app only reaches the server once `setup.ts` has
+ * reverse-forwarded the port, so the client can still be in its connection backoff here. Retry
+ * rather than read that silence as a wrong environment.
  */
-function assertSupportedEnvironment() {
-  if (ledgerSyncEnvironment !== "STAGING") {
+async function readAppLedgerSyncEnvironment() {
+  for (let attempt = 1; ; attempt++) {
+    const rawFlags = await getFlags();
+    if (rawFlags) {
+      return parseExtraFeatureFlags<PartialFeatures>(rawFlags).llmWalletSync?.params?.environment;
+    }
+    if (attempt === 3) {
+      throw new Error(
+        "Ledger Sync: the app never answered `getFlags`, so its environment could not be checked. " +
+          "The bridge is down — look for a launch or connection failure above.",
+      );
+    }
+  }
+}
+
+/**
+ * The environment reaches the app as the `ledger_sync_environment` launch arg, which the e2e bridge
+ * turns into a flag override before the app tree mounts — the only window that works, since the app
+ * builds its trustchain SDK on first render and keeps it in a module singleton.
+ *
+ * Call this *before* `app.init`: once a suite has pushed its own flags the read is circular, and it
+ * is the value the app booted with that the SDK is holding. A launch arg that stopped arriving then
+ * fails here, by name, rather than as the `400 Invalid value for: header Authorization` that a
+ * trustchain and a cloud-sync on different backends produce.
+ */
+export async function verifyLedgerSyncEnvironment() {
+  const appEnvironment = await readAppLedgerSyncEnvironment();
+
+  if (appEnvironment !== ledgerSyncEnvironment) {
     throw new Error(
-      `Ledger Sync: mobile can only run against STAGING, got ${ledgerSyncEnvironment}. ` +
-        "The app pins its trustchain SDK at boot, so LEDGER_SYNC_ENVIRONMENT cannot move it.",
+      `Ledger Sync: the app booted on ${appEnvironment}, the e2e CLI targets ${ledgerSyncEnvironment}. ` +
+        "Both sides must share a backend: the trustchain mints the JWT cloud-sync validates.",
     );
   }
 }
@@ -65,7 +94,6 @@ function assertSupportedEnvironment() {
 export function setupLedgerSyncSeed() {
   let previousSeed: string | undefined;
   beforeAll(() => {
-    assertSupportedEnvironment();
     previousSeed = app.ledgerSync.useGeneratedSeed();
   });
   afterAll(() => {

--- a/e2e/mobile/helpers/ledgerSyncHelpers.ts
+++ b/e2e/mobile/helpers/ledgerSyncHelpers.ts
@@ -45,12 +45,7 @@ export const LEDGER_SYNC_ACTIVATION_FEATURE_FLAGS: PartialFeatures = {
   lwmLedgerSyncOptimisation: { enabled: true },
 };
 
-/**
- * `getFlags` resolves to an empty string when the bridge does not answer in time, and this is the
- * first round-trip of the run: on Android the app only reaches the server once `setup.ts` has
- * reverse-forwarded the port, so the client can still be in its connection backoff here. Retry
- * rather than read that silence as a wrong environment.
- */
+/** `getFlags` returns "" when the bridge has not connected yet, so retry before believing it. */
 async function readAppLedgerSyncEnvironment() {
   for (let attempt = 1; ; attempt++) {
     const rawFlags = await getFlags();
@@ -66,16 +61,7 @@ async function readAppLedgerSyncEnvironment() {
   }
 }
 
-/**
- * The environment reaches the app as the `ledger_sync_environment` launch arg, which the e2e bridge
- * turns into a flag override before the app tree mounts — the only window that works, since the app
- * builds its trustchain SDK on first render and keeps it in a module singleton.
- *
- * Call this *before* `app.init`: once a suite has pushed its own flags the read is circular, and it
- * is the value the app booted with that the SDK is holding. A launch arg that stopped arriving then
- * fails here, by name, rather than as the `400 Invalid value for: header Authorization` that a
- * trustchain and a cloud-sync on different backends produce.
- */
+/** Call before `app.init`: once a suite has pushed its own flags, this reads them back to itself. */
 export async function verifyLedgerSyncEnvironment() {
   const appEnvironment = await readAppLedgerSyncEnvironment();
 

--- a/e2e/mobile/specs/contacts/contacts.ts
+++ b/e2e/mobile/specs/contacts/contacts.ts
@@ -6,6 +6,7 @@ import {
   LEDGER_SYNC_FEATURE_FLAGS,
   cleanupLedgerSyncAfterAll,
   setupLedgerSyncSeed,
+  verifyLedgerSyncEnvironment,
 } from "@e2e/helpers/ledgerSyncHelpers";
 import { FF_LWM_WALLET_40_Q2 } from "@e2e/utils/featureFlagUtils";
 
@@ -34,6 +35,7 @@ const NO_ADDRESS_LABEL = "0 address";
 
 /** Boots the app already a member of a freshly created trustchain, skipping the activation UI. */
 async function initApp(options: ApplicationOptions = {}) {
+  await verifyLedgerSyncEnvironment();
   await app.init({
     userdata: options.userdata ?? CONTACTS_USERDATA,
     speculosApp: AppInfos.LS,

--- a/e2e/mobile/specs/ledgerSync/ledgerSync.ts
+++ b/e2e/mobile/specs/ledgerSync/ledgerSync.ts
@@ -7,6 +7,7 @@ import {
   LEDGER_SYNC_FEATURE_FLAGS,
   cleanupLedgerSyncAfterAll,
   setupLedgerSyncSeed,
+  verifyLedgerSyncEnvironment,
 } from "@e2e/helpers/ledgerSyncHelpers";
 import type { LedgerSyncCliCommand } from "@ledgerhq/live-e2e-shared/ledgerSync/setup";
 import {
@@ -45,7 +46,13 @@ function ledgerSyncSuite(
       cleanupLedgerSyncAfterAll();
     }
 
-    beforeAll(init);
+    // Verified here rather than in `setupLedgerSyncSeed` so the suites that skip the seed hook are
+    // covered too. The app is already up — `setup.ts` launches it in a file-level hook — and the
+    // check has to happen before `init` pushes the suite's own flags, or it just reads those back.
+    beforeAll(async () => {
+      await verifyLedgerSyncEnvironment();
+      await init();
+    });
 
     tmsLinks.forEach(link => $TmsLink(link));
     tags.forEach(tag => $Tag(tag));

--- a/e2e/mobile/specs/ledgerSync/ledgerSync.ts
+++ b/e2e/mobile/specs/ledgerSync/ledgerSync.ts
@@ -46,9 +46,6 @@ function ledgerSyncSuite(
       cleanupLedgerSyncAfterAll();
     }
 
-    // Verified here rather than in `setupLedgerSyncSeed` so the suites that skip the seed hook are
-    // covered too. The app is already up — `setup.ts` launches it in a file-level hook — and the
-    // check has to happen before `init` pushes the suite's own flags, or it just reads those back.
     beforeAll(async () => {
       await verifyLedgerSyncEnvironment();
       await init();


### PR DESCRIPTION
## Why

[QAA-1561](https://ledgerhq.atlassian.net/browse/QAA-1561) — running the Ledger Sync suites during a release / hotfix validation fails with:

```
Error: Ledger Sync: mobile can only run against STAGING, got PROD.
The app pins its trustchain SDK at boot, so LEDGER_SYNC_ENVIRONMENT cannot move it.
```

The ticket asks that the Ledger Sync backend follow **the Firebase project the run uses** — `testing` → STAGING, `js` (production) → PROD.

That mapping already exists: [`setup-e2e-env/action.yml`](../blob/develop/tools/actions/composites/setup-e2e-env/action.yml#L32-L38) sets `LEDGER_SYNC_ENVIRONMENT=PROD` when `build_type == "js"`, and `test-mobile-e2e-reusable.yml` translates `production_firebase: true` → `'js'`. Desktop already honours it, because feature flags are injected as a `FEATURE_FLAGS` env var at Electron launch. **Mobile refused it**, for a real reason: mobile pushes flags over the Detox bridge *after* launch, while `useTrustchainSdk` builds the SDK on first render and keeps it in a module singleton — so a post-boot override moved the flag but not the SDK.

## What

Pass the environment one step earlier, as a Detox launch arg — the mechanism `disable_broadcast` already uses.

- **`e2e/mobile/helpers/commonHelpers.ts`** — `launchApp` sends `ledger_sync_environment` in `launchArgs`.
- **`apps/ledger-live-mobile/src/e2e/bridge/client.ts`** — `init()` turns it into a `setOverride` for `llmWalletSync`. `init()` runs from `onInitFinished`, in the same tick as `setReady(true)`, so it lands before `AppProviders` → `WalletSyncProvider` → `useTrustchainSdk` mounts. As a local override it also outranks Firebase for the rest of the session, which keeps the *reactive* cloud-sync SDK on the same backend — a trustchain and a cloud-sync on different backends produce a token the other rejects, surfacing only as `400 Invalid value for: header Authorization`. The flag is left `enabled: false`, matching the shipped default, so this pins the backend without turning Ledger Sync on for suites that never asked for it.
- **`e2e/mobile/helpers/ledgerSyncHelpers.ts`** — the blanket refusal becomes `verifyLedgerSyncEnvironment()`, which reads the app's resolved flag back over the bridge and fails by name if the two sides disagree. It retries, because `getFlags` resolves to `""` on timeout and this is the run's first bridge round-trip.
- **`e2e/mobile/specs/ledgerSync/ledgerSync.ts`, `specs/contacts/contacts.ts`** — the check runs *before* `app.init`, so it reads the value the app booted with rather than the suite's own override read back. Wiring it into `ledgerSyncSuite` also covers `runLedgerSyncSettingsEntryPointTest` and `runLedgerSyncActivationNoBackupTest`, which skip the seed hook and had **no guard at all** today.
- **`apps/ledger-live-mobile/scripts/e2e-ci.mjs`** — `--production` defaults `LEDGER_SYNC_ENVIRONMENT=PROD`, covering the one path `setup-e2e-env` does not (a local prerelease run).

No CI workflow changes: `production_firebase: true` / `build_type: js` already exist and already map to PROD. There is deliberately no release/hotfix *branch* detection — the ticket keys off the Firebase choice, which is a dispatch input.

## Product defect found along the way (not fixed here)

`useTrustchainSdk` caches the SDK in a module singleton and never rebuilds it. Combined with `WaitForAppReady`'s 1s Firebase timeout and `resolved` starting as `FEATURE_FLAGS_DEFAULTS` (`environment: "STAGING"`), **a real user on a slow first boot gets a STAGING trustchain while cloud-sync follows the flag to PROD** — a silent 400 until the app is restarted. The launch-arg override sidesteps it for e2e; the product fix (key the singleton on the environment, as the desktop hook would also need) belongs to Wallet XP. Flagging rather than fixing, to keep this PR test-side.

## Test plan

- [ ] LWM e2e, `production_firebase: true` — the ticket's case: production Firebase → PROD trustchain.
- [ ] LWM e2e, default — proves the STAGING path is untouched.

Both runs linked in a comment below. Confirm the job summaries read `**Firebase env to target:** production` / `testing`, and that the two hit different trustchain hosts in the App Network Logs attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1561]: https://ledgerhq.atlassian.net/browse/QAA-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ