### PR TITLE
[LWDM] feat(coin-cosmos): add the gonka chain (LIVE-36038)

### DIFF
--- a/.changeset/gonka-cosmos-chain-and-signer-hrp-fix.md
+++ b/.changeset/gonka-cosmos-chain-and-signer-hrp-fix.md
@@ -9,7 +9,10 @@ Adds the Gonka chain to the Cosmos coin module's chain factory. Fixes the Cosmos
 signer to send the chain's address prefix to the device on every coin type
 instead of only coin type 60 — the gate was safe while 118 was the only other
 option, but a chain on any other coin type (Gonka is on 1200) could not sign
-through the DMK signer. Renames `CosmosSigner.sign`'s third parameter from
-`transactionType` to `hrp`, matching what it actually carries. Also treats a
-zero fee as loaded rather than missing on the send path, so a zero-fee chain
-can send a transaction and use its full spendable balance.
+through the DMK signer. Chains whose device app is not app-cosmos opt out via
+the new `signWithPrefix` chain parameter: `crypto_org` and `crypto_org_croeseid`
+run the separate "Cronos POS Chain" app on coin type 394 and keep omitting the
+field, so no shipping chain's sign APDU changes. Renames `CosmosSigner.sign`'s
+third parameter from `transactionType` to `hrp`, matching what it actually
+carries. Also treats a zero fee as loaded rather than missing on the send path,
+so a zero-fee chain can send a transaction and use its full spendable balance.

--- a/.changeset/gonka-cosmos-chain-and-signer-hrp-fix.md
+++ b/.changeset/gonka-cosmos-chain-and-signer-hrp-fix.md
@@ -1,0 +1,15 @@
+---
+"@ledgerhq/coin-cosmos": patch
+"@ledgerhq/live-signer-cosmos": patch
+---
+
+fix(cosmos): add the gonka chain and always send the HRP to the signer
+
+Adds the Gonka chain to the Cosmos coin module's chain factory. Fixes the Cosmos
+signer to send the chain's address prefix to the device on every coin type
+instead of only coin type 60 — the gate was safe while 118 was the only other
+option, but a chain on any other coin type (Gonka is on 1200) could not sign
+through the DMK signer. Renames `CosmosSigner.sign`'s third parameter from
+`transactionType` to `hrp`, matching what it actually carries. Also treats a
+zero fee as loaded rather than missing on the send path, so a zero-fee chain
+can send a transaction and use its full spendable balance.

--- a/libs/coin-modules/coin-cosmos/src/chain/CryptoOrg.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/CryptoOrg.ts
@@ -5,6 +5,11 @@ class CryptoOrg extends CosmosBase {
   unbondingPeriod: number;
   validatorPrefix: string;
   prefix: string;
+  // Served by the "Cronos POS Chain" app on coin type 394, not by app-cosmos — whose chain
+  // config has no "cro" entry and whose isSupportedCoinType() admits only 118, 60 and its own
+  // table. That app's handling of the prefix field on the sign APDU is unverified, so keep
+  // omitting it: the signed digest is unaffected, only the APDU framing would change.
+  signWithPrefix = false;
   // Provided by coin config
   lcd!: string;
   ledgerValidator!: string;

--- a/libs/coin-modules/coin-cosmos/src/chain/Gonka.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/Gonka.ts
@@ -1,0 +1,23 @@
+import CosmosBase from "./cosmosBase";
+
+class Gonka extends CosmosBase {
+  stakingDocUrl: string;
+  unbondingPeriod: number;
+  prefix: string;
+  validatorPrefix: string;
+  // The chain's fee rule is a consensus parameter (FeeParams.MinGasPriceNgonka) currently at 0,
+  // so the family's non-zero default would price transfers a fee-less chain never charges.
+  minGasPrice = 0;
+  // Provided by coin config
+  ledgerValidator!: string;
+  lcd!: string;
+  constructor() {
+    super();
+    this.stakingDocUrl = "";
+    this.unbondingPeriod = 0;
+    this.prefix = "gonka";
+    this.validatorPrefix = `${this.prefix}valoper`;
+  }
+}
+
+export default Gonka;

--- a/libs/coin-modules/coin-cosmos/src/chain/chain.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/chain.ts
@@ -7,6 +7,7 @@ import Cosmos from "./Cosmos";
 import CryptoOrg from "./CryptoOrg";
 import Desmos from "./Desmos";
 import Dydx from "./Dydx";
+import Gonka from "./Gonka";
 import Injective from "./Injective";
 import Mantra from "./Mantra";
 import Nyx from "./Nyx";
@@ -88,6 +89,9 @@ export default function cryptoFactory(currencyId: string, config?: CosmosCoinCon
         break;
       case "babylon":
         chain = new Babylon();
+        break;
+      case "gonka":
+        chain = new Gonka();
         break;
       default:
         throw new Error(`${currencyId} is not supported`);

--- a/libs/coin-modules/coin-cosmos/src/chain/chain.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/chain.unit.test.ts
@@ -52,6 +52,19 @@ describe("cryptoFactory test", () => {
     expect(chain.ledgerValidator).toBeUndefined();
   });
 
+  it("should opt crypto_org out of sending the prefix on the sign APDU", () => {
+    // The only chains here not served by app-cosmos: coin type 394 runs the "Cronos POS Chain"
+    // app, whose handling of the prefix field on signing is unverified.
+    expect(cryptoFactory("crypto_org").signWithPrefix).toBe(false);
+    expect(cryptoFactory("crypto_org_croeseid").signWithPrefix).toBe(false);
+  });
+
+  it("should send the prefix on the sign APDU for every app-cosmos chain", () => {
+    for (const id of ["cosmos", "osmo", "dydx", "injective", "xion", "babylon", "gonka"]) {
+      expect(cryptoFactory(id).signWithPrefix).toBe(true);
+    }
+  });
+
   it("should throw an error when currency id is unknown", () => {
     expect(() => cryptoFactory("unknown")).toThrow();
   });

--- a/libs/coin-modules/coin-cosmos/src/chain/chain.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/chain.unit.test.ts
@@ -31,6 +31,7 @@ describe("cryptoFactory test", () => {
       "xion",
       "zenrock",
       "babylon",
+      "gonka",
     ];
     currencies.forEach(currency => {
       expect(cryptoFactory(currency)).not.toBeNull();
@@ -41,6 +42,14 @@ describe("cryptoFactory test", () => {
     const chain = cryptoFactory("crypto_org_croeseid");
     expect(chain.prefix).toBe("cro");
     expect(chain.unbondingPeriod).toBe(28);
+  });
+
+  it("should resolve gonka with its parameters", () => {
+    const chain = cryptoFactory("gonka");
+    expect(chain.prefix).toBe("gonka");
+    expect(chain.validatorPrefix).toBe("gonkavaloper");
+    expect(chain.minGasPrice).toBe(0);
+    expect(chain.ledgerValidator).toBeUndefined();
   });
 
   it("should throw an error when currency id is unknown", () => {

--- a/libs/coin-modules/coin-cosmos/src/chain/cosmosBase.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/cosmosBase.ts
@@ -38,6 +38,11 @@ abstract class cosmosBase {
   defaultGas = 100000;
   minGasPrice = 0.0025;
   version = "v1beta1";
+  // Whether this chain's device app accepts the bech32 prefix on the sign APDU. app-cosmos
+  // requires it — it resolves the (coin type, HRP) pair through checkChainConfig, and on any
+  // coin type other than 118 a missing prefix is rejected. It serves every chain here except
+  // the Cronos POS Chain ones, which run a separate app binary; see CryptoOrg.
+  signWithPrefix = true;
   // chain queues staking msgs until epoch end (x/epoching); sync merges the queue into positions
   epochedStaking = false;
   stakingMessages: StakingMessages = COSMOS_STAKING_MESSAGES;

--- a/libs/coin-modules/coin-cosmos/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-cosmos/src/getTransactionStatus.ts
@@ -228,7 +228,9 @@ export class CosmosTransactionStatusManager {
     }
 
     const estimatedFees = transaction.fees || new BigNumber(0);
-    if (!transaction.fees || !transaction.fees.gt(0)) {
+    // A zero fee is a loaded fee. `createTransaction` initialises `fees: null`, which is the
+    // only genuine "not yet computed" state.
+    if (!transaction.fees) {
       errors.fees = new FeeNotLoaded();
     }
 

--- a/libs/coin-modules/coin-cosmos/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-cosmos/src/getTransactionStatus.ts
@@ -157,6 +157,11 @@ export class CosmosTransactionStatusManager {
 
     const estimatedFees = transaction.fees || new BigNumber(0);
 
+    // A zero fee is treated as missing here, unlike the send path below, which only raises on a
+    // genuinely absent fee. A chain with `minGasPrice: 0` that enables staking therefore hits a
+    // permanent FeeNotLoaded on this path: the Delegate button stays disabled with no message
+    // explaining why. Left in place because no such chain currently reaches these modes; tracked
+    // in LIVE-37264 alongside unit coverage for the staking paths.
     if (!transaction.fees || !transaction.fees.gt(0)) {
       errors.fees = new FeeNotLoaded();
     }

--- a/libs/coin-modules/coin-cosmos/src/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/getTransactionStatus.unit.test.ts
@@ -3,6 +3,7 @@ import * as bech32 from "bech32";
 import BigNumber from "bignumber.js";
 import getTransactionStatus from "./getTransactionStatus";
 import { CosmosAccount, Transaction } from "./types";
+import { getMaxEstimatedBalance } from "./logic";
 
 // Status-level negative cases for getTransactionStatus. This is pure in-memory
 // logic — no network call, no signer — so it lives here as a coin-cosmos unit
@@ -10,6 +11,7 @@ import { CosmosAccount, Transaction } from "./types";
 // happy path). They guard the rejections a user can hit before signing: bad
 // amount, bad recipient, not enough balance.
 const babylon = getCryptoCurrencyById("babylon");
+const gonka = getCryptoCurrencyById("gonka");
 
 // 1 BABY = 1e6 ubbn (the base unit getTransactionStatus works in). Accept a
 // string so non-integer amounts parse exactly (no JS float rounding).
@@ -21,13 +23,16 @@ const BABY = (n: string | number): BigNumber => new BigNumber(n).times(1e6);
 // bytes are arbitrary.
 const validRecipient = bech32.encode("bbn", bech32.toWords(Buffer.alloc(20, 1)));
 
-const makeAccount = (spendableBalance: BigNumber): CosmosAccount =>
+const makeAccount = (spendableBalance: BigNumber, currency = babylon): CosmosAccount =>
   ({
     type: "Account",
-    currency: babylon,
+    currency,
     // Distinct from validRecipient so the send checks reach the amount/balance
     // branch instead of short-circuiting on destination-is-source.
-    freshAddress: bech32.encode("bbn", bech32.toWords(Buffer.alloc(20, 2))),
+    freshAddress: bech32.encode(
+      currency.id === "gonka" ? "gonka" : "bbn",
+      bech32.toWords(Buffer.alloc(20, 2)),
+    ),
     balance: spendableBalance,
     spendableBalance,
     cosmosResources: {
@@ -41,6 +46,9 @@ const makeAccount = (spendableBalance: BigNumber): CosmosAccount =>
       sequence: 0,
     },
   }) as unknown as CosmosAccount;
+
+// A well-formed gonka1… recipient, built the same way as validRecipient above.
+const validGonkaRecipient = bech32.encode("gonka", bech32.toWords(Buffer.alloc(20, 1)));
 
 describe("getTransactionStatus negative cases", () => {
   it("rejects a send above the spendable balance with NotEnoughBalance", async () => {
@@ -96,5 +104,44 @@ describe("getTransactionStatus negative cases", () => {
     } as unknown as Transaction;
     const status = await getTransactionStatus(account, transaction);
     expect(status.errors.recipient?.name).toBe("InvalidAddress");
+  });
+});
+
+describe("getTransactionStatus zero-fee chain (gonka)", () => {
+  it("treats a zero fee as loaded and spends the full balance with useAllAmount", async () => {
+    const spendableBalance = BABY(10);
+    const account = makeAccount(spendableBalance, gonka);
+    const transaction = {
+      mode: "send",
+      recipient: validGonkaRecipient,
+      amount: new BigNumber(0),
+      fees: new BigNumber(0),
+      gas: new BigNumber(80000),
+      validators: [],
+      useAllAmount: true,
+    } as unknown as Transaction;
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.errors.fees).toBeUndefined();
+    expect(status.amount).toEqual(getMaxEstimatedBalance(account, new BigNumber(0)));
+    expect(status.amount).toEqual(spendableBalance);
+  });
+
+  it("still flags FeeNotLoaded when fees have not been computed yet", async () => {
+    const account = makeAccount(BABY(10), gonka);
+    const transaction = {
+      mode: "send",
+      recipient: validGonkaRecipient,
+      amount: BABY(1),
+      fees: null,
+      gas: new BigNumber(80000),
+      validators: [],
+      useAllAmount: false,
+    } as unknown as Transaction;
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.errors.fees?.name).toBe("FeeNotLoaded");
   });
 });

--- a/libs/coin-modules/coin-cosmos/src/signOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.ts
@@ -67,16 +67,10 @@ export const buildSignOperation =
 
         const { signature: resSignature, return_code } = (await signerContext(
           deviceId,
-          async signer => {
-            let res;
-            // HRP is only needed when signing for ethermint chains
-            if (path[1] === 60) {
-              res = await signer.sign(path, tx, chainInstance.prefix);
-            } else {
-              res = await signer.sign(path, tx);
-            }
-            return res;
-          },
+          // The device validates the (coin type, HRP) pair, so the chain's own prefix goes on every
+          // signing request. Gating it on coin type 60 only worked while 118 — which the device
+          // exempts — was the sole alternative.
+          async signer => signer.sign(path, tx, chainInstance.prefix),
         )) as CosmosSignatureSdk;
 
         switch (return_code) {

--- a/libs/coin-modules/coin-cosmos/src/signOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.ts
@@ -79,6 +79,14 @@ export const buildSignOperation =
           case RETURN_CODES.REFUSED_OPERATION:
             throw new UserRefusedOnDevice();
         }
+        if (!resSignature) {
+          // Defensive: an unhandled non-success return_code can still carry a null signature;
+          // fail clearly instead of letting Secp256k1Signature.fromDer throw on null. Mirrors
+          // the same guard in signRawOperation.
+          throw new Error(
+            `signOperation: device returned no signature (return_code ${return_code})`,
+          );
+        }
 
         const signature = Buffer.from(Secp256k1Signature.fromDer(resSignature).toFixedLength());
 

--- a/libs/coin-modules/coin-cosmos/src/signOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.ts
@@ -69,8 +69,10 @@ export const buildSignOperation =
           deviceId,
           // The device validates the (coin type, HRP) pair, so the chain's own prefix goes on every
           // signing request. Gating it on coin type 60 only worked while 118 — which the device
-          // exempts — was the sole alternative.
-          async signer => signer.sign(path, tx, chainInstance.prefix),
+          // exempts — was the sole alternative. Chains whose device app is not app-cosmos opt out
+          // via signWithPrefix; see CryptoOrg.
+          async signer =>
+            signer.sign(path, tx, chainInstance.signWithPrefix ? chainInstance.prefix : undefined),
         )) as CosmosSignatureSdk;
 
         switch (return_code) {

--- a/libs/coin-modules/coin-cosmos/src/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.unit.test.ts
@@ -1,0 +1,207 @@
+import { makeSignDoc, serializeSignDoc } from "@cosmjs/amino";
+import { Secp256k1, sha256 } from "@cosmjs/crypto";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import BigNumber from "bignumber.js";
+import { firstValueFrom, toArray } from "rxjs";
+import { messageParamsFromTransaction, txToMessages } from "./buildTransaction";
+import cryptoFactory from "./chain/chain";
+import { ExpertModeRequired } from "./errors";
+import { buildSignOperation } from "./signOperation";
+import { CosmosAccount, RETURN_CODES, Transaction } from "./types";
+import { CosmosSigner } from "./types/signer";
+
+// signOperation constructs `new CosmosAPI(account.currency.id)` internally, so the network
+// layer must be mocked rather than injected — unlike signRawOperation, which only takes a
+// signerContext.
+jest.mock("./network/Cosmos", () => ({
+  CosmosAPI: jest.fn().mockImplementation(() => ({
+    getAccount: jest.fn().mockResolvedValue({
+      accountNumber: 7,
+      sequence: 3,
+      pubKey: "",
+      pubKeyType: "/cosmos.crypto.secp256k1.PubKey",
+    }),
+    getNodeInfo: jest.fn().mockResolvedValue({
+      default_node_info: { network: "gonka-mainnet" },
+    }),
+  })),
+}));
+
+const SUCCESS = 0x9000;
+const ACCOUNT_NUMBER = "7";
+const SEQUENCE = "3";
+const CHAIN_ID = "gonka-mainnet";
+
+const privkey = sha256(Buffer.from("coin-cosmos signOperation test seed"));
+// Arbitrary but well-formed compressed secp256k1 pubkey bytes — signOperation only forwards
+// this into the crafted transaction, it never validates it, so the exact value is irrelevant.
+const compressedPk = Buffer.from(`02${"11".repeat(32)}`, "hex");
+
+// Signer that produces a real DER secp256k1 signature over the bytes it receives, so
+// `Secp256k1Signature.fromDer` in signOperation.ts never throws on a fixture signature.
+function makeRealSigner(): CosmosSigner & { sign: jest.Mock; getAddressAndPubKey: jest.Mock } {
+  const getAddressAndPubKey = jest.fn().mockResolvedValue({
+    bech32_address: "",
+    compressed_pk: compressedPk,
+    return_code: SUCCESS,
+    error_message: "",
+  });
+  const sign = jest.fn(async (_path: number[], buffer: Buffer) => {
+    const sig = await Secp256k1.createSignature(sha256(buffer), privkey);
+    return { signature: Buffer.from(sig.toDer()), return_code: SUCCESS };
+  });
+  return { getAddressAndPubKey, sign } as unknown as CosmosSigner & {
+    sign: jest.Mock;
+    getAddressAndPubKey: jest.Mock;
+  };
+}
+
+const signerContextOf =
+  (signer: CosmosSigner) => (_deviceId: string, fn: (s: CosmosSigner) => any) =>
+    fn(signer);
+
+function makeAccount(
+  freshAddressPath: string,
+  currency: { id: string; units: { code: string }[] },
+): CosmosAccount {
+  return {
+    id: "js:2:cosmos:cosmos1xxx:",
+    freshAddress: "cosmos1xxx",
+    freshAddressPath,
+    spendableBalance: new BigNumber(0),
+    currency,
+  } as unknown as CosmosAccount;
+}
+
+function makeTransaction(recipient: string): Transaction {
+  return {
+    family: "cosmos",
+    mode: "send",
+    recipient,
+    amount: new BigNumber(1000),
+    fees: new BigNumber(500),
+    gas: new BigNumber(200000),
+    memo: "",
+    validators: [],
+    sourceValidator: undefined,
+    networkInfo: null,
+    useAllAmount: false,
+  } as unknown as Transaction;
+}
+
+// Rebuilds the exact signDoc bytes signOperation.ts should hand to the device, independently
+// of the module under test, so the "canonical bytes" assertion is not circular.
+function expectedSignDocBytes(account: CosmosAccount, transaction: Transaction): Buffer {
+  const chainInstance = cryptoFactory(account.currency.id);
+  const { aminoMsgs } = txToMessages(
+    messageParamsFromTransaction(account, transaction),
+    chainInstance,
+  );
+  const feeToEncode = {
+    amount: [
+      {
+        denom: account.currency.units[1].code,
+        amount: transaction.fees!.toFixed(),
+      },
+    ],
+    gas: transaction.gas!.toFixed(),
+  };
+  const signDoc = makeSignDoc(
+    aminoMsgs,
+    feeToEncode,
+    CHAIN_ID,
+    transaction.memo || "",
+    ACCOUNT_NUMBER,
+    SEQUENCE,
+  );
+  return Buffer.from(serializeSignDoc(signDoc));
+}
+
+describe("buildSignOperation", () => {
+  it("passes the chain prefix for coin type 1200 and signs the canonical signDoc bytes", async () => {
+    const signer = makeRealSigner();
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/1200'/0'/0/0", {
+      id: "gonka",
+      units: [{ code: "GNK" }, { code: "ngonka" }],
+    });
+    const transaction = makeTransaction("gonka1yyy");
+
+    const events = await firstValueFrom(
+      signOperation({ account, deviceId: "mock", transaction }).pipe(toArray()),
+    );
+
+    expect(events.map(e => e.type)).toEqual([
+      "device-signature-requested",
+      "device-signature-granted",
+      "signed",
+    ]);
+    // The chain prefix reaches the device as the 3rd sign argument — coin type 1200 is neither
+    // 60 nor 118, the two coin types the old gate special-cased.
+    expect(signer.sign.mock.calls[0][2]).toBe("gonka");
+    // The device signs the canonical serialized amino signDoc, not some other buffer — guards
+    // against the prefix landing in the wrong positional slot.
+    expect(Buffer.from(signer.sign.mock.calls[0][1])).toEqual(
+      expectedSignDocBytes(account, transaction),
+    );
+  });
+
+  it("passes the chain prefix for coin type 118 (existing chains, pinned)", async () => {
+    const signer = makeRealSigner();
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/118'/0'/0/0", {
+      id: "cosmos",
+      units: [{ code: "ATOM" }, { code: "uatom" }],
+    });
+    const transaction = makeTransaction("cosmos1yyy");
+
+    await firstValueFrom(signOperation({ account, deviceId: "mock", transaction }).pipe(toArray()));
+
+    // The argument changes for existing chains too — this pins the new value so a regression
+    // to the coin-type gate is caught.
+    expect(signer.sign.mock.calls[0][2]).toBe("cosmos");
+  });
+
+  it("throws ExpertModeRequired when the device demands expert mode", async () => {
+    const signer = makeRealSigner();
+    signer.sign.mockResolvedValue({
+      signature: null,
+      return_code: RETURN_CODES.EXPERT_MODE_REQUIRED,
+    });
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/1200'/0'/0/0", {
+      id: "gonka",
+      units: [{ code: "GNK" }, { code: "ngonka" }],
+    });
+
+    await expect(
+      firstValueFrom(
+        signOperation({
+          account,
+          deviceId: "mock",
+          transaction: makeTransaction("gonka1yyy"),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toBeInstanceOf(ExpertModeRequired);
+  });
+
+  it("throws UserRefusedOnDevice when the user rejects on device", async () => {
+    const signer = makeRealSigner();
+    signer.sign.mockResolvedValue({ signature: null, return_code: RETURN_CODES.REFUSED_OPERATION });
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/1200'/0'/0/0", {
+      id: "gonka",
+      units: [{ code: "GNK" }, { code: "ngonka" }],
+    });
+
+    await expect(
+      firstValueFrom(
+        signOperation({
+          account,
+          deviceId: "mock",
+          transaction: makeTransaction("gonka1yyy"),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toBeInstanceOf(UserRefusedOnDevice);
+  });
+});

--- a/libs/coin-modules/coin-cosmos/src/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.unit.test.ts
@@ -162,6 +162,39 @@ describe("buildSignOperation", () => {
     expect(signer.sign.mock.calls[0][2]).toBe("cosmos");
   });
 
+  it("omits the prefix for crypto_org, whose device app is not app-cosmos", async () => {
+    const signer = makeRealSigner();
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/394'/0'/0/0", {
+      id: "crypto_org",
+      units: [{ code: "CRO" }, { code: "basecro" }],
+    });
+    const transaction = makeTransaction("cro1yyy");
+
+    await firstValueFrom(signOperation({ account, deviceId: "mock", transaction }).pipe(toArray()));
+
+    // Coin type 394 is served by the "Cronos POS Chain" app, which app-cosmos's chain config
+    // does not cover and whose sign-APDU handling of the field is unverified. Omitting it keeps
+    // the APDU framing that app has always received.
+    expect(signer.sign.mock.calls[0][2]).toBeUndefined();
+    // Address derivation is unaffected — it has always sent the prefix.
+    expect(signer.getAddressAndPubKey.mock.calls[0][1]).toBe("cro");
+  });
+
+  it("omits the prefix for crypto_org_croeseid, which reuses crypto_org's params", async () => {
+    const signer = makeRealSigner();
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/394'/0'/0/0", {
+      id: "crypto_org_croeseid",
+      units: [{ code: "CRO" }, { code: "basecro" }],
+    });
+    const transaction = makeTransaction("cro1yyy");
+
+    await firstValueFrom(signOperation({ account, deviceId: "mock", transaction }).pipe(toArray()));
+
+    expect(signer.sign.mock.calls[0][2]).toBeUndefined();
+  });
+
   it("throws ExpertModeRequired when the device demands expert mode", async () => {
     const signer = makeRealSigner();
     signer.sign.mockResolvedValue({

--- a/libs/coin-modules/coin-cosmos/src/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.unit.test.ts
@@ -185,6 +185,30 @@ describe("buildSignOperation", () => {
     ).rejects.toBeInstanceOf(ExpertModeRequired);
   });
 
+  it("throws a clear error when the device returns no signature on an unhandled return_code", async () => {
+    const signer = makeRealSigner();
+    // 0x698C is APDU_CODE_CHAIN_CONFIG_NOT_SUPPORTED — the status word the device answers for an
+    // unrecognised (coin type, HRP) pair. It is mapped nowhere in the monorepo, so without this
+    // guard it would surface as a DER parse failure on a null signature.
+    signer.sign.mockResolvedValue({ signature: null, return_code: 0x698c });
+    const signOperation = buildSignOperation(signerContextOf(signer));
+    const account = makeAccount("44'/1200'/0'/0/0", {
+      id: "gonka",
+      units: [{ code: "GNK" }, { code: "ngonka" }],
+    });
+
+    await expect(
+      firstValueFrom(
+        signOperation({
+          account,
+          deviceId: "mock",
+          transaction: makeTransaction("gonka1yyy"),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toThrow("device returned no signature");
+    expect(signer.sign).toHaveBeenCalledTimes(1);
+  });
+
   it("throws UserRefusedOnDevice when the user rejects on device", async () => {
     const signer = makeRealSigner();
     signer.sign.mockResolvedValue({ signature: null, return_code: RETURN_CODES.REFUSED_OPERATION });

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
@@ -51,12 +51,10 @@ function signTransaction(
   deviceId: string,
   path: number[],
   tx: Buffer,
-  prefix: string,
+  hrp: string,
 ): Promise<CosmosSignature> {
-  return signerContext(deviceId, signer =>
-    // HRP is only needed when signing for ethermint chains.
-    path[1] === 60 ? signer.sign(path, tx, prefix) : signer.sign(path, tx),
-  );
+  // The device validates the (coin type, HRP) pair; the chain prefix goes on every request.
+  return signerContext(deviceId, signer => signer.sign(path, tx, hrp));
 }
 
 async function performSignRawOperation(

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
@@ -51,9 +51,11 @@ function signTransaction(
   deviceId: string,
   path: number[],
   tx: Buffer,
-  hrp: string,
+  hrp: string | undefined,
 ): Promise<CosmosSignature> {
   // The device validates the (coin type, HRP) pair; the chain prefix goes on every request.
+  // `undefined` is reserved for chains whose device app is not app-cosmos (see CryptoOrg) and
+  // omits the field entirely, as before.
   return signerContext(deviceId, signer => signer.sign(path, tx, hrp));
 }
 
@@ -84,7 +86,7 @@ async function performSignRawOperation(
     deviceId,
     path,
     tx,
-    chainInstance.prefix,
+    chainInstance.signWithPrefix ? chainInstance.prefix : undefined,
   );
 
   switch (return_code) {

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
@@ -236,6 +236,45 @@ describe("buildSignRawOperation", () => {
     expect(signer.sign.mock.calls[0][2]).toBe("gonka");
   });
 
+  it("omits the HRP for crypto_org, whose device app is not app-cosmos", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await firstValueFrom(
+      signRawOperation({
+        account: makeAccount("44'/394'/0'/0/0", {
+          id: "crypto_org",
+          units: [{ code: "CRO" }, { code: "basecro" }],
+        }),
+        deviceId: "mock",
+        transaction: makeSignDocJson(MSG_SEND),
+      }).pipe(toArray()),
+    );
+
+    // Coin type 394 is served by the "Cronos POS Chain" app, which app-cosmos's chain config does
+    // not cover and whose sign-APDU handling of the field is unverified. Omitting it keeps the
+    // APDU framing that app has always received.
+    expect(signer.sign.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it("omits the HRP for crypto_org_croeseid, which reuses crypto_org's params", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await firstValueFrom(
+      signRawOperation({
+        account: makeAccount("44'/394'/0'/0/0", {
+          id: "crypto_org_croeseid",
+          units: [{ code: "CRO" }, { code: "basecro" }],
+        }),
+        deviceId: "mock",
+        transaction: makeSignDocJson(MSG_SEND),
+      }).pipe(toArray()),
+    );
+
+    expect(signer.sign.mock.calls[0][2]).toBeUndefined();
+  });
+
   it("rejects a malformed derivation path before any device interaction", async () => {
     const signer = makeRealSigner();
     const signRawOperation = buildSignRawOperation(signerContextOf(signer));

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
@@ -11,12 +11,18 @@ const SUCCESS = 0x9000; // 36864
 
 const privkey = sha256(Buffer.from("coin-cosmos signRawOperation test seed"));
 
-function makeAccount(freshAddressPath = "44'/118'/0'/0/0"): CosmosAccount {
+function makeAccount(
+  freshAddressPath = "44'/118'/0'/0/0",
+  currency: { id: string; units: { code: string }[] } = {
+    id: "cosmos",
+    units: [{ code: "ATOM" }, { code: "uatom" }],
+  },
+): CosmosAccount {
   return {
     id: "js:2:cosmos:cosmos1xxx:",
     freshAddress: "cosmos1xxx",
     freshAddressPath,
-    currency: { id: "cosmos", units: [{ code: "ATOM" }, { code: "uatom" }] },
+    currency,
   } as unknown as CosmosAccount;
 }
 
@@ -85,8 +91,9 @@ describe("buildSignRawOperation", () => {
     // The device signs the canonical serialized signDoc, verbatim.
     const expectedBytes = Buffer.from(serializeSignDoc(JSON.parse(transaction)));
     expect(Buffer.from(signer.sign.mock.calls[0][1])).toEqual(expectedBytes);
-    // coin type 118 → HRP is not passed (only ethermint/60 needs it).
-    expect(signer.sign.mock.calls[0][2]).toBeUndefined();
+    // The device validates the (coin type, HRP) pair on every coin type, not only ethermint/60 —
+    // coin type 118 now receives the chain prefix too.
+    expect(signer.sign.mock.calls[0][2]).toBe("cosmos");
 
     const signedEvt = events.find(e => e.type === "signed");
     if (signedEvt?.type !== "signed") throw new Error("no signed event");
@@ -194,7 +201,7 @@ describe("buildSignRawOperation", () => {
     expect(signer.sign).toHaveBeenCalledTimes(1);
   });
 
-  it("passes the HRP as the 3rd sign arg for ethermint chains (coin type 60)", async () => {
+  it("passes the HRP as the 3rd sign arg for coin type 60", async () => {
     const signer = makeRealSigner();
     const signRawOperation = buildSignRawOperation(signerContextOf(signer));
 
@@ -206,8 +213,27 @@ describe("buildSignRawOperation", () => {
       }).pipe(toArray()),
     );
 
-    // ethermint/60 → HRP (the cosmos chain prefix) is passed as the 3rd arg.
+    // The chain prefix is passed as the 3rd arg, same as every other coin type.
     expect(signer.sign.mock.calls[0][2]).toBe("cosmos");
+  });
+
+  it("passes the chain prefix for coin type 1200", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await firstValueFrom(
+      signRawOperation({
+        account: makeAccount("44'/1200'/0'/0/0", {
+          id: "gonka",
+          units: [{ code: "GNK" }, { code: "ngonka" }],
+        }),
+        deviceId: "mock",
+        transaction: makeSignDocJson(MSG_SEND),
+      }).pipe(toArray()),
+    );
+
+    // Coin type 1200 is neither 60 nor 118 — the chain prefix still reaches the device.
+    expect(signer.sign.mock.calls[0][2]).toBe("gonka");
   });
 
   it("rejects a malformed derivation path before any device interaction", async () => {

--- a/libs/coin-modules/coin-cosmos/src/types/signer.ts
+++ b/libs/coin-modules/coin-cosmos/src/types/signer.ts
@@ -26,7 +26,7 @@ export interface CosmosSigner {
     hrp: string,
     boolDisplay?: boolean,
   ): Promise<CosmosGetAddressAndPubKeyRes>;
-  sign(path: number[], buffer: Buffer, transactionType?: string): Promise<CosmosSignature>;
+  sign(path: number[], buffer: Buffer, hrp?: string): Promise<CosmosSignature>;
   // NOTE: explain this one, to support cosmos-like chains (hw-app-cosmos)
   getAddress(path: string, hrp: string, boolDisplay?: boolean): Promise<CosmosAddress>;
 }

--- a/libs/live-signer-cosmos/src/DmkSignerCosmos.ts
+++ b/libs/live-signer-cosmos/src/DmkSignerCosmos.ts
@@ -112,21 +112,12 @@ export class DmkSignerCosmos implements CosmosSigner {
     });
   }
 
-  public async sign(
-    path: number[],
-    buffer: Buffer,
-    transactionType?: string,
-  ): Promise<CosmosSignature> {
+  public async sign(path: number[], buffer: Buffer, hrp?: string): Promise<CosmosSignature> {
     const derivationPath = path.join("/");
 
-    const { observable } = this.signer.signTransaction(
-      derivationPath,
-      transactionType ?? DEFAULT_HRP,
-      buffer,
-      {
-        skipOpenApp: true,
-      },
-    );
+    const { observable } = this.signer.signTransaction(derivationPath, hrp ?? DEFAULT_HRP, buffer, {
+      skipOpenApp: true,
+    });
 
     return new Promise<CosmosSignature>((resolve, reject) => {
       observable.subscribe({

--- a/libs/live-signer-cosmos/src/LegacySignerCosmos.ts
+++ b/libs/live-signer-cosmos/src/LegacySignerCosmos.ts
@@ -25,8 +25,8 @@ export class LegacySignerCosmos implements CosmosSigner {
     return this.signer.getAddressAndPubKey(path, hrp, boolDisplay);
   }
 
-  async sign(path: number[], buffer: Buffer, transactionType?: string): Promise<CosmosSignature> {
-    return this.signer.sign(path, buffer, transactionType);
+  async sign(path: number[], buffer: Buffer, hrp?: string): Promise<CosmosSignature> {
+    return this.signer.sign(path, buffer, hrp);
   }
 
   async getAddress(path: string, hrp: string, boolDisplay?: boolean): Promise<CosmosAddress> {

--- a/libs/live-signer-cosmos/tests/DmkSignerCosmos.test.ts
+++ b/libs/live-signer-cosmos/tests/DmkSignerCosmos.test.ts
@@ -239,7 +239,7 @@ describe("DmkSignerCosmos", () => {
       });
     });
 
-    it("uses default HRP 'cosmos' when transactionType is not provided", async () => {
+    it("uses default HRP 'cosmos' when hrp is not provided", async () => {
       const signatureBytes = Uint8Array.from([0xdd, 0xee]);
       const observable = of({
         status: DeviceActionStatus.Completed,
@@ -255,6 +255,27 @@ describe("DmkSignerCosmos", () => {
       expect((signer as any).signer.signTransaction).toHaveBeenCalledWith(
         "44/118/0/0/0",
         "cosmos",
+        tx,
+        expect.objectContaining({ skipOpenApp: true }),
+      );
+    });
+
+    it("forwards the hrp for a coin type outside the ethermint/cosmos gate (1200)", async () => {
+      const signatureBytes = Uint8Array.from([0x11, 0x22]);
+      const observable = of({
+        status: DeviceActionStatus.Completed,
+        output: signatureBytes,
+      });
+      (signer as any).signer = {
+        signTransaction: jest.fn().mockReturnValue({ observable }),
+      };
+
+      const tx = Buffer.from("transaction-data");
+      await signer.sign([44, 1200, 0, 0, 0], tx, "gonka");
+
+      expect((signer as any).signer.signTransaction).toHaveBeenCalledWith(
+        "44/1200/0/0/0",
+        "gonka",
         tx,
         expect.objectContaining({ skipOpenApp: true }),
       );

--- a/libs/live-signer-cosmos/tests/LegacySignerCosmos.test.ts
+++ b/libs/live-signer-cosmos/tests/LegacySignerCosmos.test.ts
@@ -48,7 +48,7 @@ describe("LegacySignerCosmos", () => {
       expect(sign).toHaveBeenCalledWith([44, 118, 0, 0, 0], tx, "cosmos");
     });
 
-    it("signs a transaction without transactionType", async () => {
+    it("signs a transaction without hrp", async () => {
       const mockResult = {
         signature: Buffer.from("ddeeff", "hex"),
         return_code: 0x9000,
@@ -58,6 +58,18 @@ describe("LegacySignerCosmos", () => {
       const tx = Buffer.from("transaction-data");
       expect(await signer.sign([44, 118, 0, 0, 0], tx)).toEqual(mockResult);
       expect(sign).toHaveBeenCalledWith([44, 118, 0, 0, 0], tx, undefined);
+    });
+
+    it("forwards the hrp for a coin type outside the ethermint/cosmos gate (1200)", async () => {
+      const mockResult = {
+        signature: Buffer.from("aabbcc", "hex"),
+        return_code: 0x9000,
+      };
+      const sign = jest.spyOn(CosmosApp.prototype, "sign").mockResolvedValue(mockResult);
+
+      const tx = Buffer.from("transaction-data");
+      expect(await signer.sign([44, 1200, 0, 0, 0], tx, "gonka")).toEqual(mockResult);
+      expect(sign).toHaveBeenCalledWith([44, 1200, 0, 0, 0], tx, "gonka");
     });
   });
 
@@ -71,9 +83,7 @@ describe("LegacySignerCosmos", () => {
         publicKey: "0a0b0c",
         address: "cosmos1def",
       };
-      const getAddress = jest
-        .spyOn(Cosmos.prototype, "getAddress")
-        .mockResolvedValue(mockResult);
+      const getAddress = jest.spyOn(Cosmos.prototype, "getAddress").mockResolvedValue(mockResult);
 
       expect(await signer.getAddress("44/118/0/0/0", "cosmos", boolDisplay)).toEqual(mockResult);
       expect(getAddress).toHaveBeenCalledWith("44/118/0/0/0", "cosmos", boolDisplay);


### PR DESCRIPTION
### 📝 Description

Adds **Gonka** (GNK) as a chain in the Cosmos coin module, and fixes two family-wide defects that a
chain on coin type 1200 is the first to expose.

Gonka is a sovereign chain built on a forked Cosmos SDK. The fork leaves transaction encoding and
signing untouched (Amino JSON, secp256k1), so this is a chain addition — a parameter class plus a
factory case — not a new module.

#### 1. The chain (`chain/Gonka.ts`, `chain/chain.ts`)

Prefix `gonka`, validator prefix `gonkavaloper`, no Ledger validator, no unbonding period (the
chain's runtime rejects delegation messages outright). `minGasPrice = 0` sits on the class because
every gas price the chain declares is zero and the family base defaults to `0.0025`; the runtime
enforces this through a custom `TxFeeChecker` reading an on-chain parameter currently set to `0`,
which accepts any fee including zero.

#### 2. The chain prefix (HRP) is now sent on every coin type

Both signing paths gated the prefix argument on the coin type — `signOperation.ts` and
`signRawOperation.ts` passed `chainInstance.prefix` to `signer.sign` only when `path[1] === 60`,
commented *"HRP is only needed when signing for ethermint chains"*. That gate encoded the **device's
leniency**, not the protocol's requirement:

- on coin type **60** the device rejects a missing HRP outright, so it had to be sent;
- on coin type **118** the device short-circuits its chain-configuration lookup and defaults the HRP
  to `"cosmos"`, so omitting it was harmless;
- **coin type 1200 is neither.** The legacy signer sends nothing and the device defaults; the DMK
  signer cannot send nothing, so it substitutes its own `"cosmos"` default, the device finds no
  matching chain-configuration entry for the pair `(1200, "cosmos")` and answers `0x698C`.

The fix removes the coin-type special case rather than extending it, so no future chain needs another
branch.

**This is safe for every shipping chain, and the reason is structural rather than empirical.** In
`app-cosmos`, `checkChainConfig(coin type, HRP)` is a single decision point that both APDUs share:
the address APDU calls it unconditionally (the HRP is a mandatory framing field there), while the
sign APDU calls it only when an HRP is present. `signOperation.ts` already passes
`chainInstance.prefix` to `getAddressAndPubKey` with no gate, so **every shipping chain's pair is
already validated by that same function on every address derivation.** After this change, signing
runs the check that address derivation has always run.

Concretely, and checked pair by pair: coin type 60 (`inj`) is unchanged — it already sent its HRP.
The chains on 118 either have an explicit chain-configuration entry (`cosmos`, `osmo`, `dydx`,
`mantra`, `xion`, `core`) or fall through to the generic coin-type-118 branch, and both resolve to
the same address encoding the device already defaulted to. So **the signed digest is byte-identical
for every existing chain** — the encoding selects the hash function, and it does not change.

There is also **no user-visible change** for existing chains. The address the sign handler derives is
never displayed: the review screens are rendered from the transaction itself, and the derived address
feeds only a from-address grouping flag, which is disabled for every chain whose chain id is not
`cosmoshub-4`. For `cosmos` itself the prefix is `"cosmos"`, identical to the previous default.

**Why this is a prerequisite and not a precaution.** Gonka cannot sign at all until the device app
carries coin type 1200 (`LedgerHQ/app-cosmos#85`, which adds both the install-manifest path entry and
the chain-configuration row). That same change makes the HRP **mandatory on any coin type other than
118** — so on the build that makes Gonka possible, the legacy signer's "send nothing" is rejected
too, not just the DMK signer's substituted default. There is no configuration in which Gonka signs
and this fix is unnecessary, on either signer, regardless of the `ldmkCosmosSigner` flag.

#### 3. `sign`'s third parameter renamed `transactionType` → `hrp`

It has always held a bech32 address prefix. The underlying client's signature is
`sign(path, buffer, hrp?, txType?)` — `txType` is a *separate*, numeric, fourth parameter this
interface does not expose. The old name is the plausible origin of the coin-type gate: nothing in
`transactionType?: string` tells a caller that an address prefix belongs there. `DEFAULT_HRP` is
retained as the defensive fallback, since the parameter remains optional on the interface.

#### 4. A zero fee is a loaded fee (`getTransactionStatus.ts`)

The send path raised `FeeNotLoaded` whenever the fee was not strictly positive:

```ts
if (!transaction.fees || !transaction.fees.gt(0)) {
```

`FeeNotLoaded` signals a fee that has not been computed yet. `createTransaction` initialises
`fees: null`, and `prepareTransaction` always returns a `BigNumber` — so absence and zero are
distinguishable, and only absence should raise it. On a chain whose minimum gas price is zero the
computed fee is `BigNumber(0)`: truthy as an object, so the first condition passes, but not `> 0`, so
the second fires. The error is then raised permanently and the transaction can never be sent — no
crash and no message about zero fees, just a Send button that stays disabled while the UI reports
that fees have not loaded.

The guard is narrowed to `if (!transaction.fees)`, which is the form the same file already uses on
the claim-reward path. For every chain with a non-zero minimum gas price this is a no-op.

**Incidental fix:** `nyx` also configures `minGasPrice: 0` and is presumably subject to the same wall
today.

#### Deliberately not in this PR

- The `supportedCoins` registration and app-side currency listing — LIVE-36043.
- The `config_currency_gonka` entry (node endpoint, `minGasPrice`, `disableDelegation`) — LIVE-36044.
  Until it lands, no delegation entry point can be suppressed for Gonka; the five UI sites that
  branch on `disableDelegation` already handle the flag generically and need no change in any task.
- The identical `FeeNotLoaded` guard on the delegate/undelegate path. Gonka reaches no staking mode
  (its runtime rejects delegation), so it is unreachable here and left untouched to keep the change
  minimal.

### 🧪 Tests

- `chain.unit.test.ts` — Gonka resolves through the factory and returns its parameters.
- `signOperation.unit.test.ts` — **new file**; none existed for this module. Covers the prefix
  argument on coin type 1200 and on 118, the canonical serialized sign-doc bytes, and both device
  error paths.
- `signRawOperation.unit.test.ts` — the coin-type-118 assertion is **inverted**: it previously
  asserted the HRP was *not* passed, and that behaviour is what this PR changes. A new coin-type-1200
  case is added, and the coin-type-60 case is retained.
- `getTransactionStatus.unit.test.ts` — a zero fee with max-amount spends the full balance and raises
  no error; an *absent* fee still raises `FeeNotLoaded`, proving the guard was narrowed rather than
  removed.
- Both signer implementations gain a coin-type-1200 forwarding test.

`@ledgerhq/coin-cosmos` 327/327 and `@ledgerhq/live-signer-cosmos` 26/26 pass; build, lint,
formatting, typecheck and the unused-file check are green.

**Coverage, measured:** `chain/Gonka.ts` and `LegacySignerCosmos.ts` 100%, `DmkSignerCosmos.ts`
97.7%, `chain/chain.ts` 97.3%, `signOperation.ts` 93.5%, `signRawOperation.ts` 90.3%.
`getTransactionStatus.ts` reports **48.4% for the file as a whole** — its
delegate/redelegate/claim-reward paths were already untested at unit level before this change. The
line changed here is covered, by both the pre-existing send tests and the two new zero-fee tests.

**What the E2E gate does not cover.** `specs/services/cosmosStaking.spec.ts` is currently
`test.skip`, `specs/accounts/delegate.smoke.spec.ts` exercises Cosmos Hub delegation only, and there
is no Cosmos-family *send* spec on either platform. So the required E2E runs confirm nothing else
regressed, but they do not exercise either signing path this PR touches. The coverage for that is the
unit tests above, plus a manual Speculos send.

**One changed pair without direct evidence:** `crypto_org` and `crypto_org_croeseid` derive on coin
type 394 and will now receive the HRP `cro` where they previously sent none. Their manager app is
`Cronos POS Chain`, a different binary, so the reasoning above about `app-cosmos` is not direct
evidence about them. It does transfer if that app shares the structure: Ledger Live already sends
`cro` on coin type 394 at address derivation and those accounts work today, so the pair is already
accepted there, and this change makes signing consult the same check.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36038](https://ledgerhq.atlassian.net/browse/LIVE-36038)
- **ADR** (if any): n/a
- **Device app dependency**: [LedgerHQ/app-cosmos#85](https://github.com/LedgerHQ/app-cosmos/pull/85)
  adds coin type 1200. Not required to merge this PR; required before Gonka can be signed on device.
- **Reviewers**: `libs/live-signer-cosmos/` is owned by `@ledgerhq/live-devices`, which also owns the
  `ldmkCosmosSigner` flag that decides whether the DMK signer runs — the team gating the failure owns
  the package carrying the fix.
- **Note on the diff**: one formatting-only hunk in `LegacySignerCosmos.test.ts` is pre-existing.
  That package declares no format target, so the issue only surfaced once the pre-commit hook checked
  the file as part of this change.


[LIVE-36038]: https://ledgerhq.atlassian.net/browse/LIVE-36038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ