### PR TITLE
[LWDM] feat(concordium): craft and sign PLT transfers (LIVE-28337)

### DIFF
--- a/.changeset/concordium-craft-sign-plt.md
+++ b/.changeset/concordium-craft-sign-plt.md
@@ -1,0 +1,22 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/live-signer-concordium": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Craft and sign PLT transfers
+
+`craftPltTransaction` builds a `TokenUpdate` payload from the CAL-resolved token id, the
+CAL unit magnitude as the amount's exponent, and the energy persisted at estimation time,
+and `signOperation` routes a transaction carrying a token sub-account to it. The signer
+interface widens to `AnyTransaction`; its body already serialized both kinds. A PLT send
+now reports the CCD fee on the parent account and the token amount on the sub-account,
+matching the pair sync builds once the transfer is indexed. `updateTransaction` drops the
+persisted energy alongside the fee, so a re-selected token cannot inherit the previous
+token's energy limit. Adds the English error strings for the two signer failures this path
+can surface.
+
+Signing on a device needs the PLT-capable Concordium app; until it ships, an attempt
+surfaces as a translated "update your Concordium app" error. PLT sub-accounts remain behind
+the `enableTokens` config switch.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7888,6 +7888,14 @@
       "title": "This transaction cannot be prepared",
       "description": "The token's details are outside what your Ledger device accepts, so the transaction cannot be built. Please contact Ledger Support."
     },
+    "ConcordiumAppOutdatedError": {
+      "title": "App update required",
+      "description": "The Concordium app on your Ledger device does not support token transfers. Update it in My Ledger and try again."
+    },
+    "ConcordiumSignerProtocolError": {
+      "title": "Something went wrong. Please reconnect your device",
+      "description": "The Concordium app could not process the transaction. If the problem continues, please contact Ledger Support."
+    },
     "StacksMemoTooLong": {
       "title": "Memo length is too long"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -262,6 +262,14 @@
       "title": "This transaction cannot be prepared",
       "description": "The token's details are outside what your Ledger device accepts, so the transaction cannot be built. Please contact Ledger Support."
     },
+    "ConcordiumAppOutdatedError": {
+      "title": "App update required",
+      "description": "The Concordium app on your Ledger device does not support token transfers. Update it in My Ledger and try again."
+    },
+    "ConcordiumSignerProtocolError": {
+      "title": "Something went wrong. Please reconnect your device",
+      "description": "The Concordium app could not process the transaction. If the problem continues, please contact Ledger Support."
+    },
     "CosmosBroadcastCodeInternal": {
       "title": "Something went wrong (Error #1)",
       "description": "Please save your logs using the button below and provide them to Ledger Support."

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -1,5 +1,9 @@
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
-import { ConcordiumTokenAccountUnavailable } from "../types/errors";
+import type { Operation } from "@ledgerhq/types-live";
+import {
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumTokenAccountUnavailable,
+} from "../types/errors";
 import BigNumber from "bignumber.js";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountAddress } from "@ledgerhq/concordium-core";
@@ -29,6 +33,19 @@ jest.mock("../logic", () => {
       payload: {
         toAddress: AccountAddress.fromBuffer(Buffer.alloc(32)),
         amount: 5000000n,
+      },
+    }),
+    craftPltTransaction: jest.fn().mockReturnValue({
+      type: 27, // TokenUpdate
+      header: {
+        sender: AccountAddress.fromBuffer(Buffer.alloc(32)),
+        nonce: 5n,
+        expiry: 1700003600n,
+        energyAmount: 1080n,
+      },
+      payload: {
+        tokenId: Buffer.from("t-USDT", "utf-8"),
+        operations: Buffer.from("81", "hex"),
       },
     }),
     combine: jest.fn().mockReturnValue("combined-signature"),
@@ -471,7 +488,7 @@ describe("signOperation", () => {
   });
 
   describe("the persisted estimate", () => {
-    const { craftTransaction, estimateFees } = jest.requireMock("../logic");
+    const { craftPltTransaction, craftTransaction, estimateFees } = jest.requireMock("../logic");
 
     const tokenTransaction = (over = {}) => {
       const { account, subAccount } = withTokenSubAccount();
@@ -489,18 +506,96 @@ describe("signOperation", () => {
     it("does not re-estimate when preparation persisted the energy", async () => {
       const { account, transaction } = tokenTransaction();
 
-      await expect(sign(transaction, account)).rejects.toThrow(/not supported yet/);
+      await sign(transaction, account);
 
       expect(estimateFees).not.toHaveBeenCalled();
     });
 
-    // Reaching the device at all is the defect here: a completed signature would
-    // be a CCD transfer. Flipped back by LIVE-28337.
-    it("refuses to sign a token transfer, rather than signing a native one", async () => {
+    // Crafting natively would move CCD at the token's integer amount — the wrong
+    // asset, at a magnitude the token's decimals chose.
+    it("crafts a PLT transfer, never a native one", async () => {
       const { account, transaction } = tokenTransaction();
 
-      await expect(sign(transaction, account)).rejects.toThrow(/not supported yet/);
+      await sign(transaction, account);
+
+      expect(craftPltTransaction).toHaveBeenCalled();
       expect(craftTransaction).not.toHaveBeenCalled();
+    });
+
+    it("signs with the persisted fee and energy, and the token's own id and decimals", async () => {
+      const { account, transaction } = tokenTransaction();
+
+      const { mockSigner } = await sign(transaction, account);
+
+      expect(craftPltTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ address: account.freshAddress, nextSequenceNumber: 5 }),
+        expect.objectContaining({
+          tokenId: account.subAccounts[0].token.contractAddress,
+          decimals: account.subAccounts[0].token.units[0].magnitude,
+          energy: BigInt(1080),
+        }),
+      );
+      // The max fee reaching the device is the persisted µCCD cost, not a
+      // re-estimate: it is the figure already shown to the user.
+      expect(mockSigner.signTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 27 }),
+        account.freshAddressPath,
+        BigInt(3600),
+      );
+    });
+
+    // Two balances move, so the send emits two operations: sync builds the
+    // confirmed pair the same way, and a mismatch would double-count the fee.
+    it("reports the fee on the parent and the token on the sub-account", async () => {
+      const { account, transaction } = tokenTransaction();
+
+      const { events } = await sign(transaction, account);
+      const { operation } = (
+        events[events.length - 1] as { signedOperation: { operation: Operation } }
+      ).signedOperation;
+
+      expect(operation).toMatchObject({
+        accountId: account.id,
+        type: "FEES",
+        value: new BigNumber(3600),
+        fee: new BigNumber(3600),
+      });
+      expect(operation.subOperations).toHaveLength(1);
+      expect(operation.subOperations?.[0]).toMatchObject({
+        accountId: account.subAccounts[0].id,
+        type: "OUT",
+        value: new BigNumber(5000000),
+      });
+    });
+
+    it("leaves a native transfer reporting a single OUT operation", async () => {
+      const { events } = await sign(createFixtureTransaction({ fee: new BigNumber(1000) }));
+      const { operation } = (
+        events[events.length - 1] as { signedOperation: { operation: Operation } }
+      ).signedOperation;
+
+      expect(operation.type).toBe("OUT");
+      expect(operation.subOperations).toBeUndefined();
+    });
+
+    // Status blocks this, but signing does not read `status.errors`.
+    it("refuses a token whose CAL magnitude is missing", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const strippedToken = { ...subAccount.token, units: [] };
+      const accountWithoutMagnitude = {
+        ...account,
+        subAccounts: [{ ...subAccount, token: strippedToken }],
+      };
+      const transaction = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        fee: new BigNumber(3600),
+        energy: 1080,
+      });
+
+      await expect(sign(transaction, accountWithoutMagnitude)).rejects.toBeInstanceOf(
+        ConcordiumInvalidPltPayloadError,
+      );
+      expect(craftPltTransaction).not.toHaveBeenCalled();
     });
 
     it("keeps estimating for a native transfer", async () => {
@@ -536,6 +631,20 @@ describe("signOperation", () => {
       // the invariant this replaced.
       await expect(sign(transaction)).rejects.toBeInstanceOf(ConcordiumTokenAccountUnavailable);
       expect(craftTransaction).not.toHaveBeenCalled();
+    });
+
+    // A `BigNumber` holding NaN is truthy, so the falsiness guard alone let it
+    // through. What this pins is the ordering: the throw lands before any event.
+    it("refuses a NaN fee before requesting the device", async () => {
+      const { account, transaction } = tokenTransaction({ fee: new BigNumber(NaN) });
+
+      const { events } = await sign(transaction, account).catch(e => {
+        expect(e).toBeInstanceOf(FeeNotLoaded);
+        return { events: [] as unknown[] };
+      });
+
+      expect(events).toHaveLength(0);
+      expect(craftPltTransaction).not.toHaveBeenCalled();
     });
 
     // The energy half of the pair is missing, so the fee on screen has no

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -4,11 +4,19 @@ import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge, Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import invariant from "invariant";
 import { Observable } from "rxjs";
 import type { ConcordiumSigner, Transaction } from "../types";
-import { ConcordiumTokenAccountUnavailable } from "../types/errors";
-import { combine, craftTransaction, estimateFees, getNextValidSequence } from "../logic";
+import {
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumTokenAccountUnavailable,
+} from "../types/errors";
+import {
+  combine,
+  craftPltTransaction,
+  craftTransaction,
+  estimateFees,
+  getNextValidSequence,
+} from "../logic";
 import { getTransactionStatus } from "./getTransactionStatus";
 import coinConfig from "../config";
 
@@ -17,8 +25,12 @@ export const buildSignOperation =
   ({ account, deviceId, transaction }) =>
     new Observable(o => {
       async function main() {
+        // `fromTransactionRaw` builds the fee with `new BigNumber(tr.fee)`, and a
+        // `BigNumber` holding NaN is truthy — so falsiness alone would let it reach
+        // `BigInt(fee.toString())` on the token path and throw a raw `SyntaxError`
+        // after the device prompt had been requested.
         const { fee } = transaction;
-        if (!fee) throw new FeeNotLoaded();
+        if (!fee || fee.isNaN()) throw new FeeNotLoaded();
 
         const status = await getTransactionStatus(account, transaction);
         const actualAmount = status.amount;
@@ -40,54 +52,68 @@ export const buildSignOperation =
         // the selected sub-account, not a present `energy`: that field outlives
         // any token selection, so reading it alone would declare a token energy
         // limit on a native transfer.
-        const isTokenTransfer =
-          findSubAccountById(account, transaction.subAccountId ?? "")?.type === "TokenAccount";
+        const subAccount = findSubAccountById(account, transaction.subAccountId ?? "");
+        const tokenAccount = subAccount?.type === "TokenAccount" ? subAccount : undefined;
 
         // Fails closed: the alternative is a signed CCD transfer. Typed rather
         // than an invariant because a user can reach this, so it needs to reach
         // them translated.
-        if (!isTokenTransfer && transaction.subAccountId) {
+        if (!tokenAccount && transaction.subAccountId) {
           throw new ConcordiumTokenAccountUnavailable(
             "concordium: transaction references a token sub-account that no longer exists",
           );
         }
 
-        if (isTokenTransfer && transaction.energy === undefined) throw new FeeNotLoaded();
+        if (tokenAccount && transaction.energy === undefined) throw new FeeNotLoaded();
+
+        // The chain compares the amount's exponent against the token's
+        // registered decimals, so an absent magnitude cannot be defaulted. Status
+        // blocks this case, but signing does not read `status.errors`, so the
+        // check is repeated rather than assumed.
+        const decimals = tokenAccount?.token.units[0]?.magnitude;
+        if (tokenAccount && decimals === undefined) {
+          throw new ConcordiumInvalidPltPayloadError("", { reason: "missing token magnitude" });
+        }
 
         const estimation =
-          isTokenTransfer && transaction.energy !== undefined
+          tokenAccount && transaction.energy !== undefined
             ? { cost: BigInt(fee.toString()), energy: BigInt(transaction.energy) }
             : await estimateFees(config, account.currency.id, transaction.memo);
-
-        // `craftTransaction` emits a native transfer whatever it is handed, so a
-        // token send would move CCD at the token's integer amount — the wrong
-        // asset, at a magnitude the token's decimals chose. The api layer refuses
-        // a PLT intent for this reason (`assertNativeAsset`); the bridge had no
-        // equivalent. Removed by LIVE-28337, which crafts the `TokenUpdate`
-        // payload.
-        //
-        // An invariant, not a typed error: unreachable unless the token UI ships
-        // before PLT crafting does.
-        invariant(!isTokenTransfer, "concordium: signing a PLT transfer is not supported yet");
 
         const signature = await signerContext(deviceId, async signer => {
           const { freshAddressPath: derivationPath } = account;
           const publicKey = await signer.getPublicKey(derivationPath, false);
 
-          const structuredTransaction = await craftTransaction(
-            {
-              address: account.freshAddress,
-              publicKey,
-              nextSequenceNumber,
-            },
-            {
-              recipient: transaction.recipient,
-              amount: actualAmount,
-              fee: new BigNumber(estimation.cost.toString()),
-              energy: estimation.energy,
-              ...(transaction.memo ? { memo: transaction.memo } : {}),
-            },
-          );
+          const structuredTransaction =
+            tokenAccount && decimals !== undefined
+              ? craftPltTransaction(
+                  {
+                    address: account.freshAddress,
+                    nextSequenceNumber,
+                  },
+                  {
+                    tokenId: tokenAccount.token.contractAddress,
+                    recipient: transaction.recipient,
+                    amount: actualAmount,
+                    decimals,
+                    energy: estimation.energy,
+                    ...(transaction.memo ? { memo: transaction.memo } : {}),
+                  },
+                )
+              : await craftTransaction(
+                  {
+                    address: account.freshAddress,
+                    publicKey,
+                    nextSequenceNumber,
+                  },
+                  {
+                    recipient: transaction.recipient,
+                    amount: actualAmount,
+                    fee: new BigNumber(estimation.cost.toString()),
+                    energy: estimation.energy,
+                    ...(transaction.memo ? { memo: transaction.memo } : {}),
+                  },
+                );
 
           const result = await signer.signTransaction(
             structuredTransaction,
@@ -103,21 +129,50 @@ export const buildSignOperation =
         });
 
         const hash = "";
-        const operation: Operation = {
-          id: encodeOperationId(account.id, hash, "OUT"),
+        const feeValue = new BigNumber(estimation.cost.toString());
+        const shared = {
           hash,
-          accountId: account.id,
-          type: "OUT",
-          value: actualAmount,
-          fee: new BigNumber(estimation.cost.toString()),
+          fee: feeValue,
           blockHash: null,
           blockHeight: null,
           senders: [account.freshAddress],
           recipients: [transaction.recipient],
           date: new Date(),
           transactionSequenceNumber: new BigNumber(nextSequenceNumber.toString()),
-          extra: {},
         };
+
+        // Shaped to match the pair sync builds for a confirmed transfer — the
+        // CCD fee on the parent, the token amount hanging under it — so this
+        // optimistic pair is replaced rather than duplicated once indexed.
+        const operation: Operation = tokenAccount
+          ? {
+              ...shared,
+              id: encodeOperationId(account.id, hash, "FEES"),
+              accountId: account.id,
+              type: "FEES",
+              value: feeValue,
+              extra: {},
+              subOperations: [
+                {
+                  ...shared,
+                  id: encodeOperationId(tokenAccount.id, hash, "OUT"),
+                  accountId: tokenAccount.id,
+                  type: "OUT",
+                  // The token amount alone: the fee is CCD and belongs to the
+                  // parent, so folding it in would put µCCD into a token balance.
+                  value: actualAmount,
+                  extra: transaction.memo ? { memo: transaction.memo } : {},
+                },
+              ],
+            }
+          : {
+              ...shared,
+              id: encodeOperationId(account.id, hash, "OUT"),
+              accountId: account.id,
+              type: "OUT",
+              value: actualAmount,
+              extra: {},
+            };
 
         o.next({
           type: "signed",

--- a/libs/coin-modules/coin-concordium/src/bridge/updateTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/updateTransaction.test.ts
@@ -82,6 +82,21 @@ describe("updateTransaction", () => {
     expect(result.useAllAmount).toBe(true);
   });
 
+  // `fee` and `energy` are two halves of one estimate. A leftover energy would
+  // be signed as the limit for whatever token the patch selected next, and the
+  // device's "Max fees" step would show a figure never estimated for it.
+  it("drops the energy alongside the fee", () => {
+    // GIVEN
+    const tx = createFixtureTransaction({ fee: new BigNumber(3600), energy: 1080 });
+
+    // WHEN
+    const result = updateTransaction(tx, { subAccountId: "js:2:concordium:pubkey:+other" });
+
+    // THEN
+    expect(result.fee).toBeNull();
+    expect("energy" in result).toBe(false);
+  });
+
   it("should return new transaction object (immutable)", () => {
     // GIVEN
     const tx = createFixtureTransaction();
@@ -92,5 +107,30 @@ describe("updateTransaction", () => {
 
     // THEN
     expect(result).not.toBe(tx);
+  });
+
+  // `useBridgeTransaction` compares by identity, so allocating on a no-op patch
+  // flips `bridgePending` and re-runs preparation — a fee round-trip per patch.
+  it("keeps the same reference when the patch changes nothing", () => {
+    // GIVEN - the fee is already null, so there is nothing left to reset
+    const tx = createFixtureTransaction({ fee: null });
+
+    // WHEN
+    const result = updateTransaction(tx, {});
+
+    // THEN
+    expect(result).toBe(tx);
+  });
+
+  it("allocates when there is a stale energy to strip", () => {
+    // GIVEN
+    const tx = createFixtureTransaction({ fee: null, energy: 1080 });
+
+    // WHEN
+    const result = updateTransaction(tx, {});
+
+    // THEN
+    expect(result).not.toBe(tx);
+    expect("energy" in result).toBe(false);
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/updateTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/updateTransaction.ts
@@ -2,16 +2,27 @@ import { updateTransaction as defaultUpdateTransaction } from "@ledgerhq/ledger-
 import type { AccountBridge } from "@ledgerhq/types-live";
 import type { Transaction } from "../types";
 
-// NOTE: this method is optional, use defaultUpdateTransaction
-// acts as a middleware to update the transaction patch object
-
-// NOTE: here is an example transaction updater function
-// in this case, it resets fee to null depending on the patch content
+/**
+ * Drops the estimate on every patch, so `prepareTransaction` re-prices whatever
+ * the user is now describing.
+ *
+ * `fee` and `energy` are two halves of one estimate and expire together. Energy
+ * is priced from the token id's byte length and the operations blob's size, so a
+ * leftover value would be signed as the limit for a different token.
+ *
+ * `energy` is dropped rather than set to `undefined`: `exactOptionalPropertyTypes`
+ * forbids the explicit value, and the spread in `defaultUpdateTransaction` keeps
+ * the previous number if the key is merely absent from the patch.
+ */
 export const updateTransaction: AccountBridge<Transaction>["updateTransaction"] = (tx, patch) => {
-  // eslint-disable-next-line no-constant-condition
-  if (patch.recipient === "concordium1" || true) {
-    patch = { ...patch, fee: null };
-  }
+  const updated = defaultUpdateTransaction(tx, { ...patch, fee: null });
 
-  return defaultUpdateTransaction(tx, patch);
+  // `defaultUpdateTransaction` returns `tx` itself when the patch changes
+  // nothing, and `useBridgeTransaction` compares by identity: allocating anyway
+  // would flip `bridgePending` on a no-op patch and re-run preparation, costing
+  // a fee round-trip.
+  if (!("energy" in updated)) return updated;
+
+  const { energy: _stale, ...withoutEnergy } = updated;
+  return withoutEnergy;
 };

--- a/libs/coin-modules/coin-concordium/src/logic/index.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/index.ts
@@ -1,6 +1,7 @@
 export { broadcast } from "./transaction/broadcast";
 export { combine } from "./transaction/combine";
 export { craftTransaction } from "./transaction/craftTransaction";
+export { craftPltTransaction } from "./transaction/craftPltTransaction";
 export { craftRawTransaction } from "./transaction/craftRawTransaction";
 export { estimateFees, estimateTokenFees } from "./transaction/estimateFees";
 export { getBalance } from "./account/getBalance";

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/craftPltTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/craftPltTransaction.test.ts
@@ -1,0 +1,130 @@
+import BigNumber from "bignumber.js";
+import { serializeTokenUpdate, TransactionType } from "@ledgerhq/concordium-core";
+import { VALID_ADDRESS, VALID_ADDRESS_2 } from "../../test/fixtures";
+import { craftPltTransaction } from "./craftPltTransaction";
+
+// Epoch seconds 1_700_000_000, so the header's expiry is 1_700_003_600.
+const FROZEN_NOW_MS = 1_700_000_000_000;
+
+const craft = (over: Partial<Parameters<typeof craftPltTransaction>[1]> = {}) =>
+  craftPltTransaction(
+    { address: VALID_ADDRESS, nextSequenceNumber: 5 },
+    {
+      tokenId: "Token1",
+      recipient: VALID_ADDRESS_2,
+      amount: new BigNumber(60000),
+      decimals: 2,
+      energy: BigInt(1080),
+      ...over,
+    },
+  );
+
+describe("craftPltTransaction", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(FROZEN_NOW_MS));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // The expected bytes were assembled from the wire layout, not from this
+  // implementation: the two 32-byte addresses are base58check-decoded
+  // independently, and the CBOR blob is the reference vector from
+  // `concordium-core/src/plt.test.ts`. A layout change fails here rather than at
+  // the device.
+  //
+  // [sender:32][nonce:8][energyAmount:8][payloadSize:4][expiry:8][type:1]
+  //   [token_id_length:1][token_id:6][cbor_length:4][cbor:74]
+  //
+  // `payloadSize` counts the type byte: 1 + 6 + 4 + 74 + 1 = 86. The header
+  // serializer adds it for every transaction kind, which is what the chain
+  // accepts for the CCD transfers already in production.
+  it("serializes to the exact wire layout the chain and device expect", () => {
+    const serialized = serializeTokenUpdate(craft());
+
+    expect(serialized.toString("hex")).toBe(
+      "52a9a725cef5e4a18ad2a68b3184341fc1ab33a8dc3893e386075adbbb1ed86f" + // sender
+        "0000000000000005" + // nonce
+        "0000000000000438" + // energyAmount = 1080
+        "00000056" + // payloadSize = 86, the payload plus the type byte
+        "000000006553ff10" + // expiry = 1_700_003_600
+        "1b" + // type = TokenUpdate (27)
+        "06" + // token id length
+        "546f6b656e31" + // "Token1"
+        "0000004a" + // cbor length = 74
+        "81a1687472616e73666572a266616d6f756e74c4822119ea60" + // [{transfer:{amount: 600.00
+        "69726563697069656e74d99d73a1035820" + //                 recipient:
+        "69752406cc939fc90ca6a73b57cee109963547f942006d219144924f8485fb0d", //  ...}}]
+    );
+    expect(serialized).toHaveLength(146);
+  });
+
+  it("builds a TokenUpdate, not a native transfer", () => {
+    expect(craft().type).toBe(TransactionType.TokenUpdate);
+  });
+
+  // The chain matches the id against a registered token, so any normalisation
+  // here would break the transfer rather than tidy it.
+  it("passes the token id through byte for byte", () => {
+    expect(craft({ tokenId: "t-USDT" }).payload.tokenId).toEqual(Buffer.from("t-USDT", "utf-8"));
+  });
+
+  // The chain enforces `exponent == the token's registered decimals` and rejects
+  // a mismatch, so the exponent is the token's, never a wallet default.
+  it("takes the amount's exponent from the token's decimals", () => {
+    // Tag 4, array of 2, exponent -6 (0x25), then the significand.
+    expect(craft({ decimals: 6 }).payload.operations.toString("hex")).toContain("c48225");
+    expect(craft({ decimals: 2 }).payload.operations.toString("hex")).toContain("c48221");
+  });
+
+  // Signing must reuse the buffered figure persisted at estimation time: the
+  // same number reaches the device's "Max fees" step and the user's screen.
+  it("puts the persisted energy in the header, unmodified", () => {
+    expect(craft({ energy: BigInt(4242) }).header.energyAmount).toBe(BigInt(4242));
+  });
+
+  it("emits exactly one operation", () => {
+    // 0x81 is a single-element CBOR array. The device answers a second element
+    // with 0x6B10, after the user has already been prompted.
+    expect(craft().payload.operations[0]).toBe(0x81);
+  });
+
+  it("includes the memo in the operations blob when there is one", () => {
+    const withMemo = craft({ memo: "salary" });
+
+    expect(withMemo.payload.operations.toString("hex")).toContain(
+      Buffer.from("salary", "utf-8").toString("hex"),
+    );
+    expect(withMemo.payload.operations.length).toBeGreaterThan(craft().payload.operations.length);
+  });
+
+  it("omits the memo key entirely when there is none", () => {
+    expect(craft().payload.operations.toString("hex")).not.toContain(
+      Buffer.from("memo", "utf-8").toString("hex"),
+    );
+  });
+
+  it("expires an hour after crafting", () => {
+    expect(craft().header.expiry).toBe(BigInt(FROZEN_NOW_MS / 1000 + 3600));
+  });
+
+  it("defaults the nonce to 0 when the sequence number is unknown", () => {
+    expect(
+      craftPltTransaction(
+        { address: VALID_ADDRESS },
+        {
+          tokenId: "Token1",
+          recipient: VALID_ADDRESS_2,
+          amount: new BigNumber(1),
+          decimals: 2,
+          energy: BigInt(1),
+        },
+      ).header.nonce,
+    ).toBe(BigInt(0));
+  });
+
+  it("rejects an unparseable recipient rather than crafting a transfer to nowhere", () => {
+    expect(() => craft({ recipient: "not-an-address" })).toThrow();
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/craftPltTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/craftPltTransaction.ts
@@ -1,0 +1,74 @@
+import BigNumber from "bignumber.js";
+import {
+  AccountAddress,
+  encodePltTransferOperations,
+  TransactionType,
+  type TokenUpdateTransaction,
+} from "@ledgerhq/concordium-core";
+
+const EXPIRY_WINDOW_SECONDS = 3600;
+
+/**
+ * Crafts a PLT transfer as a `TokenUpdate` transaction.
+ *
+ * Separate from {@link craftTransaction} because `TransactionType.TokenUpdate`
+ * is absent from the native `Transaction` union by construction, so one function
+ * cannot return both.
+ *
+ * Three values come from the caller and are never derived here:
+ *
+ * - `tokenId` is the CAL-resolved `contract_address`, passed byte for byte. The
+ *   chain matches it against a registered token, so normalising it would break
+ *   the transfer.
+ * - `decimals` is the CAL unit magnitude. The chain enforces
+ *   `exponent == the token's registered decimals` and rejects a mismatch rather
+ *   than rescaling.
+ * - `energy` is the figure persisted at estimation time. Re-estimating here would
+ *   sign a different number from the one the user approved.
+ *
+ * The recipient carries no coin info: the encoder can add the tagged network id
+ * and the device accepts it, but the Concordium SDK omits it for a transfer
+ * (`TokenHolder.fromAccountAddress`), so these bytes match the chain's.
+ *
+ * The blob holds exactly one `transfer`. The device rejects a second element with
+ * `0x6B10`, and `serializeTokenUpdate` checks the array header before the user is
+ * prompted.
+ */
+export function craftPltTransaction(
+  account: {
+    address: string;
+    nextSequenceNumber?: number;
+  },
+  transaction: {
+    tokenId: string;
+    recipient: string;
+    amount: BigNumber;
+    decimals: number;
+    energy: bigint;
+    memo?: string;
+  },
+): TokenUpdateTransaction {
+  const expiryEpochSeconds = Math.floor(Date.now() / 1000) + EXPIRY_WINDOW_SECONDS;
+  const memo = transaction.memo ? Buffer.from(transaction.memo, "utf-8") : undefined;
+
+  return {
+    type: TransactionType.TokenUpdate,
+    header: {
+      sender: AccountAddress.fromBase58(account.address),
+      nonce: BigInt(account.nextSequenceNumber ?? 0),
+      expiry: BigInt(expiryEpochSeconds),
+      energyAmount: transaction.energy,
+    },
+    payload: {
+      tokenId: Buffer.from(transaction.tokenId, "utf-8"),
+      operations: encodePltTransferOperations({
+        recipient: AccountAddress.fromBase58(transaction.recipient),
+        // `toFixed(0)` rather than `toString`: an amount that reached here as a
+        // decimal would otherwise throw inside `BigInt` after the fee was shown.
+        amount: BigInt(transaction.amount.toFixed(0)),
+        decimals: transaction.decimals,
+        ...(memo ? { memo } : {}),
+      }),
+    },
+  };
+}

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/craftTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/craftTransaction.ts
@@ -36,7 +36,8 @@ export async function craftTransaction(
       sender: AccountAddress.fromBase58(account.address),
       nonce: BigInt(account.nextSequenceNumber || 0),
       expiry: BigInt(expiryEpochSeconds),
-      // Drop this fallback when signing reads the persisted energy (LIVE-28337):
+      // Still reachable, so not removable: the api path crafts without an
+      // energy (`api/index.ts`), while the bridge always passes an estimate.
       // 0 NRG is rejected at broadcast, after the device ceremony has completed.
       energyAmount: transaction.energy ?? BigInt(0),
     },

--- a/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
+++ b/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
@@ -9,7 +9,7 @@
 import crypto from "node:crypto";
 import type {
   Address,
-  Transaction,
+  AnyTransaction,
   CredentialDeploymentTransaction,
   SigningResult,
 } from "@ledgerhq/concordium-core";
@@ -87,7 +87,7 @@ export function createMockSigner(keyPair: ConcordiumTestKeyPair): ConcordiumSign
     },
 
     signTransaction: async (
-      tx: Transaction,
+      tx: AnyTransaction,
       path: string,
       _maxFee: bigint,
     ): Promise<SigningResult> => {

--- a/libs/coin-modules/coin-concordium/src/types/signer.ts
+++ b/libs/coin-modules/coin-concordium/src/types/signer.ts
@@ -1,7 +1,7 @@
 import type {
   Address,
+  AnyTransaction,
   CredentialDeploymentTransaction,
-  Transaction,
   SigningResult,
 } from "@ledgerhq/concordium-core";
 import type { ConcordiumNetwork } from "./config";
@@ -28,7 +28,7 @@ export interface ConcordiumSigner {
   getPublicKey(path: string, confirm?: boolean): Promise<string>;
 
   /**
-   * Sign a transaction (Transfer or TransferWithMemo).
+   * Sign a transaction (Transfer, TransferWithMemo or TokenUpdate).
    * Routes to the appropriate signing method based on transaction type.
    * Returns both signature and serialized transaction.
    *
@@ -36,7 +36,7 @@ export interface ConcordiumSigner {
    * display only when the firmware supports it; not part of the canonical
    * signed bytes.
    */
-  signTransaction(tx: Transaction, path: string, maxFee: bigint): Promise<SigningResult>;
+  signTransaction(tx: AnyTransaction, path: string, maxFee: bigint): Promise<SigningResult>;
 
   /**
    * Sign a credential deployment transaction (hw-app format).

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -7,7 +7,7 @@ import {
   encodeWord64,
   type Address,
   type CredentialDeploymentTransaction,
-  type Transaction,
+  type AnyTransaction,
   type SigningResult,
 } from "@ledgerhq/concordium-core";
 import {
@@ -74,7 +74,7 @@ export class DmkSignerConcordium implements ConcordiumSigner {
     return { address: publicKey, publicKey };
   }
 
-  async signTransaction(tx: Transaction, path: string, maxFee: bigint): Promise<SigningResult> {
+  async signTransaction(tx: AnyTransaction, path: string, maxFee: bigint): Promise<SigningResult> {
     const serialized = serializeTransaction(tx);
 
     const { observable } = this.signer.signTransaction(path, new Uint8Array(serialized), maxFee, {

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -10,8 +10,17 @@ import {
 import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import { UserRefusedOnDevice } from "../src/errors";
 import { SignerConcordiumBuilder } from "@ledgerhq/device-signer-kit-concordium";
-import { TransactionType, AccountAddress } from "@ledgerhq/concordium-core";
-import type { Transaction, CredentialDeploymentTransaction } from "@ledgerhq/concordium-core";
+import {
+  TransactionType,
+  AccountAddress,
+  serializeTokenUpdate,
+  encodePltTransferOperations,
+} from "@ledgerhq/concordium-core";
+import type {
+  Transaction,
+  TokenUpdateTransaction,
+  CredentialDeploymentTransaction,
+} from "@ledgerhq/concordium-core";
 import { of } from "rxjs";
 import { DmkSignerConcordium } from "../src/DmkSignerConcordium";
 
@@ -213,6 +222,46 @@ describe("DmkSignerConcordium", () => {
       expect(mockSignerConcordium.signTransaction).toHaveBeenCalledWith(
         mockPath,
         expect.any(Uint8Array),
+        mockMaxFee,
+        { skipOpenApp: true },
+      );
+    });
+
+    // The PLT path relies on `serializeTransaction` dispatching on the
+    // TokenUpdate discriminator. Nothing else in either package pushes real PLT
+    // bytes through the signer, so an edit to the dispatch or the framing would
+    // otherwise break PLT signing with a green suite.
+    it("serializes a TokenUpdate through the PLT serializer", async () => {
+      const recipient = AccountAddress.fromBase58(
+        "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
+      );
+      const pltTx: TokenUpdateTransaction = {
+        header: {
+          sender: AccountAddress.fromBase58("3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"),
+          nonce: 1n,
+          expiry: 1000n,
+          energyAmount: 1080n,
+        },
+        type: TransactionType.TokenUpdate,
+        payload: {
+          tokenId: Buffer.from("Token1", "utf-8"),
+          operations: encodePltTransferOperations({ recipient, amount: 60000n, decimals: 2 }),
+        },
+      };
+      const expected = serializeTokenUpdate(pltTx);
+      mockSignerConcordium.signTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: new Uint8Array(64).fill(0xcc),
+        }),
+      });
+
+      const result = await signer.signTransaction(pltTx, mockPath, mockMaxFee);
+
+      expect(result.serialized).toBe(expected.toString("hex"));
+      expect(mockSignerConcordium.signTransaction).toHaveBeenCalledWith(
+        mockPath,
+        new Uint8Array(expected),
         mockMaxFee,
         { skipOpenApp: true },
       );


### PR DESCRIPTION
### 📝 Description

Crafts and signs PLT transfers. `signOperation` previously refused them with an invariant.

`craftPltTransaction` builds the `TokenUpdate`. Three values come from the caller and are never derived here:

| Value | Source | Why it can't be defaulted |
| --- | --- | --- |
| token id | CAL `contract_address`, byte for byte | the chain matches it against a registered token |
| amount exponent | CAL unit magnitude | the chain enforces `exponent == registered decimals` |
| energy | persisted at estimation time | the device's "Max fees" must equal the figure shown |

The recipient carries no coin info, matching the Concordium SDK. `estimateFees` is not called on the token path.

Also:

- `signOperation` routes a token sub-account to the PLT craft; the CCD path is untouched.
- The signer interface widens to `AnyTransaction` — `serializeTransaction` already dispatched both kinds.
- A PLT send emits the pair sync builds for a confirmed transfer: CCD fee on the parent, token amount as a sub-operation. A single parent `OUT` in token units would corrupt the parent's optimistic CCD balance.
- `updateTransaction` drops `energy` with `fee`, and keeps `defaultUpdateTransaction`'s reference stability when there is nothing to strip.
- `fee.isNaN()` joins the signing guard: a `BigNumber` holding NaN is truthy and would throw a raw `SyntaxError` inside `BigInt`.
- English strings for the two signer errors this path can reach (`ConcordiumAppOutdatedError`, `ConcordiumSignerProtocolError`).

**Verification.** The wire fixture was derived independently of the implementation — both addresses base58check-decoded separately, CBOR from `concordium-core`'s reference vectors — and caught a one-byte `payloadSize` disagreement (it counts the type byte). 638 coin-module tests, 44 signer tests; `typecheck`, `lint`, `format:check` and `unimported` clean.

**Out of scope.** On-device signing and proxy acceptance need the PLT-capable Concordium app (NAPPS-1236); until it ships an attempt surfaces as a translated app-update error. PLT sub-accounts stay behind the `enableTokens` switch. The api layer still refuses PLT intents (`assertNativeAsset`). `mapPltRejectReason` has no production caller, so its three errors are left untranslated.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28337](https://ledgerhq.atlassian.net/browse/LIVE-28337) — on-device criteria blocked by [NAPPS-1236](https://ledgerhq.atlassian.net/browse/NAPPS-1236)
- **ADR** (if any): n/a


[LIVE-28337]: https://ledgerhq.atlassian.net/browse/LIVE-28337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ