### PR TITLE
[LWM] feat(earn): forward device-intent flag to earn webview (LIVE-37179)

### DIFF
--- a/.changeset/few-news-add.md
+++ b/.changeset/few-news-add.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Forward llmWalletApiDeviceIntentSignEnabled to the Earn live-app on mobile

--- a/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/__tests__/useEarnLiveAppModalContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/__tests__/useEarnLiveAppModalContentViewModel.test.ts
@@ -41,10 +41,23 @@ describe("useEarnLiveAppModalContentViewModel (mobile)", () => {
     expect(result.current.extraInputs).toEqual({
       uiVersion: "v2",
       lw40enabled: "true",
+      llmWalletApiDeviceIntentSignEnabled: "false",
       ethDepositCohort: "cohort-a",
       stakeProgramsParam: JSON.stringify({ ethereum: "earn", bitcoin: "stakekit" }),
       stakeCurrenciesParam: JSON.stringify(["ethereum", "bitcoin"]),
     });
+  });
+
+  it("returns the enabled device-intent sign flag state", () => {
+    mockedUseVersionedStakePrograms.mockReturnValue(null);
+
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        llmWalletApiDeviceIntentSign: { enabled: true },
+      }),
+    });
+
+    expect(result.current.extraInputs?.llmWalletApiDeviceIntentSignEnabled).toBe("true");
   });
 
   it("returns v3 when earn upselling is enabled", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.ts
@@ -20,6 +20,7 @@ const useEarnLiveAppModalContentViewModel = (): EarnLiveAppModalContentViewModel
   } = useWalletFeaturesConfig("mobile");
   const stakePrograms = useVersionedStakePrograms();
   const earnUiVersion = useFeature("ptxEarnUi");
+  const deviceIntentSignEnabled = useFeature("llmWalletApiDeviceIntentSign")?.enabled ?? false;
   const computedUiVersion = computeEarnUiVersion({
     baseUiVersion: earnUiVersion?.params?.value ?? "v2",
     shouldDisplayEarnUpselling,
@@ -33,13 +34,14 @@ const useEarnLiveAppModalContentViewModel = (): EarnLiveAppModalContentViewModel
     return {
       uiVersion: isLwm40Enabled ? computedUiVersion : "v1",
       lw40enabled: isLwm40Enabled ? "true" : "false",
+      llmWalletApiDeviceIntentSignEnabled: deviceIntentSignEnabled ? "true" : "false",
       ethDepositCohort,
       stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
       stakeCurrenciesParam: stakeCurrenciesParam?.length
         ? JSON.stringify(stakeCurrenciesParam)
         : undefined,
     };
-  }, [stakePrograms, isLwm40Enabled, computedUiVersion]);
+  }, [stakePrograms, isLwm40Enabled, computedUiVersion, deviceIntentSignEnabled]);
 
   return { extraInputs };
 };

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/index.test.tsx
@@ -135,4 +135,13 @@ describe("EarnScreen canvas background wiring", () => {
 
     expect(capturedProps.current?.inputs?.stableSavings).toBe(JSON.stringify({ enabled: false }));
   });
+
+  it("should pass the device-intent sign flag state", () => {
+    renderEarnScreen("deposit", {
+      lwmWallet40: { enabled: true },
+      llmWalletApiDeviceIntentSign: { enabled: true },
+    });
+
+    expect(capturedProps.current?.inputs?.llmWalletApiDeviceIntentSignEnabled).toBe("true");
+  });
 });

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -105,6 +105,7 @@ function Earn({ route }: Props) {
         : undefined,
     [stableSavingsFlag],
   );
+  const deviceIntentSignEnabled = useFeature("llmWalletApiDeviceIntentSign")?.enabled ?? false;
 
   const shouldDisplayBackgroundCanvas = useMemo(
     () => shouldDisplayEarnBackgroundCanvas(params?.intent, swapToEarnFlag?.enabled ?? false),
@@ -139,6 +140,7 @@ function Earn({ route }: Props) {
       uiVersion: "v1",
       ...restParams,
       ...Object.fromEntries(searchParams.entries()),
+      llmWalletApiDeviceIntentSignEnabled: deviceIntentSignEnabled ? "true" : "false",
     };
 
     return {
@@ -157,6 +159,7 @@ function Earn({ route }: Props) {
     ethDepositCohort,
     swapToEarnParam,
     stableSavingsParam,
+    deviceIntentSignEnabled,
     params,
     searchParams,
   ]);


### PR DESCRIPTION
### 📝 Description

Dice UX v2 needs `llmWalletApiDeviceIntentSignEnabled` on Earn live-app events. Swap already receives this input; Earn webviews did not.

Forward the `llmWalletApiDeviceIntentSign` flag state (`true`/`false`) into Earn screen and Live App Modal webview inputs, matching Swap. The companion earn-live-app PR reads the param and attaches it to Segment event properties.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37179](https://ledgerhq.atlassian.net/browse/LIVE-37179)
- **ADR** (if any):

[LIVE-37179]: https://ledgerhq.atlassian.net/browse/LIVE-37179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ