### PR TITLE
[LWDM] feat(coin-aleo): craft unbond and claim staking transactions

### DIFF
--- a/.changeset/aleo-craft-staking-unbond-claim.md
+++ b/.changeset/aleo-craft-staking-unbond-claim.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+feat: craft unbond_public and claim_unbond_public staking transactions — the two backend wire
+intents, the staker guard, their credits.aleo function names, the shared staking mode →
+operation-type table, fee-valued optimistic operations for all three staking modes, and no Amount
+row on a claim's device confirmation. No user-reachable behaviour yet: nothing can construct a
+transaction in either mode until the bridge transaction mode union is extended.

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
@@ -5,6 +5,7 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/types";
 import { TRANSACTION_TYPE } from "../../constants";
 import type {
+  AleoStakingMode,
   AleoTransactionIntent,
   AleoTransactionIntentData,
   Transaction,
@@ -30,6 +31,16 @@ export const getMockedTransaction = (overrides?: Partial<Transaction>): Transact
     ...overrides,
   } as Transaction;
 };
+
+/**
+ * Unbond and claim are not yet members of the bridge `Transaction` union, so a staking transaction
+ * can only be built by widening. One cast here rather than one per test; it disappears when the
+ * union gains the two modes.
+ */
+export const getMockedStakingTransaction = (
+  mode: AleoStakingMode,
+  overrides?: Partial<Omit<Transaction, "mode">>,
+): Transaction => getMockedTransaction({ mode, ...overrides } as unknown as Partial<Transaction>);
 
 export const getMockedTransactionRaw = (overrides?: Partial<TransactionRaw>): TransactionRaw => {
   return {
@@ -71,6 +82,21 @@ export const mockTxIntentBondPublic: AleoTransactionIntent = {
     type: TRANSACTION_TYPE.BOND_PUBLIC,
     withdrawal: "aleo1sender",
   },
+};
+
+// The staker of an unbond or a claim is the account itself, so recipient and sender are one address.
+export const mockTxIntentUnbondPublic: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  recipient: baseTxIntentFields.sender,
+  amount: 1_000_000n,
+  type: TRANSACTION_TYPE.UNBOND_PUBLIC,
+};
+
+export const mockTxIntentClaimUnbondPublic: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  recipient: baseTxIntentFields.sender,
+  amount: 0n,
+  type: TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC,
 };
 
 export const mockTxIntentTransferPrivate: AleoTransactionIntent = {

--- a/libs/coin-modules/coin-aleo/src/bridge/buildOptimisticOperation.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/buildOptimisticOperation.test.ts
@@ -2,7 +2,10 @@ import BigNumber from "bignumber.js";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { TRANSACTION_TYPE } from "../constants";
 import { getMockedAccount, getMockedTokenAccount } from "../__tests__/fixtures/account.fixture";
-import { getMockedTransaction } from "../__tests__/fixtures/transaction.fixture";
+import {
+  getMockedStakingTransaction,
+  getMockedTransaction,
+} from "../__tests__/fixtures/transaction.fixture";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";
 
 describe("buildOptimisticOperation", () => {
@@ -171,4 +174,28 @@ describe("buildOptimisticOperation", () => {
       },
     });
   });
+
+  it.each([
+    [TRANSACTION_TYPE.BOND_PUBLIC, "BOND", "bond_public"],
+    [TRANSACTION_TYPE.UNBOND_PUBLIC, "UNBOND", "unbond_public"],
+    [TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC, "WITHDRAW_UNBONDED", "claim_unbond_public"],
+  ] as const)(
+    "should build a fee-valued %s staking operation typed %s",
+    (mode, operationType, functionId) => {
+      const transaction = getMockedStakingTransaction(mode, {
+        amount: new BigNumber(5_000_000),
+        fees: new BigNumber(34_060),
+        recipient: account.freshAddress,
+      });
+
+      const operation = buildOptimisticOperation({ account, transaction });
+
+      expect(operation.type).toBe(operationType);
+      expect(operation.value).toEqual(transaction.fees);
+      expect(operation.fee).toEqual(transaction.fees);
+      expect(operation.id).toBe(encodeOperationId(account.id, "", operationType));
+      expect(operation.extra).toEqual({ functionId, transactionType: "public" });
+      expect(operation.subOperations).toBeUndefined();
+    },
+  );
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/buildOptimisticOperation.ts
@@ -5,6 +5,7 @@ import {
   getFunctionNameFromTransactionType,
   getNextSequenceNumber,
   getOperationTransactionType,
+  getStakingOperationType,
   isTokenTransaction,
 } from "../logic/utils";
 
@@ -17,8 +18,10 @@ export function buildOptimisticOperation({
 }): AleoOperation {
   const fee = transaction.fees;
   const isTokenTx = isTokenTransaction(transaction);
-  const value = isTokenTx ? fee : transaction.amount;
-  const mainOperationType: OperationType = isTokenTx ? "FEES" : "OUT";
+  const stakingType = getStakingOperationType(transaction.mode);
+  // Staking moves funds between the account's own balances, so the fee is all that leaves it.
+  const value = isTokenTx || stakingType ? fee : transaction.amount;
+  const mainOperationType: OperationType = isTokenTx ? "FEES" : (stakingType ?? "OUT");
   const subOperations: Operation[] = [];
   const tokenSubAccount = account.subAccounts?.find(s => s.id === transaction.subAccountId);
   const transactionSequenceNumber = getNextSequenceNumber(account);

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -1,3 +1,5 @@
+import type { OperationType } from "@ledgerhq/types-live";
+
 export const ALEO_DUMMY_ADDRESS = "aleo14pfq40wgltv8wrhsxqe5tlme4pkp448rfejfvqhd4yj0qycs7c9s2xkcwv";
 
 export const PROGRAM_ID = {
@@ -26,6 +28,14 @@ export const TRANSACTION_TYPE = {
   UNBOND_PUBLIC: "unbond_public",
   CLAIM_UNBOND_PUBLIC: "claim_unbond_public",
 } as const;
+
+// The three staking modes are named exactly after the credits.aleo functions they call, so this
+// one table serves both a mode on the craft path and a `function_id` read back from the indexer.
+export const STAKING_OPERATION_TYPE = {
+  [TRANSACTION_TYPE.BOND_PUBLIC]: "BOND",
+  [TRANSACTION_TYPE.UNBOND_PUBLIC]: "UNBOND",
+  [TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC]: "WITHDRAW_UNBONDED",
+} as const satisfies Record<string, OperationType>;
 
 export const FEE_INTENT_TYPES = new Set(["fee_public", "fee_private"]);
 

--- a/libs/coin-modules/coin-aleo/src/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-aleo/src/deviceTransactionConfig.test.ts
@@ -4,7 +4,10 @@ import { TRANSACTION_TYPE } from "./constants";
 import aleoCoinConfig from "./config";
 import { getMockedAccount } from "./__tests__/fixtures/account.fixture";
 import { getMockedConfig } from "./__tests__/fixtures/config.fixture";
-import { getMockedTransaction } from "./__tests__/fixtures/transaction.fixture";
+import {
+  getMockedStakingTransaction,
+  getMockedTransaction,
+} from "./__tests__/fixtures/transaction.fixture";
 import type { TransactionStatus } from "./types";
 
 jest.mock("./config");
@@ -87,7 +90,7 @@ describe("getDeviceTransactionConfig", () => {
     });
   });
 
-  it("should always include the Amount field", async () => {
+  it("should include the Amount field for a public transfer", async () => {
     const fields = await getDeviceTransactionConfig({
       account: mockAccount,
       transaction: mockTransaction,
@@ -95,6 +98,44 @@ describe("getDeviceTransactionConfig", () => {
     });
 
     expect(fields).toContainEqual({ type: "amount", label: "Amount" });
+  });
+
+  it.each([
+    ["Bond Public", TRANSACTION_TYPE.BOND_PUBLIC],
+    ["Unbond Public", TRANSACTION_TYPE.UNBOND_PUBLIC],
+    ["Claim Unbond Public", TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC],
+  ] as const)("should return method '%s' for staking mode '%s'", async (expectedMethod, mode) => {
+    const fields = await getDeviceTransactionConfig({
+      account: mockAccount,
+      transaction: getMockedStakingTransaction(mode),
+      status: mockStatus,
+    });
+
+    expect(fields).toContainEqual({ type: "text", label: "Method", value: expectedMethod });
+  });
+
+  it.each([TRANSACTION_TYPE.BOND_PUBLIC, TRANSACTION_TYPE.UNBOND_PUBLIC] as const)(
+    "should include the Amount field for staking mode '%s'",
+    async mode => {
+      const fields = await getDeviceTransactionConfig({
+        account: mockAccount,
+        transaction: getMockedStakingTransaction(mode),
+        status: mockStatus,
+      });
+
+      expect(fields).toContainEqual({ type: "amount", label: "Amount" });
+    },
+  );
+
+  it("should omit the Amount field for a claim", async () => {
+    const fields = await getDeviceTransactionConfig({
+      account: mockAccount,
+      transaction: getMockedStakingTransaction(TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC),
+      status: mockStatus,
+    });
+
+    expect(fields).not.toContainEqual({ type: "amount", label: "Amount" });
+    expect(fields.map(f => f.label)).toEqual(["Method", "From", "To", "Fees"]);
   });
 
   it("should include the Fees field when estimatedFees is non-zero and sponsorship is disabled", async () => {

--- a/libs/coin-modules/coin-aleo/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-aleo/src/deviceTransactionConfig.ts
@@ -18,6 +18,10 @@ const mapTransactionModeToMethod: Record<TransactionType, string> = {
   [TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC]: "Claim Unbond Public",
 };
 
+// credits.aleo `claim_unbond_public` takes only the staker — the chain decides how much is
+// released, so the signed payload carries no amount and the device's review screen shows none.
+const MODES_WITHOUT_AMOUNT_ROW = new Set<TransactionType>([TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC]);
+
 async function getDeviceTransactionConfig({
   account,
   parentAccount,
@@ -37,8 +41,11 @@ async function getDeviceTransactionConfig({
     { type: "text", label: "Method", value: method },
     { type: "address", label: "From", address: mainAccount.freshAddress },
     { type: "address", label: "To", address: transaction.recipient },
-    { type: "amount", label: "Amount" },
   );
+
+  if (!MODES_WITHOUT_AMOUNT_ROW.has(transaction.mode)) {
+    fields.push({ type: "amount", label: "Amount" });
+  }
 
   // TODO: restore config.isFeeSponsored check
   // https://ledgerhq.atlassian.net/browse/LIVE-29092

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -38,6 +38,8 @@ import {
   mockTxIntentFeePrivate,
   mockTxIntentFeePublic,
   mockTxIntentBondPublic,
+  mockTxIntentUnbondPublic,
+  mockTxIntentClaimUnbondPublic,
   mockTxIntentSelfTransferToPrivate,
   mockTxIntentSelfTransferToPublic,
   mockTxIntentSelfTransferToPublic2,
@@ -82,6 +84,7 @@ import {
   isProvableApiConfigured,
   isRecordScannerReady,
   getOperationTransactionType,
+  getStakingOperationType,
   splitPrivateAndPublicOperations,
   toHex,
   fromHex,
@@ -1203,6 +1206,49 @@ describe("mapTransactionIntentToSdkIntent", () => {
 
     expect(() => mapTransactionIntentToSdkIntent(withoutData as AleoTransactionIntent)).toThrow(
       "aleo: intent data is required for bond_public",
+    );
+  });
+
+  // The staker arrives as the intent's `recipient` but the program argument is named `staker`.
+  it("should map unbond_public intent to the staker SDK argument name", () => {
+    const intent = mockTxIntentUnbondPublic;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "unbond_public",
+      amount: intent.amount.toString(),
+      staker: intent.recipient,
+    });
+  });
+
+  it("should map claim_unbond_public intent without an amount key", () => {
+    const intent = mockTxIntentClaimUnbondPublic;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "claim_unbond_public",
+      staker: intent.recipient,
+    });
+    // toEqual alone would pass on `amount: undefined`, which the backend's deny_unknown_fields
+    // would still see as a key.
+    expect(result).not.toHaveProperty("amount");
+  });
+
+  it("should throw when the staker is not the sender for unbond_public", () => {
+    const intent = { ...mockTxIntentUnbondPublic, recipient: "aleo1someoneelse" };
+
+    expect(() => mapTransactionIntentToSdkIntent(intent)).toThrow(
+      "aleo: unbond_public staker must be the sender (recipient aleo1someoneelse, sender aleo1sender)",
+    );
+  });
+
+  it("should throw when the staker is not the sender for claim_unbond_public", () => {
+    const intent = { ...mockTxIntentClaimUnbondPublic, recipient: "aleo1someoneelse" };
+
+    expect(() => mapTransactionIntentToSdkIntent(intent)).toThrow(
+      "aleo: claim_unbond_public staker must be the sender (recipient aleo1someoneelse, sender aleo1sender)",
     );
   });
 
@@ -2355,6 +2401,8 @@ describe("getFunctionNameFromTransactionType", () => {
     ["transfer_token_public_to_private", TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE],
     ["transfer_token_private_to_public", TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC],
     ["bond_public", TRANSACTION_TYPE.BOND_PUBLIC],
+    ["unbond_public", TRANSACTION_TYPE.UNBOND_PUBLIC],
+    ["claim_unbond_public", TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC],
   ])("should return '%s' for transaction type '%s'", (expected, transactionType) => {
     expect(getFunctionNameFromTransactionType(transactionType)).toBe(expected);
   });
@@ -2364,6 +2412,24 @@ describe("getFunctionNameFromTransactionType", () => {
     expect(() => getFunctionNameFromTransactionType("unknown_type")).toThrow(
       "aleo: unsupported transaction type: unknown_type",
     );
+  });
+});
+
+describe("getStakingOperationType", () => {
+  it.each([
+    ["BOND", TRANSACTION_TYPE.BOND_PUBLIC],
+    ["UNBOND", TRANSACTION_TYPE.UNBOND_PUBLIC],
+    ["WITHDRAW_UNBONDED", TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC],
+  ])("should return '%s' for staking mode '%s'", (expected, mode) => {
+    expect(getStakingOperationType(mode)).toBe(expected);
+  });
+
+  it("should return undefined for a non-staking transaction type", () => {
+    expect(getStakingOperationType(TRANSACTION_TYPE.TRANSFER_PUBLIC)).toBeUndefined();
+  });
+
+  it("should return undefined for a prototype member", () => {
+    expect(getStakingOperationType("constructor")).toBeUndefined();
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -35,6 +35,7 @@ import {
   PRIVATE_TRANSFER_FUNCTIONS,
   PROGRAM_ID,
   SINGLE_CALL_SIGNING_TIME,
+  STAKING_OPERATION_TYPE,
   TOKEN_RECORD_NAME,
   TRANSACTION_TYPE,
 } from "../constants";
@@ -548,6 +549,12 @@ export function getOperationTransactionType(transactionType: TransactionType): A
   }
 }
 
+export function getStakingOperationType(functionName: string): OperationType | undefined {
+  return Object.hasOwn(STAKING_OPERATION_TYPE, functionName)
+    ? STAKING_OPERATION_TYPE[functionName as AleoStakingMode]
+    : undefined;
+}
+
 export function isPublicTokenTransaction(transaction: Pick<Transaction, "mode">): boolean {
   return (
     transaction.mode === TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC ||
@@ -868,6 +875,19 @@ export function mapTransactionIntentToSdkIntent(
         validator: to,
         withdrawal: txIntent.data.withdrawal,
       };
+    }
+    case TRANSACTION_TYPE.UNBOND_PUBLIC:
+    case TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC: {
+      // The intent carries a single address: for a bond it is the validator, for an unbond or a
+      // claim it is the staker — and the program only accepts the signing account as its own staker.
+      invariant(
+        to === txIntent.sender,
+        `aleo: ${type} staker must be the sender (recipient ${to}, sender ${txIntent.sender})`,
+      );
+
+      return type === TRANSACTION_TYPE.UNBOND_PUBLIC
+        ? { type: "unbond_public", amount, staker: to }
+        : { type: "claim_unbond_public", staker: to };
     }
     default: {
       throw new Error(`aleo: unsupported intent type: ${type}`);
@@ -1223,6 +1243,10 @@ export function getFunctionNameFromTransactionType(transactionType: TransactionT
       return "transfer_token_private_to_public";
     case TRANSACTION_TYPE.BOND_PUBLIC:
       return "bond_public";
+    case TRANSACTION_TYPE.UNBOND_PUBLIC:
+      return "unbond_public";
+    case TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC:
+      return "claim_unbond_public";
     default:
       throw new Error(`aleo: unsupported transaction type: ${transactionType}`);
   }

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -4,7 +4,7 @@ import type {
   TransactionIntent,
   TxDataNotSupported,
 } from "@ledgerhq/coin-module-framework/api/types";
-import type { TRANSACTION_TYPE } from "../constants";
+import type { STAKING_OPERATION_TYPE, TRANSACTION_TYPE } from "../constants";
 import type {
   AleoRecordScannerStatusResponse,
   AleoPublicTransactionDetailsResponse,
@@ -86,10 +86,7 @@ export type AleoTokenType = "arc20" | "arc21" | "arc22" | "unknown";
 
 export type TransactionType = (typeof TRANSACTION_TYPE)[keyof typeof TRANSACTION_TYPE];
 
-export type AleoStakingMode =
-  | typeof TRANSACTION_TYPE.BOND_PUBLIC
-  | typeof TRANSACTION_TYPE.UNBOND_PUBLIC
-  | typeof TRANSACTION_TYPE.CLAIM_UNBOND_PUBLIC;
+export type AleoStakingMode = keyof typeof STAKING_OPERATION_TYPE;
 
 export type AleoTransactionIntentData =
   | TxDataNotSupported

--- a/libs/coin-modules/coin-aleo/src/types/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/types/sdk.ts
@@ -129,6 +129,17 @@ interface BondPublicIntent {
   withdrawal: string;
 }
 
+interface UnbondPublicIntent {
+  type: "unbond_public";
+  amount: string;
+  staker: string;
+}
+
+interface ClaimUnbondPublicIntent {
+  type: "claim_unbond_public";
+  staker: string;
+}
+
 export type Intent =
   | TransferPrivateIntent
   | TransferPublicIntent
@@ -140,7 +151,9 @@ export type Intent =
   | TransferTokenPrivateToPublicIntent
   | FeePrivateIntent
   | FeePublicIntent
-  | BondPublicIntent;
+  | BondPublicIntent
+  | UnbondPublicIntent
+  | ClaimUnbondPublicIntent;
 
 export interface FeeConfiguration {
   function_name: "fee_private" | "fee_public";


### PR DESCRIPTION
## Description

### 📝 Description

Adds the crafting-side support for the two remaining `credits.aleo` staking functions:

- the two backend wire intents (`unbond_public`, `claim_unbond_public`) in the SDK `Intent` union;
- intent → wire translation for both modes, guarded so the staker must be the signing account;
- their `credits.aleo` function names on the broadcast path;
- a single staking mode → operation-type table (`bond_public`→`BOND`, `unbond_public`→`UNBOND`,
  `claim_unbond_public`→`WITHDRAW_UNBONDED`), with `AleoStakingMode` derived from its keys so the
  two cannot drift, and an accessor a future history slice can reuse against an indexer `function_id`;
- staking typing and **fee valuation** of the optimistic operation for **all three** staking modes,
  bond included - staking moves funds between the account's own balances, so the fee is all that leaves it;
- **no Amount row** on a claim's device confirmation: `claim_unbond_public` takes only the staker, the
  chain decides how much is released, and the device's own review screen shows no amount.

**Not user-reachable.** Nothing in the repository can construct a transaction in either new mode until
the bridge `Transaction` mode union is extended (LIVE-32277). This slice is exercisable only from
hand-built intents and widened fixtures in tests. A reviewer expecting to click through it will not be
able to - that is deliberate, not an omission.

**Routed to LIVE-32277, not dropped**: the `Transaction` / `TransactionRaw` mode variants, and with them
producing a transaction intent from a bridge transaction. Extending the union here was measured to force
changes to `getAvailableBalance`, which cannot be answered correctly on `develop` - the bonded and
unbonding balances it needs do not exist there. Test fixtures widen through a single documented cast
(`getMockedStakingTransaction`) until the union lands.

**Constraint on LIVE-32277**: the withdrawal address is still caller-supplied and copied verbatim at every
hop. It decides where unbonded funds are paid. It is not exploitable today (no bridge path, disabled UI),
and it must not ship reachable without being pinned. LIVE-32280's own description currently claims the
staker is "already pinned in LIVE-32277" - that is false against `develop` and should be corrected on the
ticket.

**Also unowned**: fee estimation for staking (the craft path prices a staking transaction from a static
table under an invariant that throws on a miss - it holds today), and the earn funnel's aleo vocabulary
(`libs/transaction-observability` has no `aleo` entry, so `BOND` and `UNBOND` classify as nothing once
these operation types start being emitted).

### Tests

New coverage (+20 tests, 1134 -> 1154; suite count unchanged at 37):

- `logic/utils.test.ts` - unbond and claim intent mapping (including `not.toHaveProperty("amount")` on a
  claim, since `toEqual` alone would pass on `amount: undefined` and the backend's `deny_unknown_fields`
  would still see a key), both staker-mismatch rejections, the two new `getFunctionNameFromTransactionType`
  rows, and `getStakingOperationType` (three modes, a non-staking mode, and a prototype member).
- `bridge/buildOptimisticOperation.test.ts` - one `it.each` over all three staking modes asserting type,
  fee-valuation, fee, id and `extra`, with a non-zero amount distinct from the fee so the two are
  distinguishable.
- `deviceTransactionConfig.test.ts` - the three staking method labels, the Amount row present for bond and
  unbond, and absent for a claim (asserted on the label list, not only `not.toContainEqual`).

**One pre-existing test edited**: `deviceTransactionConfig.test.ts`'s `"should always include the Amount
field"` renamed to `"should include the Amount field for a public transfer"`. Body unchanged. Reason: the
unqualified claim stops being true once a claim suppresses the row. No other pre-existing test was touched.

### Coverage

| File | % Stmts | % Branch | % Funcs | % Lines |
|---|---|---|---|---|
| `src/logic/utils.ts` | 98.45 | 96.35 | 96.87 | 98.32 |
| `src/constants.ts` | 91.07 | 100 | 100 | 100 |
| `src/bridge/buildOptimisticOperation.ts` | 100 | 100 | 100 | 100 |
| `src/deviceTransactionConfig.ts` | 100 | 100 | 100 | 100 |
| All files | 97.06 | 91.95 | 95.99 | 98.32 |

Every figure is at or above the pre-change baseline.

`src/types/sdk.ts` and `src/types/logic.ts` do **not** appear in the coverage report and are not expected
to: both are pure type declarations that emit no JavaScript, so istanbul never instruments them. They fall
under the "pure type declarations" exclusion of the repo's coverage rule. (The report does contain a
`sdk.ts` row at 100 / 83.33 - that is `src/network/sdk.ts`, an unrelated file this change does not touch.)

### Validation

`lint` PASS  `typecheck` PASS  `test` PASS (37 suites, 1154 passed / 2 skipped) · `coverage` PASS ·
`unimported` PASS.

`pnpm test:family aleo` reports one failure - **pre-existing on `develop`**, byte-identical before and
after this change, and outside this package: `live-common`'s `src/families/aleo/hw/getViewKey/index.test.ts`
fails to resolve `@ledgerhq/hw-app-btc/shouldUseTrustedInputForSegwit` from `src/apps/support.ts`.

### 🔗 Context

JIRA: [LIVE-32280](https://ledgerhq.atlassian.net/browse/LIVE-32280). 
ADR: none - the key decisions are each cheap to reverse or a sequencing choice, so none
clears the ADR bar.

[LIVE-32280]: https://ledgerhq.atlassian.net/browse/LIVE-32280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ