### PR TITLE
[LWDM] fix(wallet-api): guard undefined spdable balance(LIVE-37189)

### DIFF
--- a/.changeset/guard-undefined-wallet-api-spendable-balance.md
+++ b/.changeset/guard-undefined-wallet-api-spendable-balance.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Guard against a bridge extension returning an undefined spendable balance, which crashed the wallet-api serializer when selecting an Aleo token with no synced sub-account

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__integrations__/tokenWithoutSubAccount.integration.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__integrations__/tokenWithoutSubAccount.integration.test.ts
@@ -1,0 +1,97 @@
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { resolveWalletApiSpendableBalance } from "@ledgerhq/live-common/wallet-api/converters";
+import aleoExtensions from "@ledgerhq/live-common/families/aleo/bridgeExtensions";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { act, renderHook } from "tests/testSetup";
+import { useAddAccountFlowNavigation } from "../useAddAccountFlowNavigation";
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn(),
+}));
+
+jest.mock("../analytics/useAddAccountAnalytics", () => ({
+  __esModule: true,
+  default: () => ({ trackAddAccountEvent: jest.fn() }),
+}));
+
+// The two ARC-22 stablecoins promoted into the production swap whitelist. Aleo token sync is off
+// (`enableTokens: false`), so neither ever has a sub-account: selecting one always makes the
+// drawer build an empty token account on the fly.
+const makeArc22Token = (id: string, ticker: string, programId: string): TokenCurrency =>
+  ({
+    type: "TokenCurrency",
+    id: `aleo/arc22/${id}`,
+    name: ticker,
+    ticker,
+    contractAddress: programId,
+    parentCurrencyId: getCryptoCurrencyById("aleo").id,
+    tokenType: "arc22",
+    units: [{ name: ticker, code: ticker, magnitude: 6 }],
+  }) as TokenCurrency;
+
+const USAD = makeArc22Token("usad", "USAD", "usad_stablecoin.aleo");
+const USDCX = makeArc22Token("usdcx", "USDCx", "usdcx_stablecoin.aleo");
+
+/** Selects `token` in the drawer against `parentAccount`, returning what the drawer hands back. */
+function selectTokenInDrawer(parentAccount: Account, token: TokenCurrency) {
+  const onAccountSelected = jest.fn();
+
+  const { result } = renderHook(() =>
+    useAddAccountFlowNavigation({
+      selectedAccounts: [parentAccount],
+      onAccountSelected,
+      originalCurrency: token,
+    }),
+  );
+
+  act(() => {
+    result.current.navigateToFundAccount(parentAccount);
+  });
+
+  expect(onAccountSelected).toHaveBeenCalledTimes(1);
+  const [account, parent] = onAccountSelected.mock.calls[0] as [AccountLike, Account | undefined];
+  return { account, parent };
+}
+
+describe("selecting an Aleo ARC-22 token with no sub-account", () => {
+  const aleoAccount: Account = genAccount("aleo-1", {
+    currency: getCryptoCurrencyById("aleo"),
+  });
+
+  beforeEach(() => {
+    jest.mocked(getAccountBridge).mockReturnValue(aleoExtensions as never);
+  });
+
+  it.each([
+    ["USAD", USAD],
+    ["USDCx", USDCX],
+  ])("hands back a token account with no transparentBalance for %s", (_ticker, token) => {
+    const { account, parent } = selectTokenInDrawer(aleoAccount, token);
+
+    expect(account.type).toBe("TokenAccount");
+    expect((account as TokenAccount).token.id).toBe(token.id);
+    expect(parent).toBe(aleoAccount);
+    // The shape the crash hinged on: the sync never ran, so the family field is simply absent.
+    expect(account).not.toHaveProperty("transparentBalance");
+  });
+
+  it.each([
+    ["USAD", USAD],
+    ["USDCx", USDCX],
+  ])("resolves a usable wallet-api spendable balance for %s", async (_ticker, token) => {
+    const { account, parent } = selectTokenInDrawer(aleoAccount, token);
+
+    // Same call the account.request / account.list handlers make (wallet-api/react.ts:611, :644).
+    const spendableBalance = await resolveWalletApiSpendableBalance(account, parent);
+
+    // Undefined here is what used to reach the wallet-api serializer and throw
+    // "Cannot read properties of undefined (reading 'toString')". The serializer end of the
+    // chain is covered in live-common's converters.test.ts, which owns that dependency.
+    expect(BigNumber.isBigNumber(spendableBalance)).toBe(true);
+    expect(spendableBalance).toEqual(new BigNumber(0));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useDeviceNavigation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useDeviceNavigation.test.ts
@@ -7,6 +7,18 @@ import {
 import { NavigationProp } from "@react-navigation/native";
 import { ModularDrawerStep } from "../../types";
 import { State } from "~/reducers/types";
+import BigNumber from "bignumber.js";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { resolveWalletApiSpendableBalance } from "@ledgerhq/live-common/wallet-api/converters";
+import aleoExtensions from "@ledgerhq/live-common/families/aleo/bridgeExtensions";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn(),
+}));
 
 const mockNavigate = jest.fn();
 const mockNavigation: Partial<NavigationProp<Record<string, never>>> = {
@@ -109,5 +121,73 @@ describe("useDeviceNavigation", () => {
     expect(mockNavigate).toHaveBeenCalled();
     const callArgs = mockNavigate.mock.calls[0];
     expect(callArgs[1].params.inline).toBe(false);
+  });
+});
+
+// The two ARC-22 stablecoins in the production swap whitelist. Aleo token sync is off
+// (`enableTokens: false`), so neither ever has a sub-account: selecting one always makes the
+// drawer build an empty token account on the fly, exactly like the desktop drawer does.
+const makeArc22Token = (id: string, ticker: string, programId: string): TokenCurrency =>
+  ({
+    type: "TokenCurrency",
+    id: `aleo/arc22/${id}`,
+    name: ticker,
+    ticker,
+    contractAddress: programId,
+    parentCurrencyId: getCryptoCurrencyById("aleo").id,
+    tokenType: "arc22",
+    units: [{ name: ticker, code: ticker, magnitude: 6 }],
+  }) as TokenCurrency;
+
+describe("useDeviceNavigation - Aleo ARC-22 token with no sub-account", () => {
+  const aleoAccount: Account = genAccount("aleo-1", { currency: getCryptoCurrencyById("aleo") });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getAccountBridge).mockReturnValue(aleoExtensions as never);
+  });
+
+  /** Picks `token` in the drawer, then replays the device flow success with `aleoAccount`. */
+  function selectTokenThenAddAccount(token: TokenCurrency) {
+    const onAccountSelected = jest.fn();
+    const { result } = renderHook(() =>
+      useDeviceNavigation({ onClose: jest.fn(), resetSelection: jest.fn(), onAccountSelected }),
+    );
+
+    act(() => result.current.navigateToDeviceWithCurrency(token));
+
+    const { onSuccess } = mockNavigate.mock.calls[0][1].params;
+    act(() => onSuccess({ scannedAccounts: [aleoAccount], selected: [aleoAccount] }));
+
+    expect(onAccountSelected).toHaveBeenCalledTimes(1);
+    return onAccountSelected.mock.calls[0] as [AccountLike, Account | undefined];
+  }
+
+  it.each([
+    ["USAD", makeArc22Token("usad", "USAD", "usad_stablecoin.aleo")],
+    ["USDCx", makeArc22Token("usdcx", "USDCx", "usdcx_stablecoin.aleo")],
+  ])("hands back a token account with no transparentBalance for %s", (_ticker, token) => {
+    const [account, parent] = selectTokenThenAddAccount(token);
+
+    expect(account.type).toBe("TokenAccount");
+    expect((account as TokenAccount).token.id).toBe(token.id);
+    expect(parent).toBe(aleoAccount);
+    // The shape the crash hinged on: the sync never ran, so the family field is simply absent.
+    expect(account).not.toHaveProperty("transparentBalance");
+  });
+
+  it.each([
+    ["USAD", makeArc22Token("usad", "USAD", "usad_stablecoin.aleo")],
+    ["USDCx", makeArc22Token("usdcx", "USDCx", "usdcx_stablecoin.aleo")],
+  ])("resolves a usable wallet-api spendable balance for %s", async (_ticker, token) => {
+    const [account, parent] = selectTokenThenAddAccount(token);
+
+    // Same call the account.request / account.list handlers make (wallet-api/react.ts:611, :644).
+    // Undefined here is what used to reach the wallet-api serializer and throw
+    // "Cannot read properties of undefined (reading 'toString')".
+    const spendableBalance = await resolveWalletApiSpendableBalance(account, parent);
+
+    expect(BigNumber.isBigNumber(spendableBalance)).toBe(true);
+    expect(spendableBalance).toEqual(new BigNumber(0));
   });
 });

--- a/libs/ledger-live-common/src/coin-modules/loaders.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.test.ts
@@ -1,3 +1,9 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockTokenCurrency } from "@domain/entity-currency-token/schema.mock";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { makeEmptyTokenAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { coinModuleLoaders } from "./loaders";
 
 describe("coinModuleLoaders smoke test", () => {
@@ -11,4 +17,39 @@ describe("coinModuleLoaders smoke test", () => {
       });
     }
   }
+});
+
+// What the asset drawer hands to the wallet-api for a token the user has no sub-account for:
+// the generic shape of makeEmptyTokenAccount, without any field a sync would have written.
+const makeDrawerTokenAccount = (parentCurrencyId: string) => {
+  const currency = getCryptoCurrencyById(parentCurrencyId);
+  const parentAccount: Account = genAccount(`contract-${parentCurrencyId}`, { currency });
+
+  return makeEmptyTokenAccount(parentAccount, mockTokenCurrency({ parentCurrencyId: currency.id }));
+};
+
+describe("getWalletApiSpendableBalance contract", () => {
+  it("no family returns undefined for a drawer-built token account", async () => {
+    const offenders: string[] = [];
+
+    for (const { family, supportedCoins, loadBridgeExtensions } of coinModuleLoaders) {
+      const getSpendableBalance = (await loadBridgeExtensions?.())?.getWalletApiSpendableBalance;
+      if (!getSpendableBalance) continue;
+
+      try {
+        // Throwing is a valid answer: resolveWalletApiSpendableBalance catches it and falls back
+        // to the account's own spendableBalance. Returning undefined is not — it flows past the
+        // catch into the wallet-api serializer, which calls .toString() on it unguarded.
+        if (
+          !BigNumber.isBigNumber(getSpendableBalance(makeDrawerTokenAccount(supportedCoins[0])))
+        ) {
+          offenders.push(family);
+        }
+      } catch {
+        // an explicit throw is fine, see above
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
 });

--- a/libs/ledger-live-common/src/families/aleo/bridgeExtensions.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/bridgeExtensions.test.ts
@@ -19,6 +19,17 @@ describe("aleo bridgeExtensions", () => {
       expect(result).toEqual(new BigNumber(123));
     });
 
+    it("falls back to zero when the TokenAccount has no transparentBalance", () => {
+      const tokenAccount = {
+        type: "TokenAccount",
+        token: { parentCurrencyId: mockAccount.currency.id },
+      } as AleoTokenAccount;
+
+      const result = extensions.getWalletApiSpendableBalance?.(tokenAccount);
+
+      expect(result).toEqual(new BigNumber(0));
+    });
+
     it("returns the account's aleoResources.transparentBalance for a main Account", () => {
       const account: AleoAccount = {
         ...mockAccount,

--- a/libs/ledger-live-common/src/families/aleo/bridgeExtensions.ts
+++ b/libs/ledger-live-common/src/families/aleo/bridgeExtensions.ts
@@ -8,8 +8,6 @@ const extensions: AccountBridgeExtensions = {
     invariant(isAleoAccount(account), "aleo: invalid account in bridgeExtensions");
 
     if (account.type === "TokenAccount") {
-      // transparentBalance is only set by the sync; an empty token account built by the asset
-      // drawer has none, so mirror the main-account fallback instead of returning undefined.
       return account.transparentBalance ?? new BigNumber(0);
     }
 

--- a/libs/ledger-live-common/src/families/aleo/bridgeExtensions.ts
+++ b/libs/ledger-live-common/src/families/aleo/bridgeExtensions.ts
@@ -8,7 +8,9 @@ const extensions: AccountBridgeExtensions = {
     invariant(isAleoAccount(account), "aleo: invalid account in bridgeExtensions");
 
     if (account.type === "TokenAccount") {
-      return account.transparentBalance;
+      // transparentBalance is only set by the sync; an empty token account built by the asset
+      // drawer has none, so mirror the main-account fallback instead of returning undefined.
+      return account.transparentBalance ?? new BigNumber(0);
     }
 
     return account.aleoResources?.transparentBalance ?? new BigNumber(0);

--- a/libs/ledger-live-common/src/wallet-api/converters.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.test.ts
@@ -2,6 +2,9 @@ import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import { mockTokenCurrency } from "@domain/entity-currency-token/schema.mock";
 import type { AccountNamesState } from "@domain/entity-account-name";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { makeEmptyTokenAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { serializeAccount } from "@ledgerhq/wallet-api-core";
+import aleoExtensions from "../families/aleo/bridgeExtensions";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import "../__tests__/test-helpers/setup";
@@ -150,6 +153,19 @@ describe("resolveWalletApiSpendableBalance", () => {
     expect(result).toEqual(bridgeSpendableBalance);
   });
 
+  it("falls back to account.spendableBalance when the bridge returns undefined", async () => {
+    // Given
+    mockGetAccountBridge.mockResolvedValue({
+      getWalletApiSpendableBalance: jest.fn().mockReturnValue(undefined),
+    } as never);
+
+    // When
+    const result = await resolveWalletApiSpendableBalance(account);
+
+    // Then
+    expect(result).toEqual(account.spendableBalance);
+  });
+
   it("falls back to account.spendableBalance and logs when the bridge lookup fails", async () => {
     // Given
     mockGetAccountBridge.mockRejectedValue(new Error("unsupported family"));
@@ -165,6 +181,33 @@ describe("resolveWalletApiSpendableBalance", () => {
       expect.stringContaining("falling back to account.spendableBalance"),
       { error: "unsupported family" },
     );
+  });
+});
+
+// The crash this guards against only shows up once the three real pieces are chained: the family
+// extension, the converter funnel, and the wallet-api serializer that calls .toString() on what
+// they produce. Each one alone is green. Only the bridge lookup is stubbed, with the real
+// extension behind it.
+describe("wallet-api serialization of a drawer-built token account", () => {
+  it("serializes an Aleo ARC-22 token account that has no sub-account", async () => {
+    // Given: what the asset drawer builds for a token the user holds no sub-account for
+    const parentAccount = makeMainAccount("aleo-parent");
+    const tokenAccount = makeEmptyTokenAccount(
+      parentAccount,
+      mockTokenCurrency({ parentCurrencyId: getCryptoCurrencyById("aleo").id }),
+    );
+    mockGetAccountBridge.mockResolvedValue(aleoExtensions as never);
+
+    // When: the account.request / account.list handler shape (see react.ts)
+    const spendableBalance = await resolveWalletApiSpendableBalance(tokenAccount, parentAccount);
+    const walletApiAccount = {
+      ...accountToWalletAPIAccount(walletState, tokenAccount, parentAccount),
+      spendableBalance,
+    };
+
+    // Then: the real serializer must not blow up on an undefined balance
+    expect(() => serializeAccount(walletApiAccount)).not.toThrow();
+    expect(serializeAccount(walletApiAccount).spendableBalance).toBe("0");
   });
 });
 

--- a/libs/ledger-live-common/src/wallet-api/converters.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.ts
@@ -150,7 +150,10 @@ export async function resolveWalletApiSpendableBalance(
 ): Promise<BigNumber> {
   try {
     const bridge = await getAccountBridge(account, parentAccount);
-    return bridge.getWalletApiSpendableBalance(account);
+    // A family extension can return undefined for an account shape it did not expect (e.g. an
+    // empty token account built on the fly by the asset drawer). Undefined would reach the
+    // wallet-api serializer, which calls .toString() on it unguarded.
+    return bridge.getWalletApiSpendableBalance(account) ?? account.spendableBalance;
   } catch (error) {
     log(
       "wallet-api/converters",

--- a/libs/ledger-live-common/src/wallet-api/converters.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.ts
@@ -150,9 +150,6 @@ export async function resolveWalletApiSpendableBalance(
 ): Promise<BigNumber> {
   try {
     const bridge = await getAccountBridge(account, parentAccount);
-    // A family extension can return undefined for an account shape it did not expect (e.g. an
-    // empty token account built on the fly by the asset drawer). Undefined would reach the
-    // wallet-api serializer, which calls .toString() on it unguarded.
     return bridge.getWalletApiSpendableBalance(account) ?? account.spendableBalance;
   } catch (error) {
     log(


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Selecting the Aleo ARC-22 tokens USAD or USDCx as a swap asset failed in Ledger Wallet Desktop, with the swap live app logging:

error fetching account TypeError: Cannot read properties of undefined (reading 'toString')

For a token the user holds no sub-account for, the asset drawer fabricates an empty one (getAccountToReturn → makeEmptyTokenAccount), which is a generic TokenAccount carrying no family-specific fields.

### 🔗 Context

- **JIRA / GitHub issue**:  https://ledgerhq.atlassian.net/browse/LIVE-37189
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
