### PR TITLE
ci(e2e): fix team selection and update skill with new input

### DIFF
--- a/.agents/skills/run-e2e-ci/SKILL.md
+++ b/.agents/skills/run-e2e-ci/SKILL.md
@@ -16,11 +16,21 @@ description: Trigger the on-demand E2E / Coin Tester CI workflows (Desktop E2E, 
 | One coin module (`libs/coin-modules/coin-solana`) | `test_filter=@solana` + Coin Tester `chain=solana` |
 | A coin family (`**/families/evm`) | `test_filter=@family-evm` (or `@generic-coin-framework`) |
 | A specific spec / flow (`swap`, `subAccount`, `newSendFlow`) | `test_filter` with the tag or spec path |
+| Everything one team owns | `team=<slug>` — **ANDs** with `test_filter`, Smoke and the device |
 | Platform-specific (Android manifest, iOS plist) | narrow Mobile `tests_type` (`Android Only` / `iOS Only`); skip the other surfaces |
 | Desktop-only or Mobile-only change | run only that surface; skip the others + Coin Tester |
 | Shared / cross-cutting (build tooling, TS upgrade, currency core) | full suite — **and add a one-line rationale** |
 
 Filter tags: `@bitcoin`, `@family-evm`, `@solana`, `@generic-coin-framework`, `@smoke`, … See the [test-filter guide](../../../e2e/tooling/filter/test-filter-guide.md) for the grammar and the mobile (whole spec files by path/`@`-tag) vs desktop (test titles) matching difference.
+
+**`team` vs `test_filter`.** `test_filter` is an **OR** over its patterns; the `team` dropdown is an **AND** that narrows the run to one team's specs. Combine them: `team=bst` + `test_filter=@bitcoin` runs only the bitcoin specs BST owns. Slugs: `bst`, `buy-and-sell`, `coin-integration`, `earn`, `engagement`, `swap`, `wallet-xp` (`all` is the default and changes nothing). List them with their spec counts:
+
+```bash
+node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/desktop/tests --runner playwright
+node e2e/tooling/filter/resolve.mjs --list-teams --check-dir e2e/mobile/specs  --runner detox
+```
+
+Selection is per spec **file**, so a spec two teams share runs for both. `bst` and `coin-integration` each own about half the suite — pair those with a coin tag or you have not narrowed much. Do **not** put `@team-<slug>` in `test_filter`: it is rejected, with a message pointing at the dropdown.
 
 ## Dispatch
 
@@ -36,6 +46,11 @@ CHAIN=<derived-chain>  # e.g. "solana" or "evm,solana" — derive from the diff;
 # Filtered runs (preferred). Narrow tests_type when the change is platform-specific.
 gh workflow run test-ui-e2e-only-desktop.yml --ref "$BR" -f test_filter="$TAGS"
 gh workflow run test-mobile-e2e-reusable.yml --ref "$BR" -f test_filter="$TAGS" -f tests_type="iOS & Android" -f speculos_device=nanoX
+
+# Scope to one team (optional, ANDs with the filter above). Omit -f team for the default "all".
+gh workflow run test-ui-e2e-only-desktop.yml --ref "$BR" -f team=swap -f test_filter="$TAGS"
+gh workflow run test-mobile-e2e-reusable.yml --ref "$BR" -f team=swap -f test_filter="$TAGS" -f tests_type="iOS & Android" -f speculos_device=nanoX
+
 gh workflow run test-coin-tester.yml --ref "$BR" -f chain="$CHAIN"   # or omit -f chain to auto-detect affected coins
 
 gh run list --branch "$BR" --limit 6   # grab the run IDs
@@ -43,7 +58,21 @@ gh run list --branch "$BR" --limit 6   # grab the run IDs
 
 Mobile **requires** `tests_type` (`Android Only`|`iOS Only`|`iOS & Android`) and `speculos_device` (`nanoS`|`nanoSP`|`nanoX`|`stax`|`flex`|`nanoGen5`). Desktop defaults to Speculos nanoSP. Coin Tester auto-detects affected coins (or `-f chain="evm,solana"`).
 
-**Verify the filter took effect:** open the run's Summary → **Resolved filtered pattern** and confirm it matched specs. A filter that matches 0 specs is wasted — on **Mobile** the test jobs are skipped, on **Desktop** the run **fails** ("No tests executed") — and `resolve.mjs` emits a "filter has no matches" warning. Fix the filter and re-dispatch.
+`team` is optional on both and defaults to `all`. Some combinations are refused outright, failing the run in the first minute rather than running the wrong thing:
+
+- **`invert_filter` with `team`, or with `smoke_tests`.** `--grep-invert` is applied to the whole pattern, so anything the resolver folds into it is inverted too: with a team you get every *other* team's specs, and with Smoke you get the whole suite *minus* the smoke tests. Invert only ever applies to `test_filter`, so use it alone.
+- **`@team-<slug>` typed into `test_filter`.** Use the dropdown; the error says so.
+
+`-f team=` only exists on branches that already carry the input — a branch cut before it landed will reject the flag.
+
+**Verify the filter took effect:** open the run's Summary → **Workflow Context**. Desktop prints **Filtered pattern**; Mobile prints both **Filtered pattern** (your raw input) and **Resolved filtered pattern** (what the runner selects with). Both print a **Team** line.
+
+A filter that matches 0 specs is wasted, and the failure mode depends on whether a team is set:
+
+- **No team** — `resolve.mjs` warns "filter has no matches"; on **Mobile** the test jobs are then skipped and the run still reports success, on **Desktop** it **fails** ("No tests executed").
+- **With a team** — an empty selection, an unknown team, or a team that owns nothing on that app is a **hard error in the first minute**, before any build. Look for `E2E selection is empty` or `Unknown E2E team`. A team that owns nothing on the app you dispatched is the easy way to hit this — check with `--list-teams` first.
+
+Fix the filter and re-dispatch.
 
 ## Post the run on the PR
 
@@ -56,8 +85,8 @@ Manually dispatched on `<branch>` (commit <short-sha>, `git rev-parse --short HE
 
 | Workflow | Scope | Run |
 |---|---|---|
-| [Desktop] E2E Only | `<@tag>` filter, Speculos nanoSP | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
-| [Mobile] E2E Only | `<@tag>` filter, <tests_type>, nanoX | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
+| [Desktop] E2E Only | `<@tag>` filter + `team=<slug>`, Speculos nanoSP | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
+| [Mobile] E2E Only | `<@tag>` filter + `team=<slug>`, <tests_type>, nanoX | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
 | [Coin] Test Coin modules | `chain=<...>` (or affected coins) | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
 
 Scope rationale: <which surfaces changed, what you filtered to, and why the rest were skipped>.

--- a/.agents/skills/run-e2e-ci/SKILL.md
+++ b/.agents/skills/run-e2e-ci/SKILL.md
@@ -70,7 +70,7 @@ Mobile **requires** `tests_type` (`Android Only`|`iOS Only`|`iOS & Android`) and
 A filter that matches 0 specs is wasted, and the failure mode depends on whether a team is set:
 
 - **No team** — `resolve.mjs` warns "filter has no matches"; on **Mobile** the test jobs are then skipped and the run still reports success, on **Desktop** it **fails** ("No tests executed").
-- **With a team** — an empty selection, an unknown team, or a team that owns nothing on that app is a **hard error in the first minute**, before any build. Look for `E2E selection is empty` or `Unknown E2E team`. A team that owns nothing on the app you dispatched is the easy way to hit this — check with `--list-teams` first.
+- **With a team** — unknown teams and teams that own nothing fail in the first minute (look for `Unknown E2E team` / `E2E selection is empty`). On **Mobile**, an empty team ∩ filter is also a hard error (`E2E selection is empty`). On **Desktop**, the resolver can only warn when the team ∩ filter looks empty; the run may still proceed and fail later with "No tests executed".
 
 Fix the filter and re-dispatch.
 

--- a/e2e/tooling/filter/resolve.mjs
+++ b/e2e/tooling/filter/resolve.mjs
@@ -14,6 +14,10 @@ import { TEAM_SLUGS, createTeamExpander } from "./teamSpecs.mjs";
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
 const repoRoot = path.resolve(currentDir, "../../..");
+
+function useRepoRootCwd() {
+  if (process.cwd() !== repoRoot) process.chdir(repoRoot);
+}
 const genericCoinFrameworkFamiliesPath = path.join(
   repoRoot,
   "libs/ledger-live-common/src/bridge/generic-coin-framework/genericCoinFrameworkFamilies.json",
@@ -120,7 +124,10 @@ function warnZeroMatches(checkDir, files, baseFilter, expandedTags, runner) {
   const isDetox = runner === "detox";
 
   if (files.length === 0) {
-    console.warn(`::warning title=E2E filter check skipped::No test files found in ${checkDir}`);
+    console.warn(
+      `::warning title=E2E filter check skipped::No test files found in ` +
+        `${path.resolve(repoRoot, checkDir)} (--check-dir "${checkDir}")`,
+    );
     return;
   }
 
@@ -182,7 +189,8 @@ export function resolveE2eSelection({
   invertFilter = false,
 } = {}) {
   const isDetox = runner === "detox";
-  const specRoot = checkDir ? path.resolve(repoRoot, checkDir) : "";
+  useRepoRootCwd();
+  const specRoot = checkDir;
   const specFiles = specRoot ? findSpecFiles(specRoot) : []; // scanned ONCE, reused below
 
   const selectedTeam = String(team ?? "")
@@ -210,11 +218,12 @@ export function resolveE2eSelection({
     ok = false;
   }
 
-  if (hasTeam && invertFilter) {
-    // The composite applies --grep-invert to the whole pattern, team conjunct included, so this
-    // would run every OTHER team's specs — the exact opposite of what the dropdown promises.
+  if (invertFilter && (hasTeam || smokeTests)) {
+    const conflicting = [hasTeam && `team=${selectedTeam}`, smokeTests && "smoke_tests"]
+      .filter(Boolean)
+      .join(" and ");
     console.warn(
-      `::error title=E2E team filter cannot be inverted::team=${selectedTeam} with invert_filter=true would run every other team's specs; drop one of the two`,
+      `::error title=E2E filter cannot be inverted::invert_filter applies to the whole pattern, so ${conflicting} would be inverted too — drop invert_filter, or drop ${conflicting}`,
     );
     ok = false;
   }
@@ -333,26 +342,55 @@ function parseArgs(args) {
     listTeams: false,
   };
 
+  const seen = new Set();
+  let positional = false;
+  const value = i => {
+    const next = args[i + 1];
+    if (next === undefined || next.startsWith("-")) {
+      console.error(`${args[i]} requires a value`);
+      process.exit(1);
+    }
+    return next;
+  };
+  const once = flag => {
+    if (seen.has(flag)) {
+      console.error(`${flag} given more than once`);
+      process.exit(1);
+    }
+    seen.add(flag);
+  };
+
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
+    if (arg.startsWith("-")) once(arg);
     switch (arg) {
       case "--input":
-        parsed.input = args[++i] ?? "";
+        if (positional) {
+          console.error(`--input conflicts with the filter already given as a positional argument`);
+          process.exit(1);
+        }
+        parsed.input = value(i);
+        i += 1;
         break;
       case "--smoke-tests":
-        parsed.smokeTests = args[++i] === "true";
+        parsed.smokeTests = value(i) === "true";
+        i += 1;
         break;
       case "--check-dir":
-        parsed.checkDir = args[++i] ?? "";
+        parsed.checkDir = value(i);
+        i += 1;
         break;
       case "--runner":
-        parsed.runner = args[++i] ?? "playwright";
+        parsed.runner = value(i);
+        i += 1;
         break;
       case "--team":
-        parsed.team = args[++i] ?? "";
+        parsed.team = value(i);
+        i += 1;
         break;
       case "--invert-filter":
-        parsed.invertFilter = args[++i] === "true";
+        parsed.invertFilter = value(i) === "true";
+        i += 1;
         break;
       case "--github-output":
         parsed.githubOutput = true;
@@ -361,7 +399,18 @@ function parseArgs(args) {
         parsed.listTeams = true;
         break;
       default:
-        if (!parsed.input) parsed.input = arg;
+        if (arg.startsWith("-")) {
+          console.error(
+            `Unknown option ${arg}. Valid: --input --smoke-tests --check-dir --runner --team --invert-filter --github-output --list-teams`,
+          );
+          process.exit(1);
+        }
+        if (positional || seen.has("--input")) {
+          console.error(`Unexpected extra argument ${arg} — the filter was already given`);
+          process.exit(1);
+        }
+        positional = true;
+        parsed.input = arg;
         break;
     }
   }
@@ -379,6 +428,7 @@ function formatGithubOutput(values) {
 }
 
 if (process.argv[1] === currentFile) {
+  useRepoRootCwd();
   const options = parseArgs(process.argv.slice(2));
 
   if (options.listTeams) {
@@ -390,12 +440,13 @@ if (process.argv[1] === currentFile) {
       );
       process.exit(1);
     }
-    const specRoot = path.resolve(repoRoot, options.checkDir);
+    const specRoot = options.checkDir;
     const files = findSpecFiles(specRoot);
     if (files.length === 0) {
       // Distinguish a typo from a real but empty tree: both are useless to report counts for.
       console.error(
-        `No .spec.ts files under ${options.checkDir} (resolved to ${specRoot}) — check the path.`,
+        `No .spec.ts files under ${path.resolve(repoRoot, options.checkDir)} ` +
+          `(--check-dir "${options.checkDir}") — check the path.`,
       );
       process.exit(1);
     }

--- a/e2e/tooling/filter/teamSpecs.mjs
+++ b/e2e/tooling/filter/teamSpecs.mjs
@@ -171,8 +171,12 @@ function collapseToDirectories(teamPaths, allPaths, rootRel) {
 export function createTeamExpander({ files, specRoot, runner }) {
   const index = buildTeamIndex(files);
   const isDetox = runner === "detox";
-  const rootRel = path.relative(repoRoot, specRoot).replaceAll(path.sep, "/");
-  const toRel = filePath => path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+  // Reading the spec files themselves still assumes the process is at the repo root; resolve.mjs
+  // guarantees that with useRepoRootCwd().
+  const repoRelative = target =>
+    path.relative(repoRoot, path.resolve(repoRoot, target)).replaceAll(path.sep, "/");
+  const rootRel = repoRelative(specRoot);
+  const toRel = filePath => repoRelative(filePath);
   const allRel = files.map(toRel);
 
   return {

--- a/e2e/tooling/filter/test-filter-guide.md
+++ b/e2e/tooling/filter/test-filter-guide.md
@@ -68,10 +68,12 @@ Things worth knowing before you rely on it:
 - **The dropdown is single-select.** To cover several teams in one go, filter on something they
   share (a path or coin tag) or dispatch once per team.
 - **An unknown team, an empty team ∩ filter, or a team that owns nothing on that app fails the run
-  immediately**, with the valid list printed. It never falls back to running everything —
-  `engagement` owns no desktop spec today, so picking it on Desktop is always an error.
-- **`team` and `invert_filter` cannot be combined.** Inversion is applied to the whole pattern, so
-  "only earn" would become "everything except earn". The run fails in the first minute instead.
+  immediately**, with the valid list printed. It never falls back to running everything. Team
+  ownership differs per app, so check `--list-teams` for the app you are dispatching.
+- **`invert_filter` cannot be combined with `team` or with Smoke.** Inversion is applied to the whole
+  pattern, so anything added to it is inverted too: with a team you would get every *other* team's
+  specs, and with Smoke the whole suite *minus* the smoke tests. Invert applies to `test_filter`
+  only — the run fails in the first minute instead.
 - **A spec can have more than one owning team**, because ownership is recorded per test — the
   shared send/addAccount flows are split per currency between `bst` and `coin-integration`.
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR updates the E2E filter resolver and its documentation to better support team-based scoping, improve error messaging, and align the run-e2e-ci skill docs with the newer team input behavior.

### 🔗 Context

- Desktop
  - [all](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/c899c0af-c90e-4407-9490-6da5c53daee7/)
  - [swap](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/3aab1f8e-4c1a-4b89-90d4-5a8ce8dc9f63/)

- Mobile
  - [all](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/383d9902-f758-49a3-84b7-61d0f37d06ad/)
  - [swap](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/a17e44b7-e518-401e-b698-76c3371f974e/#suites/781e6ae56075cf16fbb9816d64f30f59/2bcd10768eaf5b9d/)
