### PR TITLE
[LWDM] fix(tezos): bump coin-tezos to 10.2.4 to fix stake fee estimation

### DIFF
--- a/.changeset/swift-badgers-thread.md
+++ b/.changeset/swift-badgers-thread.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Pass the coin-tezos context to the baker lookups, which now resolve the config themselves instead of taking a resolved one

--- a/libs/ledger-live-common/src/families/tezos/bakers.ts
+++ b/libs/ledger-live-common/src/families/tezos/bakers.ts
@@ -1,7 +1,6 @@
 import type { AccountLike } from "@ledgerhq/types-live";
 import { loadBaker } from "@ledgerhq/coin-tezos/network/bakers";
-import type { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
-import { getCurrencyConfiguration } from "../../config";
+import { buildContext } from "../../bridge/generic-coin-framework/api/context";
 import type { Delegation } from "./types";
 
 export function getAccountDelegationSync(account: AccountLike): Delegation | null | undefined {
@@ -42,9 +41,6 @@ export async function loadAccountDelegation(
 ): Promise<Delegation | null | undefined> {
   const delegation = getAccountDelegationSync(account);
   if (!delegation) return null;
-  const baker = await loadBaker(
-    getCurrencyConfiguration<TezosCoinConfig>("tezos"),
-    delegation.address,
-  );
+  const baker = await loadBaker(buildContext("tezos"), delegation.address);
   return { ...delegation, baker };
 }

--- a/libs/ledger-live-common/src/families/tezos/react.ts
+++ b/libs/ledger-live-common/src/families/tezos/react.ts
@@ -3,8 +3,7 @@ import BigNumber from "bignumber.js";
 import { useEffect, useMemo, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import { bakers } from "@ledgerhq/coin-tezos/network/index";
-import type { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
-import { getCurrencyConfiguration } from "../../config";
+import { buildContext } from "../../bridge/generic-coin-framework/api/context";
 import {
   isDelegationPosition,
   isFinalizablePosition,
@@ -22,9 +21,7 @@ export function useBakers(whitelistAddresses: string[]): Baker[] {
     bakers.listBakersWithDefault(whitelistAddresses),
   );
   useEffect(() => {
-    bakers
-      .listBakers(getCurrencyConfiguration<TezosCoinConfig>("tezos"), whitelistAddresses)
-      .then(setWhitelistedBakers);
+    bakers.listBakers(buildContext("tezos"), whitelistAddresses).then(setWhitelistedBakers);
   }, [whitelistAddresses]);
 
   return whitelistedBakers;
@@ -69,7 +66,7 @@ export function useBaker(addr: string): Baker | undefined {
     }
     let cancelled = false;
     bakers
-      .loadBaker(getCurrencyConfiguration<TezosCoinConfig>("tezos"), addr)
+      .loadBaker(buildContext("tezos"), addr)
       .then(b => {
         if (cancelled) return;
         setBaker(b);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: 9.6.0
       version: 9.6.0
     '@ledgerhq/coin-tezos':
-      specifier: 10.2.2
-      version: 10.2.2
+      specifier: 10.2.4
+      version: 10.2.4
     '@ledgerhq/coin-xrp':
       specifier: 10.1.0
       version: 10.1.0
@@ -11857,7 +11857,7 @@ importers:
         version: link:../../coin-tester
       '@ledgerhq/coin-tezos':
         specifier: 'catalog:'
-        version: 10.2.2
+        version: 10.2.4
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -13064,7 +13064,7 @@ importers:
         version: link:../coin-modules/coin-sui
       '@ledgerhq/coin-tezos':
         specifier: 'catalog:'
-        version: 10.2.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)
+        version: 10.2.4(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/coin-ton':
         specifier: workspace:^
         version: link:../coin-modules/coin-ton
@@ -18465,7 +18465,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -22240,17 +22240,21 @@ packages:
     peerDependencies:
       '@ledgerhq/live-network': ^3.0.0
 
+  '@ledgerhq/coin-module-framework@8.5.0':
+    resolution: {integrity: sha512-wIEcjk0BZAsDTEIgYEyiTsoeP0J6GXkVVUHfzzIZ8/n+mWCIhu2K0JDoKHNi2sovteCd6Mxw+aoLk/9kmI6e4w==}
+    peerDependencies:
+      '@ledgerhq/live-network': ^3.0.0
+
   '@ledgerhq/coin-stellar@9.6.0':
     resolution: {integrity: sha512-r1Pi5nZ/bvNDbHvMkJVq5PnSoA05wv5+mS8TryCTVNh5BKfPlr4MnFVKDjTV7NWxPYGCHcrChAO9IA1Ri8uA5w==}
     peerDependencies:
       '@ledgerhq/live-network': ^3.0.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/coin-tezos@10.2.2':
-    resolution: {integrity: sha512-yFQQ7adR6xJG0Mv5U9YHEzyv0xP3IdGWuTNAFlEnX9njp6me2y/gZl2+GI2pBpWscIRVqqzjaxkHfB/qdLiw4A==}
+  '@ledgerhq/coin-tezos@10.2.4':
+    resolution: {integrity: sha512-qgBV3NeQSGMPJIbbF8wAor6RRKRLUAF7UZr4e7pC8Br02GYdggqCgXYYRIKApLeWGzhdHQJKaFg4GSnv8fiYRA==}
     peerDependencies:
       '@ledgerhq/live-network': ^3.0.0
-      '@ledgerhq/logs': ^6.17.0
 
   '@ledgerhq/coin-xrp@10.1.0':
     resolution: {integrity: sha512-qkKVgvmJEdGhkIs3Om8X9IQCNGa9w73vdN2CSMT6J/4Je/i8+S/RYEIBiFLe9+0J8wNcEUYr9oxIfIUztQ5XLw==}
@@ -47673,6 +47677,15 @@ snapshots:
       '@ledgerhq/live-network': link:libs/live-network
       bignumber.js: 9.1.2
 
+  '@ledgerhq/coin-module-framework@8.5.0':
+    dependencies:
+      bignumber.js: 9.1.2
+
+  '@ledgerhq/coin-module-framework@8.5.0(@ledgerhq/live-network@libs+live-network)':
+    dependencies:
+      '@ledgerhq/live-network': link:libs/live-network
+      bignumber.js: 9.1.2
+
   '@ledgerhq/coin-stellar@9.6.0(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
     dependencies:
       '@exodus/patch-broken-hermes-typed-arrays': 1.0.0-alpha.1(patch_hash=7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732)
@@ -47684,9 +47697,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ledgerhq/coin-tezos@10.2.2':
+  '@ledgerhq/coin-tezos@10.2.4':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.4.0
+      '@ledgerhq/coin-module-framework': 8.5.0
       '@taquito/ledger-signer': 23.0.1
       '@taquito/rpc': 23.0.1
       '@taquito/taquito': 23.0.1
@@ -47694,11 +47707,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@ledgerhq/coin-tezos@10.2.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
+  '@ledgerhq/coin-tezos@10.2.4(@ledgerhq/live-network@libs+live-network)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.4.0(@ledgerhq/live-network@libs+live-network)
+      '@ledgerhq/coin-module-framework': 8.5.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network': link:libs/live-network
-      '@ledgerhq/logs': 6.19.0
       '@taquito/ledger-signer': 23.0.1
       '@taquito/rpc': 23.0.1
       '@taquito/taquito': 23.0.1
@@ -65259,7 +65271,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -215,7 +215,7 @@ catalog:
   "@ledgerhq/coin-hypercore": 2.0.1
   "@ledgerhq/coin-module-framework": 8.4.0
   "@ledgerhq/coin-stellar": 9.6.0
-  "@ledgerhq/coin-tezos": 10.2.2
+  "@ledgerhq/coin-tezos": 10.2.4
   "@ledgerhq/coin-xrp": 10.1.0
   detox: 20.51.3
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Opening Stake or toggling Use Max on a Tezos account failed fee estimation with a raw `(500) … stake_amount_too_small`. The fix is in coin-tezos, published as 10.2.4 (LedgerHQ/coin-modules#873); this bumps the catalog pin so it reaches the apps. The error copy merged in #21685 and stays inert until this lands. Regression tests live with the fix; the guard here is the build.

10.2.4 also carries 10.2.3, which never reached npm: it moved the baker lookups from a resolved config to the module context (LedgerHQ/coin-modules#876), so the two live-common call sites follow. Skipping them fails live-common's build — that is what reddened the bot's #21727, which this PR supersedes (it contains the same bump commit) and which can be closed.

Review note: the catalog still pins `@ledgerhq/coin-module-framework` 8.4.0 while 10.2.4 wants `^8.5.0`, so the lockfile transiently holds both. #21699 moves the pin and `coin-tezos@10.2.2` is that PR's only 8.4.0 consumer, so merging both collapses to a single 8.5.0; the two `config.d.ts` are byte-identical.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37117](https://ledgerhq.atlassian.net/browse/LIVE-37117)
- **ADR** (if any): ADR-019 — the coin-module context the baker lookups now take. No new ADR for this PR.


[LIVE-37117]: https://ledgerhq.atlassian.net/browse/LIVE-37117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ