### PR TITLE
feat(contacts): use @shared/i18n in feature packages (LIVE-37080)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { DialogFlow, type DialogFlowScreenRegistry } from "LLD/components/DialogFlow";
 import { ModularDialogFlow } from "LLD/features/ModularDialog/ModularDialogFlow";
 import {
@@ -11,10 +12,7 @@ import type { ContactsAddAddressFlowDialogProps } from "./types";
 
 export function ContactsAddAddressFlowDialog({
   state,
-  entryLabels,
   sanctionedAddressBanner,
-  nameLabels,
-  reviewLabels,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -23,6 +21,7 @@ export function ContactsAddAddressFlowDialog({
   onBack,
   onClose,
 }: ContactsAddAddressFlowDialogProps): React.JSX.Element | null {
+  const { t } = useTranslation();
   if (state.status === "closed") {
     return null;
   }
@@ -33,15 +32,13 @@ export function ContactsAddAddressFlowDialog({
     <ModularDialogFlow fillAvailableHeight={isSelectingCurrency} onClose={onClose}>
       {modularDialog => {
         const currentStep = resolveAddAddressWebFlowStep(state);
+        const entryTitle = t("contacts.addAddressEntry.title");
         const flowContent =
           state.status === "selectingCurrency" ? (
             modularDialog.content
           ) : (
             <ContactsAddAddressFlowContent
-              entryLabels={entryLabels}
               sanctionedAddressBanner={sanctionedAddressBanner}
-              nameLabels={nameLabels}
-              reviewLabels={reviewLabels}
               onAddressChange={onAddressChange}
               onAddressLabelChange={onAddressLabelChange}
               onContinueFromAddressDetails={onContinueFromAddressDetails}
@@ -65,28 +62,28 @@ export function ContactsAddAddressFlowDialog({
           address: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: true,
             },
           },
           name: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: true,
             },
           },
           review: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: true,
             },
           },
           success: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: false,
             },
           },

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
@@ -1,18 +1,12 @@
 import type {
-  AddAddressEntryLabels,
   AddAddressFlowState,
   AddAddressInputSource,
-  ContactsAddAddressNameLabels,
-  ContactsAddAddressReviewLabels,
   SanctionedAddressBannerProps,
 } from "@features/flow-contacts-add-address";
 
 export type ContactsAddAddressFlowDialogProps = Readonly<{
   state: AddAddressFlowState;
-  entryLabels: AddAddressEntryLabels;
   sanctionedAddressBanner: SanctionedAddressBannerProps;
-  nameLabels: ContactsAddAddressNameLabels;
-  reviewLabels: ContactsAddAddressReviewLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
@@ -1,12 +1,7 @@
-import {
-  type Contact,
-  DUPLICATE_CONTACT_NAME_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
-} from "@domain/entity-contact";
+import type { Contact } from "@domain/entity-contact";
 import { type AddContactAppAdapterResult, useAddContactAppAdapter } from "@features/flow-contacts";
 import { createContactCreationPort } from "@features/flow-contacts-add-contact";
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import { v4 as uuid } from "uuid";
 import { useDispatch } from "LLD/hooks/redux";
 import { useContactsAnalytics } from "../../analytics";
@@ -15,30 +10,15 @@ export function useAddContactDialogAdapter(
   onSaveSuccess: (contact: Contact) => void,
 ): AddContactAppAdapterResult {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
   const analytics = useContactsAnalytics();
   const contactCreation = useMemo(
     () => createContactCreationPort({ dispatch, generateId: uuid }),
     [dispatch],
-  );
-  const labels = useMemo(
-    () => ({
-      title: t("contacts.addContact"),
-      namePlaceholder: t("contacts.addContactDrawer.namePlaceholder"),
-      namingDisclaimer: t("contacts.addContactDrawer.namingDisclaimer"),
-      confirmName: t("contacts.addContact"),
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.invalidNameError"),
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
-      },
-    }),
-    [t],
   );
 
   return useAddContactAppAdapter({
     analytics,
     contactCreation,
     onSaveSuccess,
-    labels,
   });
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
@@ -1,7 +1,6 @@
 import { ContactIdSchema, type ContactId } from "@domain/entity-contact";
 import {
   type ContactsEditSignerMismatchDialogProps,
-  type ContactDetailActionsLabels,
   createContactDetailEditDeleteUiState,
   resolveContactDetailEditDeleteLabels,
   useContactDetailEditDeleteAnalytics,
@@ -18,7 +17,6 @@ import { useContactsAnalytics } from "../../analytics";
 export type ContactDetailEditDeleteDialogProps = Readonly<{
   detailActions?: Readonly<{
     canDelete: boolean;
-    labels: ContactDetailActionsLabels;
     onEdit: () => void;
     onDelete: () => void;
   }>;
@@ -56,7 +54,6 @@ export function useContactDetailEditDeleteAdapter(
     detailActions: contactId
       ? {
           canDelete: flow.canDelete,
-          labels: labels.actions,
           onEdit,
           onDelete,
         }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router";
 import { ContactIdSchema, type ContactId } from "@domain/entity-contact";
 import {
-  createMeDisplayNameFormatter,
   useContacts,
   useContactsMeContact,
   type ContactDeviceIntentsPort,
@@ -15,7 +14,6 @@ import {
   useContactAddressDetailDialog,
   type ContactAddressDetailDialogLabels,
   type ContactAddressDetailDialogProps,
-  type ContactDetailLabels,
   type ContactDetailViewProps,
   type ContactsViewProps,
   CONTACTS_EVENT_SOURCE,
@@ -94,26 +92,7 @@ export function useContactDetailPaneAdapter(
     addressDetailAsset,
     addressDetailNetwork,
   );
-  const labels = useMemo<ContactDetailLabels>(
-    () => ({
-      addAddress: t("contacts.addAddress"),
-      addYourAddress: t("contacts.addYourAddress"),
-      emptyMeTitle: t("contacts.detail.emptyState.meTitle"),
-      emptyContactTitle: name => t("contacts.detail.emptyState.contactTitle", { name }),
-      emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
-      emptyContactDescription: () => t("contacts.detail.emptyState.contactDescription"),
-      ledgerWalletAddresses: t("contacts.detail.ledgerWalletAddresses"),
-      formatMeDisplayName: createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
-        t("contacts.detail.meDisplayName", { name }),
-      ),
-      formatAddressCount: count => t("contacts.addressCount", { count }),
-    }),
-    [t],
-  );
-  const detailSharedState = useContactDetailSharedState(
-    detailContactId,
-    labels.formatMeDisplayName,
-  );
+  const detailSharedState = useContactDetailSharedState(detailContactId);
   const addressDetailDialogLabels = useMemo<ContactAddressDetailDialogLabels>(
     () => ({
       send: t("contacts.addressDetail.send"),
@@ -161,7 +140,6 @@ export function useContactDetailPaneAdapter(
     }
 
     return {
-      labels,
       meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
       contact,
       onAddAddress: () => handleAddAddress(contact),
@@ -180,7 +158,6 @@ export function useContactDetailPaneAdapter(
     emptyContact,
     editDeleteDialogs.detailActions,
     handleAddAddress,
-    labels,
     onLedgerWalletAccountsPress,
     onAddressRowPress,
     populatedContactDetail,

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -5,19 +5,11 @@ import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
 import { v4 as uuid } from "uuid";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  addAddress,
-  contactAddress,
-  type ContactId,
-} from "@domain/entity-contact";
+import { addAddress, contactAddress, type ContactId } from "@domain/entity-contact";
 import {
   createContactsListViewModel,
   createContactsSearchViewModel,
   type ContactAddressDetailDialogProps,
-  type ContactsListViewLabels,
   CONTACTS_EVENT_SOURCE,
   CONTACTS_FLOW,
   CONTACTS_PAGE_PROPERTY,
@@ -32,10 +24,7 @@ import {
   useAddAddressCurrencySelectionViewModel,
   useAddAddressFlowViewModel,
   type AddAddressContact,
-  type AddAddressEntryLabels,
   type AddAddressFlowState,
-  type ContactsAddAddressNameLabels,
-  type ContactsAddAddressReviewLabels,
 } from "@features/flow-contacts-add-address";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
@@ -300,61 +289,14 @@ export function useContactsViewModel(): ContactsPageViewModel {
     goBackAddAddress();
     selectCurrencyForContact(selectedContactId);
   }, [addAddressFlowState, goBackAddAddress, selectCurrencyForContact]);
-  const addAddressEntryLabels = useMemo<AddAddressEntryLabels>(
-    () => ({
-      title: t("contacts.addAddressEntry.title"),
-      addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-      confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
-      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-      ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-      ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-    }),
-    [t],
-  );
-  const addAddressNameLabels = useMemo<ContactsAddAddressNameLabels>(
-    () => ({
-      inputLabel: t("contacts.addAddressName.inputLabel"),
-      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-      namingDisclaimerAccessibilityLabel: t(
-        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
-      ),
-      continueToReview: t("contacts.addAddressName.continueToReview"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      validationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
-      },
-    }),
-    [t],
-  );
-  const addAddressReviewLabels = useMemo<ContactsAddAddressReviewLabels>(
-    () => ({
-      title: t("contacts.addAddressReview.title"),
-      addressLabel: t("contacts.addAddressReview.addressLabel"),
-      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
-      networkLabel: t("contacts.addAddressReview.networkLabel"),
-      nameLabel: t("contacts.addAddressReview.nameLabel"),
-      continue: t("contacts.addAddressReview.continue"),
-    }),
-    [t],
-  );
   const addAddressFlowDialog = useMemo<ContactsAddAddressFlowDialogProps>(
     () => ({
       state: addAddressFlowState,
-      entryLabels: addAddressEntryLabels,
       sanctionedAddressBanner: {
         description: t("contacts.addAddressEntry.sanctioned.description"),
         actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
         onAction: handleSanctionedAddressLearnMore,
       },
-      nameLabels: addAddressNameLabels,
-      reviewLabels: addAddressReviewLabels,
       onAddressChange: (address, inputMethod) => {
         void updateAddress(address, inputMethod);
       },
@@ -366,10 +308,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       onClose: onCloseAddAddress,
     }),
     [
-      addAddressEntryLabels,
       handleSanctionedAddressLearnMore,
-      addAddressNameLabels,
-      addAddressReviewLabels,
       addAddressFlowState,
       onBackAddAddress,
       onCloseAddAddress,
@@ -396,17 +335,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
       isContactsEntryAvailable: true,
       preference,
     });
-  const labels = useMemo<ContactsListViewLabels>(
-    () => ({
-      title: t("contacts.title"),
-      searchPlaceholder: t("contacts.searchPlaceholder"),
-      searchNoResults: t("contacts.searchNoResults"),
-      addContact: t("contacts.addContact"),
-      formatAddressCount: count => t("contacts.addressCount", { count }),
-      formatMeDisplayName: createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
         t("contacts.detail.meDisplayName", { name }),
       ),
-    }),
     [t],
   );
   const featureIntroductionHighlights = useMemo(
@@ -420,16 +353,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
   );
   const viewModel = useMemo(() => {
     if (searchQuery.trim().length > 0) {
-      return createContactsSearchViewModel(
-        meContact,
-        contacts,
-        searchQuery,
-        labels.formatMeDisplayName,
-      );
+      return createContactsSearchViewModel(meContact, contacts, searchQuery, formatMeDisplayName);
     }
 
-    return createContactsListViewModel(meContact, contacts, labels.formatMeDisplayName);
-  }, [contacts, labels.formatMeDisplayName, meContact, searchQuery]);
+    return createContactsListViewModel(meContact, contacts, formatMeDisplayName);
+  }, [contacts, formatMeDisplayName, meContact, searchQuery]);
   const onSearchInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
   }, []);
@@ -485,7 +413,6 @@ export function useContactsViewModel(): ContactsPageViewModel {
     editDeleteDialogs,
     addressDetailActionsDialogs,
     viewModel,
-    labels,
     searchQuery,
     meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
     onSearchInputChange,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -1,14 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { v4 as uuid } from "uuid";
-import {
-  addAddress,
-  contactAddress,
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  type Contact,
-} from "@domain/entity-contact";
+import { addAddress, contactAddress, type Contact } from "@domain/entity-contact";
 import { SEND_FLOW_STEP, type SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
 import { resolvePrefillAddAddressParams } from "@ledgerhq/live-common/flows/send/recipient/utils/resolvePrefillAddAddressParams";
 import { getMinVersion } from "@ledgerhq/live-common/apps/support";
@@ -25,9 +17,6 @@ import {
 import {
   isPrefillAddAddressFlowOpen,
   useAddAddressFlowViewModel,
-  type AddAddressEntryLabels,
-  type ContactsAddAddressNameLabels,
-  type ContactsAddAddressReviewLabels,
   type PrefillAddAddressFlowVisibleState,
 } from "@features/flow-contacts-add-address";
 import { useContactsAddressValidationAdapter } from "LLD/features/Contacts/hooks/useContactsAddressValidationAdapter";
@@ -46,9 +35,6 @@ import { track, trackPage } from "~/renderer/analytics/segment";
 
 export type SendPrefillAddAddressPhase = Readonly<{
   state: PrefillAddAddressFlowVisibleState;
-  entryLabels: AddAddressEntryLabels;
-  nameLabels: ContactsAddAddressNameLabels;
-  reviewLabels: ContactsAddAddressReviewLabels;
   dieProps: ContactsDeviceIntentExecutorProps | undefined;
   onAddressLabelChange: (value: string) => void;
   onContinueFromName: () => void;
@@ -75,7 +61,6 @@ export function useSendPrefillAddAddressFlow({
   idleHeaderState,
   contactType,
 }: UseSendPrefillAddAddressFlowOptions): SendPrefillAddAddressFlow {
-  const { t } = useTranslation();
   const dispatch = useDispatch();
   const { navigation } = useFlowWizard<SendFlowStep>();
   const { state, recipientSearch } = useSendFlowData();
@@ -287,56 +272,9 @@ export function useSendPrefillAddAddressFlow({
     [navigation, recipientSearch.value, startWithPrefilled, state.account.currency],
   );
 
-  const entryLabels = useMemo<AddAddressEntryLabels>(
-    () => ({
-      title: t("contacts.addAddressEntry.title"),
-      addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-      confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
-      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-      ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-      ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-    }),
-    [t],
-  );
-  const nameLabels = useMemo<ContactsAddAddressNameLabels>(
-    () => ({
-      inputLabel: t("contacts.addAddressName.inputLabel"),
-      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-      namingDisclaimerAccessibilityLabel: t(
-        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
-      ),
-      continueToReview: t("contacts.addAddressName.continueToReview"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      validationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
-      },
-    }),
-    [t],
-  );
-  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
-    () => ({
-      title: t("contacts.addAddressReview.title"),
-      addressLabel: t("contacts.addAddressReview.addressLabel"),
-      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
-      networkLabel: t("contacts.addAddressReview.networkLabel"),
-      nameLabel: t("contacts.addAddressReview.nameLabel"),
-      continue: t("contacts.addAddressReview.continue"),
-    }),
-    [t],
-  );
   const addressPhase = isAddressPhase
     ? {
         state: addressFlowState,
-        entryLabels,
-        nameLabels,
-        reviewLabels,
         dieProps,
         onAddressLabelChange: updateAddressLabel,
         onContinueFromName: () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/AddNewContactAddressView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/AddNewContactAddressView.tsx
@@ -19,9 +19,6 @@ export function AddNewContactAddressView({ addressPhase }: AddNewContactAddressV
     >
       <ContactsAddAddressFlowContent
         state={addressPhase.state}
-        entryLabels={addressPhase.entryLabels}
-        nameLabels={addressPhase.nameLabels}
-        reviewLabels={addressPhase.reviewLabels}
         onAddressChange={() => undefined}
         onContinueFromAddressDetails={() => undefined}
         onAddressLabelChange={addressPhase.onAddressLabelChange}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -72,14 +72,7 @@ export function useContactAddressDetailActionsAdapter(
     sourceScreenName: ScreenName.MyWalletContactDetail,
   });
   const isSelectionActive = contactId !== undefined && addressId !== undefined;
-  const labels = useMemo(
-    () =>
-      resolveContactAddressDetailActionsLabels({
-        t,
-        addressLabelTooLongKey: "contacts.addAddressName.labelTooLong",
-      }),
-    [t],
-  );
+  const labels = useMemo(() => resolveContactAddressDetailActionsLabels({ t }), [t]);
   const trackQuickAction = useCallback(
     (
       button:

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -1,10 +1,5 @@
 import { useCallback } from "react";
 import { Linking, Platform } from "react-native";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
 import { useTranslation } from "~/context/Locale";
 import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
@@ -67,19 +62,6 @@ export function useContactsAddAddressFlowDrawerViewModel({
       state.status === "enteringAddress"
         ? {
             addressEntry: state.addressEntry,
-            labels: {
-              title: t("contacts.addAddressEntry.title"),
-              addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-              confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
-              validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-              validAddress: t("contacts.addAddressEntry.validAddress"),
-              invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-              domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-              sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-              validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-              ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-              ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-            },
             sanctionedAddressBanner: {
               description: t("contacts.addAddressEntry.sanctioned.description"),
               actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
@@ -95,23 +77,6 @@ export function useContactsAddAddressFlowDrawerViewModel({
       state.status === "namingAddress" || state.status === "confirmationRequired"
         ? {
             addressLabel: state.addressLabel,
-            labels: {
-              title: t("contacts.addAddressName.title"),
-              inputLabel: t("contacts.addAddressName.inputLabel"),
-              namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-              continueToReview: t("common.continue"),
-              validationErrors: {
-                [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
-                  "contacts.addAddressName.invalidLabel",
-                ),
-                [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
-                  "contacts.addAddressName.duplicateLabel",
-                ),
-                [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(
-                  "contacts.addAddressName.labelTooLong",
-                ),
-              },
-            },
             bottomOffset,
             onChangeText: onAddressNameChange,
             onContinue: onContinueFromName,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -1,7 +1,6 @@
 import { type ContactId } from "@domain/entity-contact";
 import {
   type ContactsEditSignerMismatchDrawerProps,
-  type ContactDetailActionsLabels,
   createContactDetailEditDeleteUiState,
   resolveContactDetailEditDeleteLabels,
   useContactDetailEditDeleteAnalytics,
@@ -19,7 +18,6 @@ export type ContactDetailEditDeleteFlowProps = Readonly<{
   actionsMenu: Readonly<{
     isOpen: boolean;
     canDelete: boolean;
-    labels: ContactDetailActionsLabels;
     onEdit: () => void;
     onDelete: () => void;
     onClose: () => void;
@@ -71,7 +69,6 @@ export function useContactDetailEditDeleteAdapter(
     actionsMenu: {
       isOpen: flow.isActionsMenuOpen,
       canDelete: flow.canDelete,
-      labels: labels.actions,
       onEdit,
       onDelete,
       onClose: flow.onCloseActionsMenu,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -7,7 +7,6 @@ import { addAddress, contactAddress } from "@domain/entity-contact";
 import {
   type ContactAddressDetailDialogNativeLabels,
   type ContactAddressDetailDialogNativeProps,
-  type ContactDetailLabels,
   type ContactDetailViewProps,
   useContactDetailSharedState,
   useContactAddressDetailDialog,
@@ -33,7 +32,6 @@ import {
 } from "@features/flow-contacts-add-address";
 import { getMinVersion } from "@ledgerhq/live-common/apps/support";
 import {
-  createMeDisplayNameFormatter,
   resolveEligibleAddressCurrencyIds,
   useContactsFeature,
   useContactsMeContact,
@@ -311,27 +309,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     completeAddressConfirmation,
     continueFromName,
   ]);
-  const labels = useMemo<ContactDetailLabels>(
-    () => ({
-      addAddress: t("contacts.addAddress"),
-      addYourAddress: t("contacts.addYourAddress"),
-      emptyMeTitle: t("contacts.detail.emptyState.meTitle"),
-      emptyContactTitle: name => t("contacts.detail.emptyState.contactTitle", { name }),
-      emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
-      emptyContactDescription: name => t("contacts.detail.emptyState.contactDescription", { name }),
-      ledgerWalletAddresses: t("contacts.detail.ledgerWalletAddresses"),
-      myAddresses: t("contacts.detail.myAddresses"),
-      formatMeDisplayName: createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
-        t("contacts.detail.meDisplayName", { name }),
-      ),
-      formatAddressCount: count => t("contacts.addressCount", { count }),
-    }),
-    [t],
-  );
-  const detailSharedState = useContactDetailSharedState(
-    route.params.contactId,
-    labels.formatMeDisplayName,
-  );
+  const detailSharedState = useContactDetailSharedState(route.params.contactId);
   const addressDetailDialogLabels = useMemo<ContactAddressDetailDialogNativeLabels>(
     () => ({
       send: t("contacts.addressDetail.send"),
@@ -437,7 +415,6 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
 
   const pageProps: ContactDetailViewProps = {
     contact,
-    labels,
     meAvatarSrc: USER_AVATAR_URL,
     onAddAddress,
     ledgerWalletAccountsIntent: detailSharedState?.ledgerWalletAccountsIntent,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -1,5 +1,4 @@
 import {
-  type ContactsListViewLabels,
   type ContactsViewNativeProps,
   useContactsSearchViewModel,
   useContactsMeContact,
@@ -43,20 +42,11 @@ export function useContactsPageViewModel(
   const analytics = useContactsAnalytics();
   const meContact = useContactsMeContact();
   const contacts = useContacts();
-  const labels = useMemo<ContactsListViewLabels>(
-    () => ({
-      title: t("contacts.title"),
-      searchPlaceholder: t("contacts.searchPlaceholder"),
-      searchNoResults: t("contacts.searchNoResults"),
-      addContact: t("contacts.addContact"),
-      ledgerSyncCheckingAccessibilityLabel: t(
-        "contacts.ledgerSyncIntroduction.checkingAccessibilityLabel",
-      ),
-      formatAddressCount: count => t("contacts.addressCount", { count }),
-      formatMeDisplayName: createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
         t("contacts.detail.meDisplayName", { name }),
       ),
-    }),
     [t],
   );
   const preference = useContactsFeatureIntroductionPreference();
@@ -80,7 +70,7 @@ export function useContactsPageViewModel(
     useContactsLedgerSyncActivationDrawer();
   const [isLedgerSyncIntroductionRequested, setIsLedgerSyncIntroductionRequested] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const viewModel = useContactsSearchViewModel(searchQuery, labels.formatMeDisplayName);
+  const viewModel = useContactsSearchViewModel(searchQuery, formatMeDisplayName);
   const onSearchQueryChange = useCallback((query: string) => setSearchQuery(query), []);
   const onOpenContact = useCallback<ContactsViewNativeProps["onOpenContact"]>(
     contactId => {
@@ -143,7 +133,6 @@ export function useContactsPageViewModel(
 
   return {
     viewModel,
-    labels,
     searchQuery,
     onSearchQueryChange,
     meAvatarSrc: USER_AVATAR_URL,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
@@ -7,6 +7,7 @@ import { useContactsFeature } from "@features/platform-contacts";
 import { ScreenName } from "~/const";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { TrackScreen } from "~/analytics";
+import { useTranslation } from "~/context/Locale";
 import { ContactsPageContent } from "./components/ContactsPageContent";
 import { useContactsAddContactDrawerAdapter } from "./hooks/useContactsAddContactDrawerAdapter";
 import { useContactsPageNavigationViewModel } from "./hooks/useContactsPageNavigationViewModel";
@@ -29,6 +30,7 @@ type ContactsPageProps = Readonly<{
 }>;
 
 export function ContactsPage({ title, onSelectContact }: ContactsPageProps) {
+  const { t } = useTranslation();
   const pageViewModel = useContactsPageViewModel(onSelectContact);
   const { onSearchQueryChange } = pageViewModel;
   const onSaveSuccess = useCallback(() => {
@@ -45,7 +47,7 @@ export function ContactsPage({ title, onSelectContact }: ContactsPageProps) {
   };
 
   useContactsPageNavigationViewModel(
-    pageViewModel.labels.addContact,
+    t("contacts.addContact"),
     !isContactsSearchNoResultsViewModel(pageViewModel.viewModel),
     onAddContact,
     title,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactAddressScreens.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactAddressScreens.tsx
@@ -1,18 +1,9 @@
-import React, { useMemo } from "react";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
-import {
-  ContactsAddAddressFlowContent,
-  type ContactsAddAddressReviewLabels,
-} from "@features/flow-contacts-add-address";
+import React from "react";
+import { ContactsAddAddressFlowContent } from "@features/flow-contacts-add-address";
 import type {
   QueuedDrawerFlowOptions,
   QueuedDrawerFlowScreen,
 } from "LLM/components/QueuedDrawerFlow";
-import { useTranslation } from "~/context/Locale";
 import type { SendPrefillAddAddressPhase } from "LLM/features/Send/hooks/useSendPrefillAddAddressFlow";
 
 const LOCKED_STEP_OPTIONS = {
@@ -37,33 +28,6 @@ export function useAddNewContactAddressScreens({
   addressPhase,
   bottomOffset,
 }: UseAddNewContactAddressScreensOptions): AddNewContactAddressScreens {
-  const { t } = useTranslation();
-  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
-    () => ({
-      title: t("contacts.addAddressReview.title"),
-      addressLabel: t("contacts.addAddressReview.addressLabel"),
-      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
-      networkLabel: t("contacts.addAddressReview.networkLabel"),
-      nameLabel: t("contacts.addAddressReview.nameLabel"),
-      continue: t("contacts.addAddressReview.continue"),
-    }),
-    [t],
-  );
-  const nameLabels = useMemo(
-    () => ({
-      title: t("contacts.addAddressName.title"),
-      inputLabel: t("contacts.addAddressName.inputLabel"),
-      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-      continueToReview: t("contacts.addAddressName.continueToReview"),
-      validationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.labelTooLong"),
-      },
-    }),
-    [t],
-  );
-
   if (addressPhase === null) {
     return {
       name: { content: null, options: LOCKED_STEP_OPTIONS },
@@ -80,7 +44,6 @@ export function useAddNewContactAddressScreens({
           addressEntryProps={null}
           addressNameProps={{
             addressLabel: state.addressLabel,
-            labels: nameLabels,
             bottomOffset,
             onChangeText: addressPhase.onAddressLabelChange,
             onContinue: addressPhase.onContinueFromName,
@@ -101,7 +64,6 @@ export function useAddNewContactAddressScreens({
             currency: state.displayContext.assetDisplayName,
             network: state.displayContext.network.displayName,
             name: state.addressLabel.label ?? state.addressLabel.value,
-            labels: reviewLabels,
             bottomOffset,
             onContinue: addressPhase.onContinueFromReview,
           }}

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
+    "@shared/i18n": "workspace:*",
     "@features/flow-contacts-add-contact": "workspace:^",
     "@features/flow-contacts-edit-address": "workspace:^",
     "@features/flow-contacts-edit-contact": "workspace:^",

--- a/features/flow/contacts/src/ContactsView.types.ts
+++ b/features/flow/contacts/src/ContactsView.types.ts
@@ -1,6 +1,6 @@
 import type { ChangeEvent } from "react";
 import type { ContactId } from "@domain/entity-contact";
-import type { ContactsListViewLabels, ContactsPageViewModel } from "@features/flow-contacts-list";
+import type { ContactsPageViewModel } from "@features/flow-contacts-list";
 import type {
   ContactsFeatureIntroduction,
   ContactsLedgerSyncIntroduction,
@@ -10,7 +10,6 @@ import type { ContactDetailViewProps } from "./steps/Detail/types";
 
 type ContactsPageSharedProps = Readonly<{
   viewModel: ContactsPageViewModel;
-  labels: ContactsListViewLabels;
   searchQuery: string;
   meAvatarSrc: string;
   onOpenContact: (contactId: ContactId) => void;

--- a/features/flow/contacts/src/contactsListFacade.native.ts
+++ b/features/flow/contacts/src/contactsListFacade.native.ts
@@ -10,7 +10,6 @@ export {
   ContactsAddContactHeaderButton,
 } from "@features/flow-contacts-list/native";
 export type {
-  ContactsListViewLabels,
   ContactsPageViewModel,
   ContactsSearchNoResultsViewModel,
   ContactsSearchResultsViewModel,

--- a/features/flow/contacts/src/contactsListFacade.ts
+++ b/features/flow/contacts/src/contactsListFacade.ts
@@ -9,7 +9,6 @@ export {
   isPopulatedContactsListViewModel,
 } from "@features/flow-contacts-list";
 export type {
-  ContactsListViewLabels,
   ContactsPageViewModel,
   ContactsSearchNoResultsViewModel,
   ContactsSearchResultsViewModel,

--- a/features/flow/contacts/src/hooks/useAddContactAppAdapter.ts
+++ b/features/flow/contacts/src/hooks/useAddContactAppAdapter.ts
@@ -1,6 +1,5 @@
 import {
   type ContactCreationPort,
-  type ContactsAddContactContentLabels,
   type AddContactDialogViewModel,
   useAddContactDialogViewModel,
 } from "@features/flow-contacts-add-contact";
@@ -12,7 +11,6 @@ export type UseAddContactAppAdapterOptions = Readonly<{
   analytics: ContactsAnalyticsHelper;
   contactCreation: ContactCreationPort;
   onSaveSuccess: (contact: Contact) => void;
-  labels: ContactsAddContactContentLabels;
 }>;
 
 export type AddContactAppAdapterResult = AddContactDialogViewModel;
@@ -21,7 +19,6 @@ export function useAddContactAppAdapter({
   analytics,
   contactCreation,
   onSaveSuccess,
-  labels,
 }: UseAddContactAppAdapterOptions): AddContactAppAdapterResult {
   const { callbacks, onSaveSuccess: handleSaveSuccess } = useContactsAddContactAnalytics(
     analytics,
@@ -30,7 +27,6 @@ export function useAddContactAppAdapter({
 
   return useAddContactDialogViewModel({
     contactCreation,
-    labels,
     onSaveSuccess: handleSaveSuccess,
     callbacks,
   });

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
@@ -2,29 +2,40 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { createMeDisplayNameFormatter } from "@features/platform-contacts";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { createContactDetailLedgerWalletAccountsIntent } from "./model/contactDetailSharedState";
 import { createContactDetailAddressRowIntent } from "./model/viewModel";
-import type { ContactDetailLabels } from "./types";
 import { ContactDetailView } from "./ContactDetailView.native";
 
-const labels: ContactDetailLabels = {
-  addAddress: "Add address",
-  addYourAddress: "Add your address",
-  emptyMeTitle: "Save your own addresses",
-  emptyContactTitle: name => `No saved addresses for ${name}`,
-  emptyMeDescription: "Save external addresses for Me.",
-  emptyContactDescription: () => "Save their wallet addresses to send to them by name next time",
-  ledgerWalletAddresses: "Ledger Wallet addresses",
-  formatMeDisplayName: createMeDisplayNameFormatter("My addresses", name => `${name} (Me)`),
-  formatAddressCount: count => `${count} address`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        addAddress: "Add address",
+        addYourAddress: "Add your address",
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+        detail: {
+          emptyState: {
+            meTitle: "Save your own addresses",
+            contactTitle: "No saved addresses for {{name}}",
+            meDescription: "Save external addresses for Me.",
+            contactDescription: "Save their wallet addresses to send to them by name next time",
+          },
+          ledgerWalletAddresses: "Ledger Wallet addresses",
+          meDisplayName: "{{name}} (Me)",
+        },
+        me: { myAddresses: "My addresses" },
+      },
+    },
+  },
 };
 
 const onAddAddress = () => undefined;
 const onLedgerWalletAccountsPress = () => undefined;
 
 const defaultProps = {
-  labels,
   meAvatarSrc: "https://example.com/avatar.png",
   onAddAddress,
 };
@@ -35,9 +46,19 @@ const meDetailProps = {
   onLedgerWalletAccountsPress,
 };
 
+function renderContactDetailView(
+  props: React.ComponentProps<typeof ContactDetailView>,
+): ReturnType<typeof render> {
+  return render(
+    <I18nTestProvider resources={resources}>
+      <ContactDetailView {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactDetailPage", () => {
   it("should render the Me empty state", () => {
-    render(<ContactDetailView {...meDetailProps} contact={mockMeContact()} />);
+    renderContactDetailView({ ...meDetailProps, contact: mockMeContact() });
 
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeVisible();
     expect(screen.getByText("My addresses")).toBeVisible();
@@ -50,18 +71,19 @@ describe("ContactDetailPage", () => {
   });
 
   it("should render a custom Me display name with the Me suffix", () => {
-    render(<ContactDetailView {...meDetailProps} contact={mockMeContact({ name: "Maxime" })} />);
+    renderContactDetailView({
+      ...meDetailProps,
+      contact: mockMeContact({ name: "Maxime" }),
+    });
 
     expect(screen.getByText("Maxime (Me)")).toBeVisible();
   });
 
   it("should render a saved contact empty state", () => {
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={mockContact({ id: "contact-benoit", name: "Benoit" })}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact: mockContact({ id: "contact-benoit", name: "Benoit" }),
+    });
 
     expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
     expect(screen.getByText("Benoit")).toBeVisible();
@@ -73,30 +95,6 @@ describe("ContactDetailPage", () => {
     ).toBeVisible();
   });
 
-  it("should keep the shared detail defaults without Mobile-specific props", () => {
-    const sharedLabels: ContactDetailLabels = {
-      addAddress: labels.addAddress,
-      emptyMeTitle: labels.emptyMeTitle,
-      emptyContactTitle: labels.emptyContactTitle,
-      emptyMeDescription: labels.emptyMeDescription,
-      emptyContactDescription: labels.emptyContactDescription,
-      formatAddressCount: labels.formatAddressCount,
-    };
-
-    render(
-      <ContactDetailView
-        contact={mockMeContact()}
-        labels={sharedLabels}
-        meAvatarSrc={defaultProps.meAvatarSrc}
-        onAddAddress={onAddAddress}
-      />,
-    );
-
-    expect(screen.getByText("Me")).toBeVisible();
-    expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add address");
-    expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).toBeNull();
-  });
-
   it("should render populated address rows when provided", () => {
     const contact = mockContact({
       id: "contact-benoit",
@@ -106,29 +104,27 @@ describe("ContactDetailPage", () => {
     const address = contact.addresses[0]!;
     const handleAddressRowPress = jest.fn();
 
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={contact}
-        addressGroups={[
-          {
-            networkId: getCryptoCurrencyById("ethereum").id,
-            networkName: getCryptoCurrencyById("ethereum").name,
-            networkTicker: getCryptoCurrencyById("ethereum").ticker,
-            rows: [
-              {
-                addressId: address.id,
-                label: address.label,
-                address: address.address,
-                currencyId: address.currencyId,
-                intent: createContactDetailAddressRowIntent(contact.id, address.id),
-              },
-            ],
-          },
-        ]}
-        onAddressRowPress={handleAddressRowPress}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact,
+      addressGroups: [
+        {
+          networkId: getCryptoCurrencyById("ethereum").id,
+          networkName: getCryptoCurrencyById("ethereum").name,
+          networkTicker: getCryptoCurrencyById("ethereum").ticker,
+          rows: [
+            {
+              addressId: address.id,
+              label: address.label,
+              address: address.address,
+              currencyId: address.currencyId,
+              intent: createContactDetailAddressRowIntent(contact.id, address.id),
+            },
+          ],
+        },
+      ],
+      onAddressRowPress: handleAddressRowPress,
+    });
 
     expect(screen.getByTestId("contacts-detail-address-list")).toBeVisible();
     expect(screen.getByTestId("contacts-detail-network-group-ethereum")).toBeVisible();
@@ -146,29 +142,25 @@ describe("ContactDetailPage", () => {
   });
 
   it("should request adding an address when the action is pressed", () => {
-    const onAddAddress = jest.fn();
-    render(
-      <ContactDetailView
-        {...meDetailProps}
-        contact={mockMeContact()}
-        onAddAddress={onAddAddress}
-      />,
-    );
+    const onAddAddressHandler = jest.fn();
+    renderContactDetailView({
+      ...meDetailProps,
+      contact: mockMeContact(),
+      onAddAddress: onAddAddressHandler,
+    });
 
     fireEvent.press(screen.getByTestId("contacts-detail-add-address"));
 
-    expect(onAddAddress).toHaveBeenCalledTimes(1);
+    expect(onAddAddressHandler).toHaveBeenCalledTimes(1);
   });
 
   it("should request opening Ledger Wallet addresses for Me", () => {
     const handleLedgerWalletAccountsPress = jest.fn();
-    render(
-      <ContactDetailView
-        {...meDetailProps}
-        contact={mockMeContact()}
-        onLedgerWalletAccountsPress={handleLedgerWalletAccountsPress}
-      />,
-    );
+    renderContactDetailView({
+      ...meDetailProps,
+      contact: mockMeContact(),
+      onLedgerWalletAccountsPress: handleLedgerWalletAccountsPress,
+    });
 
     fireEvent.press(screen.getByTestId("contacts-detail-ledger-wallet-addresses"));
 

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
@@ -3,6 +3,7 @@ import { ScrollView } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactDetailViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
 import { ContactDetailAddressList } from "./components/ContactDetailAddressList/ContactDetailAddressList.native";
 import { ContactDetailEmptyState } from "./components/ContactDetailEmptyState.native";
 import { ContactDetailHeader } from "./components/ContactDetailHeader.native";
@@ -10,7 +11,6 @@ import { LedgerWalletAddressesCard } from "./components/LedgerWalletAddressesCar
 
 export function ContactDetailView({
   contact,
-  labels,
   meAvatarSrc,
   onAddAddress,
   ledgerWalletAccountsIntent,
@@ -18,6 +18,7 @@ export function ContactDetailView({
   addressGroups,
   onAddressRowPress,
 }: ContactDetailViewProps): React.JSX.Element {
+  const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
   const hasPopulatedAddresses = addressGroups !== undefined && onAddressRowPress !== undefined;
 
@@ -31,15 +32,12 @@ export function ContactDetailView({
       >
         <ContactDetailHeader
           contact={contact}
-          labels={labels}
           meAvatarSrc={meAvatarSrc}
           onAddAddress={onAddAddress}
         />
-        {ledgerWalletAccountsIntent &&
-        labels.ledgerWalletAddresses &&
-        onLedgerWalletAccountsPress ? (
+        {ledgerWalletAccountsIntent && onLedgerWalletAccountsPress ? (
           <LedgerWalletAddressesCard
-            label={labels.ledgerWalletAddresses}
+            label={t("contacts.detail.ledgerWalletAddresses")}
             intent={ledgerWalletAccountsIntent}
             onPress={onLedgerWalletAccountsPress}
           />
@@ -50,7 +48,7 @@ export function ContactDetailView({
             onAddressRowPress={onAddressRowPress}
           />
         ) : (
-          <ContactDetailEmptyState contact={contact} labels={labels} />
+          <ContactDetailEmptyState contact={contact} />
         )}
       </ScrollView>
     </Box>

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -3,34 +3,60 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { CONTACT_NAME_MAX_LENGTH } from "@domain/entity-contact";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { createMeDisplayNameFormatter } from "@features/platform-contacts";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { createContactDetailLedgerWalletAccountsIntent } from "./model/contactDetailSharedState";
 import { createContactDetailAddressRowIntent } from "./model/viewModel";
-import type { ContactDetailLabels } from "./types";
 import { ContactDetailView } from "./ContactDetailView.web";
 
-const labels: ContactDetailLabels = {
-  addAddress: "Add address",
-  addYourAddress: "Add your address",
-  emptyMeTitle: "No saved addresses for you",
-  emptyContactTitle: name => `No saved addresses for ${name}`,
-  emptyMeDescription: "Save your wallet addresses to receive crypto by name next time.",
-  emptyContactDescription: () => "Save their wallet addresses to send to them by name next time",
-  formatMeDisplayName: createMeDisplayNameFormatter("My addresses", name => `${name} (Me)`),
-  formatAddressCount: count => `${count} address`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        addAddress: "Add address",
+        addYourAddress: "Add your address",
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+        detail: {
+          emptyState: {
+            meTitle: "No saved addresses for you",
+            contactTitle: "No saved addresses for {{name}}",
+            meDescription: "Save your wallet addresses to receive crypto by name next time.",
+            contactDescription: "Save their wallet addresses to send to them by name next time",
+          },
+          ledgerWalletAddresses: "Ledger Wallet addresses",
+          meDisplayName: "{{name}} (Me)",
+        },
+        me: { myAddresses: "My addresses" },
+        detailActions: {
+          editContact: "Edit contact",
+          deleteContact: "Delete contact",
+        },
+      },
+    },
+  },
 };
 
 const onAddAddress = () => undefined;
 
 const defaultProps = {
-  labels,
   meAvatarSrc: "https://example.com/avatar.png",
   onAddAddress,
 };
 
+function renderContactDetailView(
+  props: React.ComponentProps<typeof ContactDetailView>,
+): ReturnType<typeof render> {
+  return render(
+    <I18nTestProvider resources={resources}>
+      <ContactDetailView {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactDetailView", () => {
   it("should render the Me empty state", () => {
-    render(<ContactDetailView {...defaultProps} contact={mockMeContact()} />);
+    renderContactDetailView({ ...defaultProps, contact: mockMeContact() });
 
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeInTheDocument();
     expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("My addresses");
@@ -42,18 +68,16 @@ describe("ContactDetailView", () => {
   });
 
   it("should render a custom Me display name with the Me suffix", () => {
-    render(<ContactDetailView {...defaultProps} contact={mockMeContact({ name: "Maxime" })} />);
+    renderContactDetailView({ ...defaultProps, contact: mockMeContact({ name: "Maxime" }) });
 
     expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Maxime (Me)");
   });
 
   it("should render a saved contact empty state", () => {
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={mockContact({ id: "contact-benoit", name: "Benoit" })}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact: mockContact({ id: "contact-benoit", name: "Benoit" }),
+    });
 
     expect(screen.getByTestId("contacts-detail-avatar")).toBeInTheDocument();
     expect(screen.getByText("Benoit")).toBeInTheDocument();
@@ -66,12 +90,10 @@ describe("ContactDetailView", () => {
   it("should preserve the saved contact name truncation styles", () => {
     const name = "Z".repeat(CONTACT_NAME_MAX_LENGTH);
 
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={mockContact({ id: "contact-long-name", name })}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact: mockContact({ id: "contact-long-name", name }),
+    });
 
     expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent(name);
     expect(screen.getByTestId("contacts-detail-name")).toHaveClass(
@@ -90,29 +112,27 @@ describe("ContactDetailView", () => {
     const address = contact.addresses[0]!;
     const handleAddressRowPress = jest.fn();
 
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={contact}
-        addressGroups={[
-          {
-            networkId: getCryptoCurrencyById("ethereum").id,
-            networkName: getCryptoCurrencyById("ethereum").name,
-            networkTicker: getCryptoCurrencyById("ethereum").ticker,
-            rows: [
-              {
-                addressId: address.id,
-                label: address.label,
-                address: address.address,
-                currencyId: address.currencyId,
-                intent: createContactDetailAddressRowIntent(contact.id, address.id),
-              },
-            ],
-          },
-        ]}
-        onAddressRowPress={handleAddressRowPress}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact,
+      addressGroups: [
+        {
+          networkId: getCryptoCurrencyById("ethereum").id,
+          networkName: getCryptoCurrencyById("ethereum").name,
+          networkTicker: getCryptoCurrencyById("ethereum").ticker,
+          rows: [
+            {
+              addressId: address.id,
+              label: address.label,
+              address: address.address,
+              currencyId: address.currencyId,
+              intent: createContactDetailAddressRowIntent(contact.id, address.id),
+            },
+          ],
+        },
+      ],
+      onAddressRowPress: handleAddressRowPress,
+    });
 
     expect(screen.getByTestId("contacts-detail-address-list")).toBeVisible();
     expect(screen.getByTestId("contacts-detail-network-group-ethereum")).toBeVisible();
@@ -131,13 +151,11 @@ describe("ContactDetailView", () => {
 
   it("should request adding an address when the action is pressed", () => {
     const handleAddAddress = jest.fn();
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={mockMeContact()}
-        onAddAddress={handleAddAddress}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact: mockMeContact(),
+      onAddAddress: handleAddAddress,
+    });
 
     fireEvent.click(screen.getByTestId("contacts-detail-add-address"));
 
@@ -156,29 +174,27 @@ describe("ContactDetailView", () => {
     });
     const address = contact.addresses[0]!;
 
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={contact}
-        addressGroups={[
-          {
-            networkId: getCryptoCurrencyById("ethereum").id,
-            networkName: getCryptoCurrencyById("ethereum").name,
-            networkTicker: getCryptoCurrencyById("ethereum").ticker,
-            rows: [
-              {
-                addressId: address.id,
-                label: address.label,
-                address: address.address,
-                currencyId: address.currencyId,
-                intent: createContactDetailAddressRowIntent(contact.id, address.id),
-              },
-            ],
-          },
-        ]}
-        onAddressRowPress={jest.fn()}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact,
+      addressGroups: [
+        {
+          networkId: getCryptoCurrencyById("ethereum").id,
+          networkName: getCryptoCurrencyById("ethereum").name,
+          networkTicker: getCryptoCurrencyById("ethereum").ticker,
+          rows: [
+            {
+              addressId: address.id,
+              label: address.label,
+              address: address.address,
+              currencyId: address.currencyId,
+              intent: createContactDetailAddressRowIntent(contact.id, address.id),
+            },
+          ],
+        },
+      ],
+      onAddressRowPress: jest.fn(),
+    });
 
     const header = screen.getByTestId("contacts-detail-header");
     const addressList = screen.getByTestId("contacts-detail-address-list");
@@ -236,25 +252,25 @@ describe("ContactDetailView", () => {
         },
       ];
     };
-    const { rerender } = render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={firstContact}
-        addressGroups={createAddressGroups(firstContact)}
-        onAddressRowPress={jest.fn()}
-      />,
-    );
+    const { rerender } = renderContactDetailView({
+      ...defaultProps,
+      contact: firstContact,
+      addressGroups: createAddressGroups(firstContact),
+      onAddressRowPress: jest.fn(),
+    });
 
     const firstAddressList = screen.getByTestId("contacts-detail-address-list");
     fireEvent.scroll(firstAddressList, { target: { scrollTop: 24 } });
 
     rerender(
-      <ContactDetailView
-        {...defaultProps}
-        contact={secondContact}
-        addressGroups={createAddressGroups(secondContact)}
-        onAddressRowPress={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactDetailView
+          {...defaultProps}
+          contact={secondContact}
+          addressGroups={createAddressGroups(secondContact)}
+          onAddressRowPress={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-detail-header")).toHaveAttribute("data-state", "expanded");
@@ -272,36 +288,33 @@ describe("ContactDetailView", () => {
     const onDelete = jest.fn();
     const onCompactAddAddress = jest.fn();
 
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={contact}
-        onAddAddress={onCompactAddAddress}
-        addressGroups={[
-          {
-            networkId: getCryptoCurrencyById("ethereum").id,
-            networkName: getCryptoCurrencyById("ethereum").name,
-            networkTicker: getCryptoCurrencyById("ethereum").ticker,
-            rows: [
-              {
-                addressId: address.id,
-                label: address.label,
-                address: address.address,
-                currencyId: address.currencyId,
-                intent: createContactDetailAddressRowIntent(contact.id, address.id),
-              },
-            ],
-          },
-        ]}
-        onAddressRowPress={jest.fn()}
-        detailActions={{
-          canDelete: true,
-          labels: { editContact: "Edit contact", deleteContact: "Delete contact" },
-          onEdit,
-          onDelete,
-        }}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact,
+      onAddAddress: onCompactAddAddress,
+      addressGroups: [
+        {
+          networkId: getCryptoCurrencyById("ethereum").id,
+          networkName: getCryptoCurrencyById("ethereum").name,
+          networkTicker: getCryptoCurrencyById("ethereum").ticker,
+          rows: [
+            {
+              addressId: address.id,
+              label: address.label,
+              address: address.address,
+              currencyId: address.currencyId,
+              intent: createContactDetailAddressRowIntent(contact.id, address.id),
+            },
+          ],
+        },
+      ],
+      onAddressRowPress: jest.fn(),
+      detailActions: {
+        canDelete: true,
+        onEdit,
+        onDelete,
+      },
+    });
 
     fireEvent.scroll(screen.getByTestId("contacts-detail-address-list"), {
       target: { scrollTop: 24 },
@@ -318,15 +331,12 @@ describe("ContactDetailView", () => {
   it("should render the Ledger Wallet addresses entry for Me", () => {
     const handleLedgerWalletAccountsPress = jest.fn();
 
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={mockMeContact()}
-        labels={{ ...labels, ledgerWalletAddresses: "Ledger Wallet addresses" }}
-        ledgerWalletAccountsIntent={createContactDetailLedgerWalletAccountsIntent(mockMeContact())}
-        onLedgerWalletAccountsPress={handleLedgerWalletAccountsPress}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact: mockMeContact(),
+      ledgerWalletAccountsIntent: createContactDetailLedgerWalletAccountsIntent(mockMeContact()),
+      onLedgerWalletAccountsPress: handleLedgerWalletAccountsPress,
+    });
 
     expect(screen.getByTestId("contacts-detail-ledger-wallet-addresses")).toHaveTextContent(
       "Ledger Wallet addresses",
@@ -340,15 +350,12 @@ describe("ContactDetailView", () => {
   });
 
   it("should not render the Ledger Wallet addresses entry for saved contacts", () => {
-    render(
-      <ContactDetailView
-        {...defaultProps}
-        contact={mockContact({ id: "contact-benoit", name: "Benoit" })}
-        labels={{ ...labels, ledgerWalletAddresses: "Ledger Wallet addresses" }}
-        ledgerWalletAccountsIntent={undefined}
-        onLedgerWalletAccountsPress={() => undefined}
-      />,
-    );
+    renderContactDetailView({
+      ...defaultProps,
+      contact: mockContact({ id: "contact-benoit", name: "Benoit" }),
+      ledgerWalletAccountsIntent: undefined,
+      onLedgerWalletAccountsPress: () => undefined,
+    });
 
     expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).not.toBeInTheDocument();
   });

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "@shared/i18n";
 import type { ContactDetailViewProps } from "./types";
 import { ContactDetailAddressList } from "./components/ContactDetailAddressList/ContactDetailAddressList.web";
 import { ContactDetailEmptyState } from "./components/ContactDetailEmptyState.web";
@@ -9,7 +10,6 @@ const COMPACT_HEADER_SCROLL_OFFSET = 150;
 
 export function ContactDetailView({
   contact,
-  labels,
   meAvatarSrc,
   onAddAddress,
   ledgerWalletAccountsIntent,
@@ -18,6 +18,7 @@ export function ContactDetailView({
   onAddressRowPress,
   detailActions,
 }: ContactDetailViewProps): React.ReactNode {
+  const { t } = useTranslation();
   const hasPopulatedAddresses = addressGroups !== undefined && onAddressRowPress !== undefined;
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
 
@@ -41,15 +42,14 @@ export function ContactDetailView({
     >
       <ContactDetailHeader
         contact={contact}
-        labels={labels}
         meAvatarSrc={meAvatarSrc}
         onAddAddress={onAddAddress}
         detailActions={detailActions}
         isCollapsed={isHeaderCollapsed}
       />
-      {ledgerWalletAccountsIntent && labels.ledgerWalletAddresses && onLedgerWalletAccountsPress ? (
+      {ledgerWalletAccountsIntent && onLedgerWalletAccountsPress ? (
         <LedgerWalletAddressesCard
-          label={labels.ledgerWalletAddresses}
+          label={t("contacts.detail.ledgerWalletAddresses")}
           intent={ledgerWalletAccountsIntent}
           onPress={onLedgerWalletAccountsPress}
         />
@@ -62,7 +62,7 @@ export function ContactDetailView({
           onScroll={handleAddressListScroll}
         />
       ) : (
-        <ContactDetailEmptyState contact={contact} labels={labels} />
+        <ContactDetailEmptyState contact={contact} />
       )}
     </div>
   );

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailActions/ContactDetailActions.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailActions/ContactDetailActions.web.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { IconButton } from "@ledgerhq/lumen-ui-react";
 import { PenEdit, Trash } from "@ledgerhq/lumen-ui-react/symbols";
-import type { ContactDetailActionsLabels } from "../../types";
+import { useTranslation } from "@shared/i18n";
 
 export type ContactDetailActionsProps = Readonly<{
   canDelete: boolean;
-  labels: ContactDetailActionsLabels;
   onEdit: () => void;
   onDelete: () => void;
   isCollapsed?: boolean;
@@ -13,11 +12,12 @@ export type ContactDetailActionsProps = Readonly<{
 
 export function ContactDetailActions({
   canDelete,
-  labels,
   onEdit,
   onDelete,
   isCollapsed = false,
 }: ContactDetailActionsProps): React.ReactNode {
+  const { t } = useTranslation();
+
   return (
     <div
       className={`absolute flex gap-8 motion-safe:transition-[top,right,transform] motion-safe:duration-[400ms] motion-safe:ease-in-out motion-reduce:transition-none ${
@@ -29,7 +29,7 @@ export function ContactDetailActions({
         appearance="transparent"
         size="sm"
         icon={PenEdit}
-        aria-label={labels.editContact}
+        aria-label={t("contacts.detailActions.editContact")}
         onClick={onEdit}
         data-testid="contacts-detail-edit-action"
       />
@@ -38,7 +38,7 @@ export function ContactDetailActions({
           appearance="transparent"
           size="sm"
           icon={Trash}
-          aria-label={labels.deleteContact}
+          aria-label={t("contacts.detailActions.deleteContact")}
           onClick={onDelete}
           data-testid="contacts-detail-delete-action"
         />

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailActionsMenu/ContactDetailActionsMenu.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailActionsMenu/ContactDetailActionsMenu.native.test.tsx
@@ -1,19 +1,37 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { ContactDetailActionsMenu } from "./ContactDetailActionsMenu.native";
 
-const labels = {
-  editContact: "Edit name",
-  deleteContact: "Delete contact",
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        detailActions: {
+          editName: "Edit name",
+          deleteContact: "Delete contact",
+        },
+      },
+    },
+  },
 };
 
 const defaultProps = {
   isOpen: true,
   canDelete: true,
-  labels,
   onEdit: jest.fn(),
   onDelete: jest.fn(),
 };
+
+function renderMenu(
+  props: React.ComponentProps<typeof ContactDetailActionsMenu>,
+): ReturnType<typeof render> {
+  return render(
+    <I18nTestProvider resources={resources}>
+      <ContactDetailActionsMenu {...props} />
+    </I18nTestProvider>,
+  );
+}
 
 describe("ContactDetailActionsMenu", () => {
   beforeEach(() => {
@@ -21,7 +39,7 @@ describe("ContactDetailActionsMenu", () => {
   });
 
   it("should render edit and delete actions when delete is allowed", () => {
-    render(<ContactDetailActionsMenu {...defaultProps} />);
+    renderMenu(defaultProps);
 
     expect(screen.getByTestId("contacts-detail-actions-menu")).toBeVisible();
     expect(screen.getByTestId("contacts-detail-edit-action")).toHaveTextContent("Edit name");
@@ -29,14 +47,14 @@ describe("ContactDetailActionsMenu", () => {
   });
 
   it("should hide the delete action for Me contacts", () => {
-    render(<ContactDetailActionsMenu {...defaultProps} canDelete={false} />);
+    renderMenu({ ...defaultProps, canDelete: false });
 
     expect(screen.getByTestId("contacts-detail-edit-action")).toBeVisible();
     expect(screen.queryByTestId("contacts-detail-delete-action")).toBeNull();
   });
 
   it("should not render menu content when closed", () => {
-    render(<ContactDetailActionsMenu {...defaultProps} isOpen={false} />);
+    renderMenu({ ...defaultProps, isOpen: false });
 
     expect(screen.queryByTestId("contacts-detail-actions-menu")).toBeNull();
   });
@@ -44,7 +62,7 @@ describe("ContactDetailActionsMenu", () => {
   it("should call action handlers when menu items are pressed", () => {
     const onEdit = jest.fn();
     const onDelete = jest.fn();
-    render(<ContactDetailActionsMenu {...defaultProps} onEdit={onEdit} onDelete={onDelete} />);
+    renderMenu({ ...defaultProps, onEdit, onDelete });
 
     fireEvent.press(screen.getByTestId("contacts-detail-edit-action"));
     fireEvent.press(screen.getByTestId("contacts-detail-delete-action"));

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailActionsMenu/ContactDetailActionsMenu.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailActionsMenu/ContactDetailActionsMenu.native.tsx
@@ -11,7 +11,7 @@ import {
   useTheme,
 } from "@ledgerhq/lumen-ui-rnative";
 import { PenEdit, Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
-import type { ContactDetailActionsLabels } from "../../types";
+import { useTranslation } from "@shared/i18n";
 
 // Spot paints custom icons with the neutral color of its "icon" appearance and injects it
 // through `style`, so the destructive color has to override that style on the symbol itself.
@@ -26,7 +26,6 @@ export type ContactDetailActionsMenuProps = Readonly<{
   isOpen: boolean;
   canDelete: boolean;
   bottomInset?: number;
-  labels: ContactDetailActionsLabels;
   onEdit: () => void;
   onDelete: () => void;
 }>;
@@ -35,10 +34,11 @@ export function ContactDetailActionsMenu({
   isOpen,
   canDelete,
   bottomInset = 0,
-  labels,
   onEdit,
   onDelete,
 }: ContactDetailActionsMenuProps): React.JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
       {isOpen ? (
@@ -49,7 +49,7 @@ export function ContactDetailActionsMenu({
               <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s12" }}>
                 <Spot appearance="icon" icon={PenEdit} size={40} />
                 <Text typography="body1SemiBold" lx={{ color: "base" }}>
-                  {labels.editContact}
+                  {t("contacts.detailActions.editName")}
                 </Text>
               </Box>
             </ListItem>
@@ -58,7 +58,7 @@ export function ContactDetailActionsMenu({
                 <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s12" }}>
                   <Spot appearance="icon" icon={TrashDestructive} size={40} />
                   <Text typography="body1SemiBold" lx={{ color: "error" }}>
-                    {labels.deleteContact}
+                    {t("contacts.detailActions.deleteContact")}
                   </Text>
                 </Box>
               </ListItem>

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.native.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "@shared/i18n";
 import type { ContactDetailViewProps } from "../types";
-import { resolveContactDetailEmptyStateCopy } from "../model/resolveContactDetailEmptyStateCopy";
 
-type ContactDetailEmptyStateProps = Pick<ContactDetailViewProps, "contact" | "labels">;
+type ContactDetailEmptyStateProps = Pick<ContactDetailViewProps, "contact">;
 
 export function ContactDetailEmptyState({
   contact,
-  labels,
 }: ContactDetailEmptyStateProps): React.JSX.Element {
-  const { title, description } = resolveContactDetailEmptyStateCopy(contact, labels);
+  const { t } = useTranslation();
+  const title = contact.isMe
+    ? t("contacts.detail.emptyState.meTitle")
+    : t("contacts.detail.emptyState.contactTitle", { name: contact.name });
+  const description = contact.isMe
+    ? t("contacts.detail.emptyState.meDescription")
+    : t("contacts.detail.emptyState.contactDescription", { name: contact.name });
 
   return (
     <Box

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.web.tsx
@@ -1,14 +1,19 @@
 import React from "react";
+import { useTranslation } from "@shared/i18n";
 import type { ContactDetailViewProps } from "../types";
-import { resolveContactDetailEmptyStateCopy } from "../model/resolveContactDetailEmptyStateCopy";
 
-type ContactDetailEmptyStateProps = Pick<ContactDetailViewProps, "contact" | "labels">;
+type ContactDetailEmptyStateProps = Pick<ContactDetailViewProps, "contact">;
 
 export function ContactDetailEmptyState({
   contact,
-  labels,
 }: ContactDetailEmptyStateProps): React.ReactNode {
-  const { title, description } = resolveContactDetailEmptyStateCopy(contact, labels);
+  const { t } = useTranslation();
+  const title = contact.isMe
+    ? t("contacts.detail.emptyState.meTitle")
+    : t("contacts.detail.emptyState.contactTitle", { name: contact.name });
+  const description = contact.isMe
+    ? t("contacts.detail.emptyState.meDescription")
+    : t("contacts.detail.emptyState.contactDescription", { name: contact.name });
 
   return (
     <div

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
@@ -1,25 +1,33 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { resolveMeContactDisplayName } from "@features/platform-contacts";
+import {
+  createMeDisplayNameFormatter,
+  resolveMeContactDisplayName,
+} from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactDetailViewProps } from "../types";
 import { ContactDetailAvatar } from "./ContactDetailAvatar.native";
 
 type ContactDetailHeaderProps = Pick<
   ContactDetailViewProps,
-  "contact" | "labels" | "meAvatarSrc" | "onAddAddress"
+  "contact" | "meAvatarSrc" | "onAddAddress"
 >;
 
 export function ContactDetailHeader({
   contact,
-  labels,
   meAvatarSrc,
   onAddAddress,
 }: ContactDetailHeaderProps): React.JSX.Element {
-  const displayName = resolveMeContactDisplayName(
-    contact,
-    labels.formatMeDisplayName ?? (name => name),
+  const { t } = useTranslation();
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+        t("contacts.detail.meDisplayName", { name }),
+      ),
+    [t],
   );
+  const displayName = resolveMeContactDisplayName(contact, formatMeDisplayName);
 
   return (
     <Box lx={{ alignItems: "center", gap: "s24", paddingTop: "s24" }}>
@@ -30,7 +38,7 @@ export function ContactDetailHeader({
             {displayName}
           </Text>
           <Text testID="contacts-detail-address-count" typography="body2" lx={{ color: "muted" }}>
-            {labels.formatAddressCount(contact.addresses.length)}
+            {t("contacts.addressCount", { count: contact.addresses.length })}
           </Text>
         </Box>
       </Box>
@@ -41,7 +49,7 @@ export function ContactDetailHeader({
         onPress={onAddAddress}
         testID="contacts-detail-add-address"
       >
-        {contact.isMe ? (labels.addYourAddress ?? labels.addAddress) : labels.addAddress}
+        {contact.isMe ? t("contacts.addYourAddress") : t("contacts.addAddress")}
       </Button>
     </Box>
   );

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader/ContactDetailHeader.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader/ContactDetailHeader.web.tsx
@@ -1,5 +1,9 @@
-import React from "react";
-import { resolveMeContactDisplayName } from "@features/platform-contacts";
+import React, { useMemo } from "react";
+import {
+  createMeDisplayNameFormatter,
+  resolveMeContactDisplayName,
+} from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactDetailViewProps } from "../../types";
 import {
   ContactDetailActions,
@@ -10,7 +14,7 @@ import { ContactDetailHeaderIdentity } from "./ContactDetailHeaderIdentity.web";
 
 type ContactDetailHeaderProps = Pick<
   ContactDetailViewProps,
-  "contact" | "labels" | "meAvatarSrc" | "onAddAddress"
+  "contact" | "meAvatarSrc" | "onAddAddress"
 > &
   Readonly<{
     detailActions?: ContactDetailActionsProps;
@@ -43,19 +47,21 @@ function getCompactHeaderLayout(detailActions?: ContactDetailActionsProps): Read
 
 export function ContactDetailHeader({
   contact,
-  labels,
   meAvatarSrc,
   onAddAddress,
   detailActions,
   isCollapsed,
 }: ContactDetailHeaderProps): React.ReactNode {
-  const displayName = resolveMeContactDisplayName(
-    contact,
-    labels.formatMeDisplayName ?? (name => name),
+  const { t } = useTranslation();
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+        t("contacts.detail.meDisplayName", { name }),
+      ),
+    [t],
   );
-  const addAddressLabel = contact.isMe
-    ? (labels.addYourAddress ?? labels.addAddress)
-    : labels.addAddress;
+  const displayName = resolveMeContactDisplayName(contact, formatMeDisplayName);
+  const addAddressLabel = contact.isMe ? t("contacts.addYourAddress") : t("contacts.addAddress");
   const { addAddressOffset, contentRight } = getCompactHeaderLayout(detailActions);
 
   return (
@@ -70,7 +76,7 @@ export function ContactDetailHeader({
         contact={contact}
         meAvatarSrc={meAvatarSrc}
         name={displayName}
-        addressCount={labels.formatAddressCount(contact.addresses.length)}
+        addressCount={t("contacts.addressCount", { count: contact.addresses.length })}
         isCollapsed={isCollapsed}
         compactContentRight={contentRight}
       />

--- a/features/flow/contacts/src/steps/Detail/editDelete/mapContactDetailEditDeleteUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/editDelete/mapContactDetailEditDeleteUiState.ts
@@ -22,12 +22,10 @@ export function createContactDetailEditDeleteUiState(
     rename: {
       ...renameViewModel,
       isDeviceRequired: flow.isSignerRequiredForEdit,
-      labels: labels.rename,
     },
     delete: {
       isOpen: flow.deleteLifecycle.status === "open",
       isDeleting: flow.isDeleting,
-      labels: labels.delete,
       onConfirm: flow.confirmDelete,
       onCancel: flow.cancelDelete,
     },

--- a/features/flow/contacts/src/steps/Detail/editDelete/resolveContactDetailEditDeleteLabels.ts
+++ b/features/flow/contacts/src/steps/Detail/editDelete/resolveContactDetailEditDeleteLabels.ts
@@ -1,51 +1,24 @@
-import {
-  DUPLICATE_CONTACT_NAME_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
-} from "@domain/entity-contact";
-import type { ContactsDeleteContactDialogLabels } from "@features/flow-contacts-delete-contact";
-import type { ContactsRenameContactLabels } from "@features/flow-contacts-edit-contact";
 import type { ContactDetailActionsLabels } from "../types";
 import { resolveContactEditSignerActionLabels } from "../model/resolveContactEditSignerActionLabels";
 
 export type ContactDetailEditDeleteLabels = Readonly<{
   actions: ContactDetailActionsLabels;
-  rename: ContactsRenameContactLabels;
-  delete: ContactsDeleteContactDialogLabels;
 }> &
   ReturnType<typeof resolveContactEditSignerActionLabels>;
 
 export type ResolveContactDetailEditDeleteLabelsOptions = Readonly<{
   t: (key: string) => string;
   editContactLabelKey?: string;
-  deleteDescriptionKey?: string;
 }>;
 
 export function resolveContactDetailEditDeleteLabels({
   t,
   editContactLabelKey = "contacts.detailActions.editContact",
-  deleteDescriptionKey = "contacts.deleteContact.description",
 }: ResolveContactDetailEditDeleteLabelsOptions): ContactDetailEditDeleteLabels {
   return {
     actions: {
       editContact: t(editContactLabelKey),
       deleteContact: t("contacts.detailActions.deleteContact"),
-    },
-    rename: {
-      title: t("contacts.editContact.title"),
-      namePlaceholder: t("contacts.editContact.namePlaceholder"),
-      namingDisclaimer: t("contacts.editContact.namingDisclaimer"),
-      applyChanges: t("contacts.editContact.applyChanges"),
-      confirmName: t("contacts.editContact.confirmName"),
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.editContact.invalidNameError"),
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
-      },
-    },
-    delete: {
-      title: t("contacts.deleteContact.title"),
-      description: t(deleteDescriptionKey),
-      confirm: t("contacts.deleteContact.confirm"),
-      cancel: t("contacts.deleteContact.cancel"),
     },
     ...resolveContactEditSignerActionLabels(t),
   };

--- a/features/flow/contacts/src/steps/Detail/editDelete/resolveContactDetailEditDeleteLabels.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/editDelete/resolveContactDetailEditDeleteLabels.web.test.ts
@@ -1,7 +1,3 @@
-import {
-  DUPLICATE_CONTACT_NAME_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
-} from "@domain/entity-contact";
 import { resolveContactDetailEditDeleteLabels } from "./resolveContactDetailEditDeleteLabels";
 
 describe("resolveContactDetailEditDeleteLabels", () => {
@@ -11,10 +7,6 @@ describe("resolveContactDetailEditDeleteLabels", () => {
     const labels = resolveContactDetailEditDeleteLabels({ t });
 
     expect(labels.actions.editContact).toBe("contacts.detailActions.editContact");
-    expect(labels.rename.nameValidationErrors).toEqual({
-      [INVALID_CONTACT_NAME_ERROR_NAME]: "contacts.editContact.invalidNameError",
-      [DUPLICATE_CONTACT_NAME_ERROR_NAME]: "contacts.addContactDrawer.duplicateNameError",
-    });
     expect(labels.signerMismatch.title).toBe("contacts.editSignerMismatch.title");
   });
 
@@ -24,10 +16,8 @@ describe("resolveContactDetailEditDeleteLabels", () => {
     const labels = resolveContactDetailEditDeleteLabels({
       t,
       editContactLabelKey: "contacts.detailActions.editName",
-      deleteDescriptionKey: "contacts.deleteContact.mobileDescription",
     });
 
     expect(labels.actions.editContact).toBe("contacts.detailActions.editName");
-    expect(labels.delete.description).toBe("contacts.deleteContact.mobileDescription");
   });
 });

--- a/features/flow/contacts/src/steps/Detail/model/mapContactAddressDetailActionsUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/model/mapContactAddressDetailActionsUiState.ts
@@ -46,7 +46,6 @@ export function createInactiveContactAddressDetailActionsUiState(
       addressEntry: EMPTY_ADDRESS_ENTRY_STATE,
       isConfirmEnabled: false,
       isDeviceRequired: false,
-      labels: labels.rename,
       onOpen: () => undefined,
       onClose: () => undefined,
       onDraftLabelChange: () => undefined,
@@ -86,7 +85,6 @@ export function createActiveContactAddressDetailActionsUiState(
     rename: {
       ...renameViewModel,
       isDeviceRequired: flow.isSignerRequiredForEdit,
-      labels: labels.rename,
     },
     signerMismatch: {
       isOpen: flow.editUiState === "signer-mismatch",

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
@@ -1,26 +1,17 @@
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
 import type { ContactsDeleteAddressDialogLabels } from "../components/ContactsDeleteAddressDialog/types";
-import type { ContactsRenameAddressLabels } from "@features/flow-contacts-edit-address";
 import { resolveContactEditSignerActionLabels } from "./resolveContactEditSignerActionLabels";
 
 export type ContactAddressDetailActionsLabels = Readonly<{
   delete: ContactsDeleteAddressDialogLabels;
-  rename: ContactsRenameAddressLabels;
 }> &
   ReturnType<typeof resolveContactEditSignerActionLabels>;
 
 export type ResolveContactAddressDetailActionsLabelsOptions = Readonly<{
   t: (key: string) => string;
-  addressLabelTooLongKey?: string;
 }>;
 
 export function resolveContactAddressDetailActionsLabels({
   t,
-  addressLabelTooLongKey = "contacts.addAddressName.tooLongLabel",
 }: ResolveContactAddressDetailActionsLabelsOptions): ContactAddressDetailActionsLabels {
   return {
     delete: {
@@ -28,27 +19,6 @@ export function resolveContactAddressDetailActionsLabels({
       description: t("contacts.deleteAddress.description"),
       confirm: t("contacts.deleteAddress.confirm"),
       cancel: t("contacts.deleteAddress.cancel"),
-    },
-    rename: {
-      title: t("contacts.editAddress.title"),
-      inputLabel: t("contacts.editAddress.inputLabel"),
-      applyChanges: t("contacts.editAddress.applyChanges"),
-      labelValidationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.editAddress.invalidLabelError"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(addressLabelTooLongKey),
-      },
-      addressValidation: {
-        addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-        validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-        validAddress: t("contacts.addAddressEntry.validAddress"),
-        invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-        domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-        sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-        validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-        ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-        ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-      },
     },
     ...resolveContactEditSignerActionLabels(t),
   };

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.web.test.ts
@@ -1,8 +1,3 @@
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
 import { resolveContactAddressDetailActionsLabels } from "./resolveContactAddressDetailActionsLabels";
 
 describe("resolveContactAddressDetailActionsLabels", () => {
@@ -12,27 +7,6 @@ describe("resolveContactAddressDetailActionsLabels", () => {
     const labels = resolveContactAddressDetailActionsLabels({ t });
 
     expect(labels.delete.title).toBe("contacts.deleteAddress.title");
-    expect(labels.rename.labelValidationErrors).toEqual({
-      [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "contacts.editAddress.invalidLabelError",
-      [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "contacts.addAddressName.duplicateLabel",
-      [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "contacts.addAddressName.tooLongLabel",
-    });
-    expect(labels.rename.addressValidation.addressPlaceholder).toBe(
-      "contacts.addAddressEntry.addressPlaceholder",
-    );
     expect(labels.signerMismatch.title).toBe("contacts.editSignerMismatch.title");
-  });
-
-  it("allows overriding the address label too long translation key", () => {
-    const t = jest.fn((key: string) => key);
-
-    const labels = resolveContactAddressDetailActionsLabels({
-      t,
-      addressLabelTooLongKey: "contacts.addAddressName.labelTooLong",
-    });
-
-    expect(labels.rename.labelValidationErrors[CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]).toBe(
-      "contacts.addAddressName.labelTooLong",
-    );
   });
 });

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -72,7 +72,6 @@ export type ContactDetailActionsLabels = Readonly<{
 
 export type ContactDetailViewProps = Readonly<{
   contact: Contact;
-  labels: ContactDetailLabels;
   meAvatarSrc: string;
   onAddAddress: () => void;
   ledgerWalletAccountsIntent?: ContactDetailLedgerWalletAccountsIntent;
@@ -81,7 +80,6 @@ export type ContactDetailViewProps = Readonly<{
   onAddressRowPress?: (intent: ContactDetailAddressRowIntent) => void;
   detailActions?: Readonly<{
     canDelete: boolean;
-    labels: ContactDetailActionsLabels;
     onEdit: () => void;
     onDelete: () => void;
   }>;

--- a/features/flow/contacts/src/steps/Detail/useContactDetailSharedState.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactDetailSharedState.ts
@@ -1,22 +1,27 @@
 import { selectContactById, type ContactId } from "@domain/entity-contact";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
-import { identityFormatMeDisplayName } from "@features/platform-contacts";
+import { createMeDisplayNameFormatter } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import { createContactDetailSharedState } from "./model/contactDetailSharedState";
 
 type ContactsStateRoot = Parameters<typeof selectContactById>[0];
 
-export function useContactDetailSharedState(
-  contactId: ContactId | undefined,
-  formatMeDisplayName?: (name: string) => string,
-) {
+export function useContactDetailSharedState(contactId: ContactId | undefined) {
+  const { t } = useTranslation();
   const contact = useSelector((state: ContactsStateRoot) =>
     contactId ? selectContactById(state, contactId) : undefined,
   );
-  const formatName = formatMeDisplayName ?? identityFormatMeDisplayName;
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+        t("contacts.detail.meDisplayName", { name }),
+      ),
+    [t],
+  );
 
   return useMemo(
-    () => (contact ? createContactDetailSharedState(contact, formatName) : undefined),
-    [contact, formatName],
+    () => (contact ? createContactDetailSharedState(contact, formatMeDisplayName) : undefined),
+    [contact, formatMeDisplayName],
   );
 }

--- a/features/flow/flow-contacts-add-address/package.json
+++ b/features/flow/flow-contacts-add-address/package.json
@@ -27,7 +27,8 @@
     "@domain/entity-contact": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
@@ -1,23 +1,12 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { ContactAddressValueSchema } from "@domain/entity-contact";
-import type { AddAddressEntryLabels, AddAddressEntryState } from "../../../../state/types";
+import type { AddAddressEntryState } from "../../../../state/types";
 import { ContactsAddAddressEntry } from "./ContactsAddAddressEntry";
 
-const labels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address or ENS",
-  confirmAddress: "Confirm address",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "No address found for this domain",
-  sanctionedAddress: "This address is sanctioned and cannot be used.",
-  validationUnavailable: "Address validation is unavailable",
-  ensDisclaimer: "ENS names resolve to wallet addresses.",
-  ensDisclaimerDescription:
-    "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
-};
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 const VALID_ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
 
@@ -29,7 +18,6 @@ function renderEntry(addressEntry: AddAddressEntryState, bottomOffset?: number) 
   render(
     <ContactsAddAddressEntry
       addressEntry={addressEntry}
-      labels={labels}
       {...(bottomOffset === undefined ? {} : { bottomOffset })}
       onChangeText={onChangeText}
       onConfirm={onConfirm}
@@ -50,8 +38,10 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     const addressInput = screen.getByTestId("contacts-add-address-input");
-    expect(screen.UNSAFE_getByProps({ title: "Enter address" }).props.title).toBe("Enter address");
-    expect(addressInput.props.placeholder).toBe("Address or ENS");
+    expect(screen.UNSAFE_getByProps({ title: "contacts.addAddressEntry.title" }).props.title).toBe(
+      "contacts.addAddressEntry.title",
+    );
+    expect(addressInput.props.placeholder).toBe("contacts.addAddressEntry.addressPlaceholder");
     expect(screen.getByTestId("contacts-add-address-entry-screen")).toHaveStyle({
       bottom: 0,
       paddingBottom: 32,
@@ -135,7 +125,7 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-input").props.helperText).toBe(
-      "Validating address",
+      "contacts.addAddressEntry.validatingAddress",
     );
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
   });
@@ -150,7 +140,6 @@ describe("ContactsAddAddressEntry", () => {
           inputMethod: "manual",
           error: "sanctioned",
         }}
-        labels={labels}
         sanctionedAddressBanner={{
           description: "This wallet address is sanctioned.",
           actionLabel: "Learn more",
@@ -179,7 +168,7 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
-      helperText: "Valid address",
+      helperText: "contacts.addAddressEntry.validAddress",
       status: "success",
     });
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(false);
@@ -190,9 +179,9 @@ describe("ContactsAddAddressEntry", () => {
   });
 
   it.each([
-    ["invalid_format", "Invalid address"],
-    ["domain_not_found", "No address found for this domain"],
-    ["sanctioned", "This address is sanctioned and cannot be used."],
+    ["invalid_format", "contacts.addAddressEntry.invalidAddress"],
+    ["domain_not_found", "contacts.addAddressEntry.domainNotFound"],
+    ["sanctioned", "contacts.addAddressEntry.sanctionedAddress"],
   ] as const)("should render the %s error", (error, expectedMessage) => {
     renderEntry({
       status: "invalid",
@@ -218,7 +207,7 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
-      helperText: "Address validation is unavailable",
+      helperText: "contacts.addAddressEntry.validationUnavailable",
       status: "error",
     });
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
@@ -233,10 +222,10 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-ens-disclaimer").props.title).toBe(
-      "ENS names resolve to wallet addresses.",
+      "contacts.addAddressEntry.ensDisclaimer",
     );
     expect(screen.getByTestId("contacts-add-address-ens-disclaimer").props.description).toBe(
-      "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
+      "contacts.addAddressEntry.ensDisclaimerDescription",
     );
   });
 });

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.ts
@@ -9,7 +9,6 @@ export type { SanctionedAddressBannerProps } from "../../../../components/Sancti
 
 export type ContactsAddAddressEntryProps = Readonly<{
   addressEntry: AddAddressEntryState;
-  labels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
   bottomOffset?: number;
   onChangeText: (value: string, inputMethod: AddAddressInputSource) => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.web.ts
@@ -10,7 +10,6 @@ import type {
 
 export type AddressLabelConfiguration = Readonly<{
   addressLabel: AddAddressLabelState;
-  nameLabels: ContactsAddAddressNameLabels;
   onAddressLabelChange: (value: string) => void;
 }>;
 
@@ -36,7 +35,6 @@ type WithoutAddressLabelViewConfiguration = Readonly<{
 
 type ContactsAddAddressEntryWebBaseProps = Readonly<{
   addressEntry: AddAddressEntryState;
-  labels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onConfirm?: () => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.native.ts
@@ -8,16 +8,30 @@ import type {
   ContactsAddAddressEntryViewProps,
 } from "../components/ContactsAddAddressEntry/ContactsAddAddressEntry.types";
 import { classifyNativeAddressInputMethod } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
-  labels,
   sanctionedAddressBanner,
   bottomOffset = 0,
   onChangeText,
   onConfirm,
   onQrCodeClick,
 }: ContactsAddAddressEntryProps): ContactsAddAddressEntryViewProps {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.addAddressEntry.title"),
+    addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+    confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+    validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+    domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+    sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+    validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+    ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+  };
   const presentation = resolveAddAddressEntryPresentation(addressEntry, labels);
   const showSanctionedAddressBanner = shouldShowSanctionedAddressBanner(
     addressEntry,

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
@@ -4,48 +4,23 @@ import {
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   ContactAddressValueSchema,
 } from "@domain/entity-contact";
-import type { ContactsAddAddressNameLabels } from "../../AddressName/types";
 import type { ContactsAddAddressEntryWebProps } from "../components/ContactsAddAddressEntry/ContactsAddAddressEntry";
-import type { AddAddressEntryLabels } from "../../../state/types";
 import { useContactsAddAddressEntryViewModel } from "./useContactsAddAddressEntryViewModel";
 
-const labels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address or ENS",
-  confirmAddress: "Continue to review",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "This address is sanctioned and cannot be used.",
-  validationUnavailable: "Address validation is temporarily unavailable.",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
-};
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
   "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
 );
-const nameLabels: ContactsAddAddressNameLabels = {
-  inputLabel: "Address name",
-  namingDisclaimer: "Address naming disclaimer",
-  namingDisclaimerAccessibilityLabel: "Address name information",
-  continueToReview: "Continue to review",
-  validAddress: "Valid address",
-  validationErrors: {
-    InvalidContactAddressLabelError: "Special characters are not allowed.",
-    DuplicateContactAddressLabelError: "Duplicate address name.",
-    ContactAddressLabelTooLongError: "Address name is too long.",
-  },
-};
 
 type ContactsAddAddressEntryWebBaseOverrides = Partial<
-  Omit<ContactsAddAddressEntryWebProps, "addressLabel" | "nameLabels" | "onAddressLabelChange">
+  Omit<ContactsAddAddressEntryWebProps, "addressLabel" | "onAddressLabelChange">
 >;
 
 type ContactsAddAddressEntryWebWithLabelOverrides = ContactsAddAddressEntryWebBaseOverrides &
-  Required<
-    Pick<ContactsAddAddressEntryWebProps, "addressLabel" | "nameLabels" | "onAddressLabelChange">
-  >;
+  Required<Pick<ContactsAddAddressEntryWebProps, "addressLabel" | "onAddressLabelChange">>;
 
 function renderViewModel(
   overrides:
@@ -55,7 +30,6 @@ function renderViewModel(
   const onAddressChange = jest.fn();
   const props: ContactsAddAddressEntryWebProps = {
     addressEntry: { status: "empty", value: "", resolvedAddress: null, inputMethod: null },
-    labels,
     onAddressChange,
     ...overrides,
   } as ContactsAddAddressEntryWebProps;
@@ -123,7 +97,7 @@ describe("useContactsAddAddressEntryViewModel", () => {
 
     expect(result.current).toMatchObject({
       inputStatus: "success",
-      helperText: "Valid address",
+      helperText: "contacts.addAddressEntry.validAddress",
       showEnsDisclaimer: true,
       isConfirmEnabled: true,
     });
@@ -161,7 +135,7 @@ describe("useContactsAddAddressEntryViewModel", () => {
 
     expect(result.current).toMatchObject({
       inputStatus: "error",
-      helperText: "This address is sanctioned and cannot be used.",
+      helperText: "contacts.addAddressEntry.sanctionedAddress",
       isConfirmEnabled: false,
     });
     expect(result.current.sanctionedAddressBanner).toEqual({
@@ -186,13 +160,12 @@ describe("useContactsAddAddressEntryViewModel", () => {
         label: null,
         validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
-      nameLabels,
       onAddressLabelChange,
       onConfirm: jest.fn(),
     });
 
     expect(result.current.isConfirmEnabled).toBe(false);
-    expect(result.current.nameValidationMessage).toBe("Special characters are not allowed.");
+    expect(result.current.nameValidationMessage).toBe("contacts.addAddressName.invalidLabel");
 
     act(() => {
       result.current.onAddressLabelChange?.({

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type ChangeEvent, type ClipboardEvent } from "react";
+import { useCallback, type ChangeEvent, type ClipboardEvent } from "react";
 import { getPastedValue } from "@features/platform-contacts";
 import {
   resolveAddAddressEntryPresentation,
@@ -9,30 +9,57 @@ import type {
   ContactsAddAddressEntryWebProps,
   ContactsAddAddressEntryWebViewProps,
 } from "../components/ContactsAddAddressEntry/ContactsAddAddressEntry.types";
+import { useTranslation } from "@shared/i18n";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
 
 function getAddressLabelConfiguration({
   addressLabel,
-  nameLabels,
   onAddressLabelChange,
 }: Partial<AddressLabelConfiguration>): AddressLabelConfiguration | undefined {
-  return addressLabel && nameLabels && onAddressLabelChange
-    ? { addressLabel, nameLabels, onAddressLabelChange }
-    : undefined;
+  return addressLabel && onAddressLabelChange ? { addressLabel, onAddressLabelChange } : undefined;
 }
 
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
-  labels,
   sanctionedAddressBanner,
   onAddressChange,
   onConfirm,
   ...addressLabelProps
 }: ContactsAddAddressEntryWebProps): ContactsAddAddressEntryWebViewProps {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.addAddressEntry.title"),
+    addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+    confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+    validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+    domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+    sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+    validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+    ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+  };
+  const nameLabels = {
+    inputLabel: t("contacts.addAddressName.inputLabel"),
+    namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+    namingDisclaimerAccessibilityLabel: t(
+      "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+    ),
+    continueToReview: t("contacts.addAddressName.continueToReview"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    validationErrors: {
+      [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+      [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+      [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+    },
+  };
   const addressLabelConfiguration = getAddressLabelConfiguration(addressLabelProps);
-  const presentation = useMemo(
-    () => resolveAddAddressEntryPresentation(addressEntry, labels),
-    [addressEntry, labels],
-  );
+  const presentation = resolveAddAddressEntryPresentation(addressEntry, labels);
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => onAddressChange(event.target.value, "manual"),
     [onAddressChange],
@@ -49,15 +76,9 @@ export function useContactsAddAddressEntryViewModel({
       addressLabelConfiguration?.onAddressLabelChange(event.target.value),
     [addressLabelConfiguration],
   );
-  const nameValidationMessage = useMemo(
-    () =>
-      addressLabelConfiguration?.addressLabel.validationError
-        ? addressLabelConfiguration.nameLabels.validationErrors[
-            addressLabelConfiguration.addressLabel.validationError
-          ]
-        : undefined,
-    [addressLabelConfiguration],
-  );
+  const nameValidationMessage = addressLabelConfiguration?.addressLabel.validationError
+    ? nameLabels.validationErrors[addressLabelConfiguration.addressLabel.validationError]
+    : undefined;
   const isNameValid =
     addressLabelConfiguration === undefined ||
     addressLabelConfiguration.addressLabel.status === "valid";
@@ -69,7 +90,7 @@ export function useContactsAddAddressEntryViewModel({
   const addressLabelViewProps = addressLabelConfiguration
     ? {
         addressLabel: addressLabelConfiguration.addressLabel,
-        nameLabels: addressLabelConfiguration.nameLabels,
+        nameLabels,
         nameValidationMessage,
         onAddressLabelChange: onNameChange,
       }

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.test.tsx
@@ -7,21 +7,12 @@ import {
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
-import type { AddAddressLabelState, AddAddressNameLabels } from "../../state/types";
+import type { AddAddressLabelState } from "../../state/types";
 import { ContactsAddAddressName } from "./ContactsAddAddressName";
 
-const labels: AddAddressNameLabels = {
-  title: "Name address",
-  inputLabel: "Address name",
-  namingDisclaimer: "Only you can see this name.",
-  continueToReview: "Continue to review",
-  validationErrors: {
-    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
-    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
-      "This address name is already used for this contact.",
-    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
-  },
-};
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 describe("ContactsAddAddressName", () => {
   it("should render the default label with an enabled review action", () => {
@@ -36,21 +27,23 @@ describe("ContactsAddAddressName", () => {
           label: ContactAddressLabelSchema.parse("Ethereum"),
           validationError: null,
         }}
-        labels={labels}
+
         onChangeText={onChangeText}
         onContinue={onContinue}
       />,
     );
 
-    expect(screen.UNSAFE_getByProps({ title: "Name address" }).props.title).toBe("Name address");
+    expect(screen.UNSAFE_getByProps({ title: "contacts.addAddressName.title" }).props.title).toBe(
+      "contacts.addAddressName.title",
+    );
     expect(screen.getByTestId("contacts-add-address-name-input").props).toMatchObject({
-      label: "Address name",
+      label: "contacts.addAddressName.inputLabel",
       maxLength: CONTACT_ADDRESS_LABEL_MAX_LENGTH,
       value: "Ethereum",
     });
     expect(screen.getByTestId("contacts-add-address-name-count")).toHaveTextContent("8/32");
     expect(screen.getByTestId("contacts-add-address-name-disclaimer").props.description).toBe(
-      "Only you can see this name.",
+      "contacts.addAddressName.namingDisclaimer",
     );
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
     expect(screen.getByTestId("contacts-add-address-name-continue").props.icon).toEqual(
@@ -73,7 +66,7 @@ describe("ContactsAddAddressName", () => {
           label: ContactAddressLabelSchema.parse("Ethereum"),
           validationError: null,
         }}
-        labels={labels}
+
         bottomOffset={320}
         onChangeText={jest.fn()}
         onContinue={jest.fn()}
@@ -95,7 +88,7 @@ describe("ContactsAddAddressName", () => {
         label: null,
         validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
-      helperText: "Special characters are not allowed.",
+      helperText: "contacts.addAddressName.invalidLabel",
     },
     {
       name: "duplicate label",
@@ -105,7 +98,7 @@ describe("ContactsAddAddressName", () => {
         label: null,
         validationError: DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
-      helperText: "This address name is already used for this contact.",
+      helperText: "contacts.addAddressName.duplicateLabel",
     },
     {
       name: "too long label",
@@ -115,7 +108,7 @@ describe("ContactsAddAddressName", () => {
         label: null,
         validationError: CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
       },
-      helperText: "This address name is too long.",
+      helperText: "contacts.addAddressName.labelTooLong",
     },
     {
       name: "empty label",
@@ -135,7 +128,7 @@ describe("ContactsAddAddressName", () => {
     render(
       <ContactsAddAddressName
         addressLabel={addressLabel}
-        labels={labels}
+
         onChangeText={jest.fn()}
         onContinue={jest.fn()}
       />,

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.tsx
@@ -9,12 +9,17 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
-import type { AddAddressLabelState, AddAddressNameLabels } from "../../state/types";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import type { AddAddressLabelState } from "../../state/types";
+import { useTranslation } from "@shared/i18n";
 
 export type ContactsAddAddressNameProps = Readonly<{
   addressLabel: AddAddressLabelState;
-  labels: AddAddressNameLabels;
   bottomOffset?: number;
   onChangeText: (value: string) => void;
   onContinue: () => void;
@@ -22,13 +27,18 @@ export type ContactsAddAddressNameProps = Readonly<{
 
 export function ContactsAddAddressName({
   addressLabel,
-  labels,
   bottomOffset = 0,
   onChangeText,
   onContinue,
 }: ContactsAddAddressNameProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const validationErrors = {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.labelTooLong"),
+  };
   const validationMessage = addressLabel.validationError
-    ? labels.validationErrors[addressLabel.validationError]
+    ? validationErrors[addressLabel.validationError]
     : undefined;
 
   return (
@@ -36,7 +46,7 @@ export function ContactsAddAddressName({
       testID="contacts-add-address-name-screen"
       style={{ bottom: 0, paddingBottom: bottomOffset > 0 ? bottomOffset : 32 }}
     >
-      <BottomSheetHeader density="expanded" title={labels.title} />
+      <BottomSheetHeader density="expanded" title={t("contacts.addAddressName.title")} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
         <Box lx={{ gap: "s16" }}>
           <Box lx={{ gap: "s8" }}>
@@ -44,7 +54,7 @@ export function ContactsAddAddressName({
               testID="contacts-add-address-name-input"
               autoFocus
               autoCorrect={false}
-              label={labels.inputLabel}
+              label={t("contacts.addAddressName.inputLabel")}
               value={addressLabel.value}
               helperText={validationMessage}
               maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
@@ -65,7 +75,7 @@ export function ContactsAddAddressName({
           <Banner
             testID="contacts-add-address-name-disclaimer"
             appearance="info"
-            description={labels.namingDisclaimer}
+            description={t("contacts.addAddressName.namingDisclaimer")}
           />
         </Box>
         <Button
@@ -77,7 +87,7 @@ export function ContactsAddAddressName({
           icon={LedgerLogo}
           onPress={onContinue}
         >
-          {labels.continueToReview}
+          {t("contacts.addAddressName.continueToReview")}
         </Button>
       </Box>
     </BottomSheetView>

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/types.ts
@@ -14,7 +14,6 @@ export type ContactsAddAddressNameLabels = Readonly<{
 export type ContactsAddAddressNameProps = Readonly<{
   addressEntry: ValidAddAddressEntryState;
   addressLabel: AddAddressLabelState;
-  labels: ContactsAddAddressNameLabels;
   showConfirmedAddress?: boolean;
   onAddressLabelChange: (value: string) => void;
   onContinue: () => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/useContactsAddAddressNameViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/useContactsAddAddressNameViewModel.web.ts
@@ -1,21 +1,37 @@
-import { useCallback, useMemo, type ChangeEvent } from "react";
+import { useCallback, type ChangeEvent } from "react";
 import type { ContactsAddAddressNameProps, ContactsAddAddressNameViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
 
 export function useContactsAddAddressNameViewModel({
   addressEntry,
   addressLabel,
-  labels,
   showConfirmedAddress = true,
   onAddressLabelChange,
   onContinue,
 }: ContactsAddAddressNameProps): ContactsAddAddressNameViewProps {
-  const validationMessage = useMemo(
-    () =>
-      addressLabel.validationError
-        ? labels.validationErrors[addressLabel.validationError]
-        : undefined,
-    [addressLabel.validationError, labels.validationErrors],
-  );
+  const { t } = useTranslation();
+  const labels = {
+    inputLabel: t("contacts.addAddressName.inputLabel"),
+    namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+    namingDisclaimerAccessibilityLabel: t(
+      "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+    ),
+    continueToReview: t("contacts.addAddressName.continueToReview"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    validationErrors: {
+      [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+      [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+      [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+    },
+  };
+  const validationMessage = addressLabel.validationError
+    ? labels.validationErrors[addressLabel.validationError]
+    : undefined;
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => onAddressLabelChange(event.target.value),
     [onAddressLabelChange],

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
@@ -1,43 +1,17 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  ContactAddressLabelSchema,
-  ContactAddressValueSchema,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
-import type { AddAddressEntryLabels, AddAddressNameLabels } from "../../state/types";
+import { ContactAddressLabelSchema, ContactAddressValueSchema } from "@domain/entity-contact";
 import {
   ContactsAddAddressFlowContent,
   type ContactsAddAddressFlowContentProps,
 } from "./ContactsAddAddressFlowContent";
 
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 const address = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
-const entryLabels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address or ENS",
-  confirmAddress: "Confirm address",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Address is sanctioned",
-  validationUnavailable: "Address validation is unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
-};
-const nameLabels: AddAddressNameLabels = {
-  title: "Address name",
-  inputLabel: "Name",
-  namingDisclaimer: "Only you can see this name.",
-  continueToReview: "Continue to review",
-  validationErrors: {
-    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Invalid characters",
-    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Duplicate name",
-    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "Name is too long",
-  },
-};
+
 function createProps(
   step: ContactsAddAddressFlowContentProps["step"],
 ): ContactsAddAddressFlowContentProps {
@@ -50,7 +24,6 @@ function createProps(
         resolvedAddress: address,
         inputMethod: "manual",
       },
-      labels: entryLabels,
       onChangeText: jest.fn(),
       onConfirm: jest.fn(),
       onQrCodeClick: jest.fn(),
@@ -62,7 +35,6 @@ function createProps(
         label: ContactAddressLabelSchema.parse("Ethereum"),
         validationError: null,
       },
-      labels: nameLabels,
       onChangeText: jest.fn(),
       onContinue: jest.fn(),
     },
@@ -71,14 +43,6 @@ function createProps(
       currency: "Ethereum",
       network: "Ethereum",
       name: "Ethereum",
-      labels: {
-        title: "Review address",
-        addressLabel: "Address",
-        currencyLabel: "Currency",
-        networkLabel: "Network",
-        nameLabel: "Address name",
-        continue: "Confirm address",
-      },
       onContinue: jest.fn(),
     },
   };

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -4,10 +4,9 @@ import {
   ContactAddressLabelSchema,
   ContactAddressValueSchema,
   type ContactAddress,
-  type ContactAddressLabelValidationErrorName,
   type ContactId,
 } from "@domain/entity-contact";
-import type { AddAddressEntryLabels, AddAddressFlowState } from "../../state/types";
+import type { AddAddressFlowState } from "../../state/types";
 import {
   ContactsAddAddressFlowContent,
   type ContactsAddAddressFlowContentProps,
@@ -15,8 +14,10 @@ import {
   shouldUseAddAddressFlowBackNavigation,
   type AddAddressWebFlowStep,
 } from "./ContactsAddAddressFlowContent";
-import type { ContactsAddAddressNameLabels } from "../AddressName/types";
-import type { ContactsAddAddressReviewLabels } from "../Review/types";
+
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 type OpenAddAddressFlowState = Exclude<AddAddressFlowState, { status: "closed" }>;
 
@@ -24,35 +25,6 @@ function createState(status: OpenAddAddressFlowState["status"]): OpenAddAddressF
   return { status } as OpenAddAddressFlowState;
 }
 
-const entryLabels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address",
-  confirmAddress: "Continue",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Address is sanctioned",
-  validationUnavailable: "Address validation is unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
-};
-const nameLabels: ContactsAddAddressNameLabels = {
-  inputLabel: "Address name",
-  namingDisclaimer: "Address naming disclaimer",
-  namingDisclaimerAccessibilityLabel: "Address name information",
-  continueToReview: "Continue to review",
-  validAddress: "Valid address",
-  validationErrors: {} as Record<ContactAddressLabelValidationErrorName, string>,
-};
-const reviewLabels: ContactsAddAddressReviewLabels = {
-  title: "Review address",
-  addressLabel: "Address",
-  currencyLabel: "Currency",
-  networkLabel: "Network",
-  nameLabel: "Address name",
-  continue: "Confirm address",
-};
 const address = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
 const label = ContactAddressLabelSchema.parse("Ethereum");
 
@@ -91,9 +63,6 @@ function createContentProps(
 ): ContactsAddAddressFlowContentProps {
   return {
     state,
-    entryLabels,
-    nameLabels,
-    reviewLabels,
     onAddressChange: jest.fn(),
     onContinueFromAddressDetails: jest.fn(),
     onAddressLabelChange: jest.fn(),

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.tsx
@@ -2,13 +2,8 @@ import React from "react";
 import { ContactsAddAddressEntry } from "../AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry";
 import type { SanctionedAddressBannerProps } from "../../components/SanctionedAddressBanner/types";
 import { ContactsAddAddressNameInput } from "../AddressName/components/Input/ContactsAddAddressNameInput";
-import type { ContactsAddAddressNameLabels } from "../AddressName/types";
-import { ContactsAddAddressReview, type ContactsAddAddressReviewLabels } from "../Review";
-import type {
-  AddAddressEntryLabels,
-  AddAddressFlowState,
-  AddAddressInputSource,
-} from "../../state/types";
+import { ContactsAddAddressReview } from "../Review";
+import type { AddAddressFlowState, AddAddressInputSource } from "../../state/types";
 
 export type AddAddressWebFlowStep = "currency" | "address" | "name" | "review" | "success";
 
@@ -17,10 +12,7 @@ type AddAddressFlowContentState = Exclude<OpenAddAddressFlowState, { status: "se
 
 export type ContactsAddAddressFlowContentProps = Readonly<{
   state: AddAddressFlowContentState;
-  entryLabels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
-  nameLabels: ContactsAddAddressNameLabels;
-  reviewLabels?: ContactsAddAddressReviewLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;
@@ -57,10 +49,7 @@ export function shouldUseAddAddressFlowBackNavigation(state: OpenAddAddressFlowS
 
 export function ContactsAddAddressFlowContent({
   state,
-  entryLabels,
   sanctionedAddressBanner,
-  nameLabels,
-  reviewLabels,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -73,9 +62,7 @@ export function ContactsAddAddressFlowContent({
         <ContactsAddAddressEntry
           addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
-          labels={entryLabels}
           sanctionedAddressBanner={sanctionedAddressBanner}
-          nameLabels={nameLabels}
           onAddressChange={onAddressChange}
           onAddressLabelChange={onAddressLabelChange}
           onConfirm={onContinueFromAddressDetails}
@@ -86,7 +73,6 @@ export function ContactsAddAddressFlowContent({
         <ContactsAddAddressNameInput
           addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
-          labels={nameLabels}
           showConfirmedAddress={state.entryMode === "mad"}
           onAddressLabelChange={onAddressLabelChange}
           onContinue={onContinueFromName}
@@ -95,17 +81,12 @@ export function ContactsAddAddressFlowContent({
     case "confirmationRequired":
       return null;
     case "reviewingAddress":
-      if (
-        state.entryMode === "prefilled" &&
-        state.displayContext !== null &&
-        reviewLabels !== undefined
-      ) {
+      if (state.entryMode === "prefilled" && state.displayContext !== null) {
         return (
           <ContactsAddAddressReview
             addressEntry={state.addressEntry}
             addressLabel={state.addressLabel}
             displayContext={state.displayContext}
-            labels={reviewLabels}
             onContinue={onContinueFromReview}
           />
         );

--- a/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.native.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { ContactsAddAddressReviewViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
 
 function ReviewRow({
   label,
@@ -24,7 +25,10 @@ function ReviewRow({
   );
 }
 
-export type ContactsAddAddressReviewNativeProps = ContactsAddAddressReviewViewProps &
+export type ContactsAddAddressReviewNativeProps = Omit<
+  ContactsAddAddressReviewViewProps,
+  "labels"
+> &
   Readonly<{
     bottomOffset?: number;
   }>;
@@ -34,35 +38,35 @@ export function ContactsAddAddressReview({
   currency,
   network,
   name,
-  labels,
   bottomOffset = 0,
   onContinue,
 }: ContactsAddAddressReviewNativeProps): React.JSX.Element {
+  const { t } = useTranslation();
   return (
     <BottomSheetView
       testID="contacts-add-address-review"
       style={{ bottom: 0, paddingBottom: 32 + bottomOffset }}
     >
-      <BottomSheetHeader density="expanded" title={labels.title} />
+      <BottomSheetHeader density="expanded" title={t("contacts.addAddressReview.title")} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
         <Box lx={{ gap: "s16" }}>
           <ReviewRow
-            label={labels.addressLabel}
+            label={t("contacts.addAddressReview.addressLabel")}
             testID="contacts-add-address-review-address"
             value={address}
           />
           <ReviewRow
-            label={labels.currencyLabel}
+            label={t("contacts.addAddressReview.currencyLabel")}
             testID="contacts-add-address-review-currency"
             value={currency}
           />
           <ReviewRow
-            label={labels.networkLabel}
+            label={t("contacts.addAddressReview.networkLabel")}
             testID="contacts-add-address-review-network"
             value={network}
           />
           <ReviewRow
-            label={labels.nameLabel}
+            label={t("contacts.addAddressReview.nameLabel")}
             testID="contacts-add-address-review-name"
             value={name}
           />
@@ -75,7 +79,7 @@ export function ContactsAddAddressReview({
           icon={LedgerLogo}
           onPress={onContinue}
         >
-          {labels.continue}
+          {t("contacts.addAddressReview.continue")}
         </Button>
       </Box>
     </BottomSheetView>

--- a/features/flow/flow-contacts-add-address/src/screens/Review/types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/types.ts
@@ -17,7 +17,6 @@ export type ContactsAddAddressReviewProps = Readonly<{
   addressEntry: ValidAddAddressEntryState;
   addressLabel: ValidAddAddressLabelState;
   displayContext: AddAddressDisplayContext;
-  labels: ContactsAddAddressReviewLabels;
   onContinue: () => void;
 }>;
 

--- a/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.ts
@@ -1,18 +1,26 @@
 import type { ContactsAddAddressReviewProps, ContactsAddAddressReviewViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
 
 export function useContactsAddAddressReviewViewModel({
   addressEntry,
   addressLabel,
   displayContext,
-  labels,
   onContinue,
 }: ContactsAddAddressReviewProps): ContactsAddAddressReviewViewProps {
+  const { t } = useTranslation();
   return {
     address: addressEntry.resolvedAddress,
     currency: displayContext.assetDisplayName,
     network: displayContext.network.displayName,
     name: addressLabel.label,
-    labels,
+    labels: {
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    },
     onContinue,
   };
 }

--- a/features/flow/flow-contacts-add-contact/package.json
+++ b/features/flow/flow-contacts-add-contact/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Banner, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "@shared/i18n";
 import { ContactNameInput } from "@features/platform-contacts";
 import type { ContactsAddContactContentNativeProps } from "./types";
 
@@ -8,29 +9,33 @@ export function ContactsAddContactContent({
   isSaving,
   draftName,
   invalidNameError,
-  labels,
   autoFocus,
   onDraftNameChange,
   onConfirm,
 }: ContactsAddContactContentNativeProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const nameValidationErrors = {
+    InvalidContactNameError: t("contacts.addContactDrawer.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   return (
     <Box testID="contacts-add-contact-content" lx={{ gap: "s24" }}>
       <Box lx={{ gap: "s16" }}>
         <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-          {labels.title}
+          {t("contacts.addContact")}
         </Text>
         <ContactNameInput
           value={draftName}
-          placeholder={labels.namePlaceholder}
+          placeholder={t("contacts.addContactDrawer.namePlaceholder")}
           errorMessage={nameValidationError}
           isEditable={!isSaving}
           autoFocus={autoFocus}
           onChangeText={onDraftNameChange}
         />
-        <Banner appearance="info" description={labels.namingDisclaimer} />
+        <Banner appearance="info" description={t("contacts.addContactDrawer.namingDisclaimer")} />
       </Box>
       <Button
         appearance="base"
@@ -41,7 +46,7 @@ export function ContactsAddContactContent({
         onPress={onConfirm}
         testID="contacts-add-contact-save"
       >
-        {labels.confirmName}
+        {t("contacts.addContactDrawer.confirmName")}
       </Button>
     </Box>
   );

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.web.tsx
@@ -1,5 +1,6 @@
 import React, { useId } from "react";
 import { Button } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "@shared/i18n";
 import { ContactNameDisclaimer, ContactNameInput } from "@features/platform-contacts";
 import type { ContactsAddContactContentProps } from "./types";
 
@@ -8,24 +9,31 @@ export function ContactsAddContactContent({
   isSaving,
   draftName,
   invalidNameError,
-  labels,
   onDraftNameChange,
   onConfirm,
 }: ContactsAddContactContentProps): React.ReactNode {
+  const { t } = useTranslation();
   const namingDisclaimerId = useId();
+  const nameValidationErrors = {
+    InvalidContactNameError: t("contacts.addContactDrawer.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   return (
     <div aria-describedby={namingDisclaimerId} className="flex flex-col gap-24 px-24 pb-24 pt-12">
       <ContactNameInput
         value={draftName}
-        placeholder={labels.namePlaceholder}
+        placeholder={t("contacts.addContactDrawer.namePlaceholder")}
         errorMessage={nameValidationError}
         isEditable={!isSaving}
         onChange={onDraftNameChange}
       />
-      <ContactNameDisclaimer disclaimerId={namingDisclaimerId} text={labels.namingDisclaimer} />
+      <ContactNameDisclaimer
+        disclaimerId={namingDisclaimerId}
+        text={t("contacts.addContactDrawer.namingDisclaimer")}
+      />
       <Button
         appearance="base"
         size="lg"
@@ -35,7 +43,7 @@ export function ContactsAddContactContent({
         onClick={() => void onConfirm()}
         data-testid="contacts-add-contact-save"
       >
-        {labels.confirmName}
+        {t("contacts.addContactDrawer.confirmName")}
       </Button>
     </div>
   );

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.tsx
@@ -1,20 +1,22 @@
 import React from "react";
 import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "@shared/i18n";
 import { ContactsAddContactContent } from "./ContactsAddContactContent.web";
 import type { AddContactDialogViewModel } from "./types";
 
 export function ContactsAddContactDialog({
   isOpen,
   onClose,
-  labels,
   ...contentProps
 }: AddContactDialogViewModel): React.ReactNode {
+  const { t } = useTranslation();
+
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
       <DialogContent className="pb-24" data-testid="contacts-add-contact-dialog">
-        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogHeader density="expanded" title={t("contacts.addContact")} onClose={onClose} />
         <DialogBody className="p-0">
-          <ContactsAddContactContent labels={labels} {...contentProps} />
+          <ContactsAddContactContent {...contentProps} />
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/types.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/types.ts
@@ -17,18 +17,7 @@ export type UseAddContactContentViewModelOptions = Readonly<{
   onSaveSuccess: (contact: Contact) => void;
 }>;
 
-export type ContactsAddContactContentLabels = Readonly<{
-  title: string;
-  namePlaceholder: string;
-  namingDisclaimer: string;
-  confirmName: string;
-  nameValidationErrors: Readonly<Record<ContactNameValidationErrorName, string>>;
-}>;
-
-export type ContactsAddContactContentProps = AddContactContentViewModel &
-  Readonly<{
-    labels: ContactsAddContactContentLabels;
-  }>;
+export type ContactsAddContactContentProps = AddContactContentViewModel;
 
 export type ContactsAddContactContentNativeProps = ContactsAddContactContentProps &
   Readonly<{
@@ -45,7 +34,6 @@ export type AddContactDialogLifecycleCallbacks = Readonly<{
 
 export type UseAddContactDialogViewModelOptions = Readonly<{
   contactCreation: ContactCreationPort;
-  labels: ContactsAddContactContentLabels;
   onSaveSuccess: (contact: Contact) => void;
   callbacks?: AddContactDialogLifecycleCallbacks;
 }>;
@@ -53,7 +41,6 @@ export type UseAddContactDialogViewModelOptions = Readonly<{
 export type AddContactDialogViewModel = AddContactContentViewModel &
   Readonly<{
     isOpen: boolean;
-    labels: ContactsAddContactContentLabels;
     onOpen: () => void;
     onClose: () => void;
   }>;

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDialogViewModel.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDialogViewModel.ts
@@ -9,7 +9,6 @@ import type { AddContactDialogViewModel, UseAddContactDialogViewModelOptions } f
  */
 export function useAddContactDialogViewModel({
   contactCreation,
-  labels,
   onSaveSuccess,
   callbacks,
 }: UseAddContactDialogViewModelOptions): AddContactDialogViewModel {
@@ -59,7 +58,6 @@ export function useAddContactDialogViewModel({
   return {
     ...contentViewModel,
     isOpen,
-    labels,
     onOpen,
     onClose,
     onConfirm,

--- a/features/flow/flow-contacts-delete-contact/package.json
+++ b/features/flow/flow-contacts-delete-contact/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native.tsx
+++ b/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native.tsx
@@ -1,16 +1,24 @@
 import React from "react";
 import { Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { ContactConfirmationBottomSheet } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsDeleteContactDrawerProps } from "./types";
 
 export function ContactsDeleteContactDialog({
   isOpen,
   isDeleting,
   bottomInset = 0,
-  labels,
   onConfirm,
   onCancel,
 }: ContactsDeleteContactDrawerProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.deleteContact.title"),
+    description: t("contacts.deleteContact.mobileDescription"),
+    confirm: t("contacts.deleteContact.confirm"),
+    cancel: t("contacts.deleteContact.cancel"),
+  };
+
   return (
     <ContactConfirmationBottomSheet
       isOpen={isOpen}

--- a/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web.tsx
+++ b/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web.tsx
@@ -1,15 +1,31 @@
 import React from "react";
 import { ContactConfirmationDialog } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsDeleteContactDialogProps } from "./types";
 
-export function ContactsDeleteContactDialog(
-  props: ContactsDeleteContactDialogProps,
-): React.ReactNode {
+export function ContactsDeleteContactDialog({
+  isOpen,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}: ContactsDeleteContactDialogProps): React.ReactNode {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.deleteContact.title"),
+    description: t("contacts.deleteContact.description"),
+    confirm: t("contacts.deleteContact.confirm"),
+    cancel: t("contacts.deleteContact.cancel"),
+  };
+
   return (
     <ContactConfirmationDialog
-      {...props}
+      isOpen={isOpen}
+      isDeleting={isDeleting}
+      labels={labels}
       dialogTestId="contacts-delete-contact-dialog"
       confirmTestId="contacts-delete-contact-confirm"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
     />
   );
 }

--- a/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/types.ts
+++ b/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/types.ts
@@ -1,14 +1,6 @@
-export type ContactsDeleteContactDialogLabels = Readonly<{
-  title: string;
-  description: string;
-  confirm: string;
-  cancel: string;
-}>;
-
 export type ContactsDeleteContactDialogProps = Readonly<{
   isOpen: boolean;
   isDeleting: boolean;
-  labels: ContactsDeleteContactDialogLabels;
   onConfirm: () => Promise<void>;
   onCancel: () => void;
 }>;

--- a/features/flow/flow-contacts-edit-address/package.json
+++ b/features/flow/flow-contacts-edit-address/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
@@ -1,13 +1,40 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressValueSchema,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameAddressDialog } from ".";
 import type { ContactsRenameAddressDialogProps } from "./types";
+
+const i18nResources = {
+  translation: {
+    contacts: {
+      editAddress: {
+        title: "Edit address",
+        inputLabel: "Address label",
+        applyChanges: "Apply changes",
+        invalidLabelError: "Address label is invalid.",
+      },
+      addAddressName: {
+        duplicateLabel: "Address label is already in use.",
+        tooLongLabel: "Address label is too long.",
+      },
+      addAddressEntry: {
+        addressPlaceholder: "Address",
+        validatingAddress: "Validating address",
+        validAddress: "Valid address",
+        invalidAddress: "Invalid address",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned address",
+        validationUnavailable: "Validation unavailable",
+        ensDisclaimer: "ENS addresses are supported.",
+        ensDisclaimerDescription: "ENS names can change over time.",
+      },
+    },
+  },
+};
 
 function createViewModel(
   overrides: Partial<ContactsRenameAddressDialogProps> = {},
@@ -27,27 +54,6 @@ function createViewModel(
       inputMethod: "manual",
     },
     isDeviceRequired: true,
-    labels: {
-      title: "Edit address",
-      inputLabel: "Address label",
-      applyChanges: "Apply changes",
-      labelValidationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is invalid.",
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is already in use.",
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "Address label is too long.",
-      },
-      addressValidation: {
-        addressPlaceholder: "Address",
-        validatingAddress: "Validating address",
-        validAddress: "Valid address",
-        invalidAddress: "Invalid address",
-        domainNotFound: "Domain not found",
-        sanctionedAddress: "Sanctioned address",
-        validationUnavailable: "Validation unavailable",
-        ensDisclaimer: "ENS addresses are supported.",
-        ensDisclaimerDescription: "ENS names can change over time.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftLabelChange: jest.fn(),
@@ -57,15 +63,21 @@ function createViewModel(
   };
 }
 
+function renderDialog(props: ContactsRenameAddressDialogProps) {
+  return render(
+    <I18nTestProvider resources={i18nResources}>
+      <ContactsRenameAddressDialog {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameAddressDialog", () => {
   it("should render the label validation error and disable confirmation", () => {
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          draftLabel: "Treasury",
-          invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        draftLabel: "Treasury",
+        invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-address-input")).toHaveValue("Treasury");
@@ -80,14 +92,12 @@ describe("ContactsRenameAddressDialog", () => {
     const onDraftLabelChange = jest.fn();
     const onConfirm = jest.fn(async () => undefined);
 
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          isConfirmEnabled: true,
-          onDraftLabelChange,
-          onConfirm,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        isConfirmEnabled: true,
+        onDraftLabelChange,
+        onConfirm,
+      }),
     );
 
     fireEvent.change(screen.getByTestId("contacts-rename-address-input"), {

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.tsx
@@ -10,7 +10,14 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  type ContactAddressLabelValidationErrorName,
+} from "@domain/entity-contact";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsRenameAddressDialogProps } from "./types";
 import { useEditAddressDialogPresentation } from "./useEditAddressDialogPresentation.web";
 
@@ -22,17 +29,21 @@ export function ContactsRenameAddressDialog({
   invalidLabelError,
   addressEntry,
   isDeviceRequired,
-  labels,
   onClose,
   onDraftLabelChange,
   onAddressChange,
   onConfirm,
 }: ContactsRenameAddressDialogProps): React.ReactNode {
+  const { t } = useTranslation();
+  const labelValidationErrors: Record<ContactAddressLabelValidationErrorName, string> = {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.editAddress.invalidLabelError"),
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+  };
   const labelValidationError =
-    invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+    invalidLabelError === null ? undefined : labelValidationErrors[invalidLabelError];
   const addressInput = useEditAddressDialogPresentation({
     addressEntry,
-    labels: labels.addressValidation,
     onAddressChange,
   });
 
@@ -48,7 +59,11 @@ export function ContactsRenameAddressDialog({
         className="w-[400px] bg-canvas-sheet pb-24"
         data-testid="contacts-rename-address-dialog"
       >
-        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogHeader
+          density="expanded"
+          title={t("contacts.editAddress.title")}
+          onClose={onClose}
+        />
         <DialogBody className="flex flex-col gap-32 px-24 pt-2 pb-24">
           <AddressInput
             autoComplete="off"
@@ -57,7 +72,7 @@ export function ContactsRenameAddressDialog({
             helperText={addressInput.helperText}
             onChange={addressInput.onChange}
             onPaste={addressInput.onPaste}
-            placeholder={labels.addressValidation.addressPlaceholder}
+            placeholder={t("contacts.addAddressEntry.addressPlaceholder")}
             prefix=""
             spellCheck={false}
             status={addressInput.inputStatus}
@@ -67,8 +82,8 @@ export function ContactsRenameAddressDialog({
             <Banner
               appearance="info"
               data-testid="contacts-edit-address-ens-disclaimer"
-              title={labels.addressValidation.ensDisclaimer}
-              description={labels.addressValidation.ensDisclaimerDescription}
+              title={t("contacts.addAddressEntry.ensDisclaimer")}
+              description={t("contacts.addAddressEntry.ensDisclaimerDescription")}
             />
           ) : null}
           <TextInput
@@ -76,7 +91,7 @@ export function ContactsRenameAddressDialog({
             autoCorrect="off"
             data-testid="contacts-rename-address-input"
             helperText={labelValidationError}
-            label={labels.inputLabel}
+            label={t("contacts.editAddress.inputLabel")}
             maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
             maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
             onChange={event => onDraftLabelChange(event.target.value)}
@@ -94,7 +109,7 @@ export function ContactsRenameAddressDialog({
             onClick={() => void onConfirm()}
             data-testid="contacts-rename-address-confirm"
           >
-            {labels.applyChanges}
+            {t("contacts.editAddress.applyChanges")}
           </Button>
         </DialogBody>
       </DialogContent>

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
@@ -1,13 +1,40 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressValueSchema,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameAddressDialog } from ".";
 import type { ContactsRenameAddressDrawerProps } from "./types";
+
+const i18nResources = {
+  translation: {
+    contacts: {
+      editAddress: {
+        title: "Edit address",
+        inputLabel: "Address label",
+        applyChanges: "Apply changes",
+        invalidLabelError: "Address label is invalid.",
+      },
+      addAddressName: {
+        duplicateLabel: "Address label is already in use.",
+        tooLongLabel: "Address label is too long.",
+      },
+      addAddressEntry: {
+        addressPlaceholder: "Address",
+        validatingAddress: "Validating address",
+        validAddress: "Valid address",
+        invalidAddress: "Invalid address",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned address",
+        validationUnavailable: "Validation unavailable",
+        ensDisclaimer: "ENS addresses are supported.",
+        ensDisclaimerDescription: "ENS names can change over time.",
+      },
+    },
+  },
+};
 
 function createViewModel(
   overrides: Partial<ContactsRenameAddressDrawerProps> = {},
@@ -27,27 +54,6 @@ function createViewModel(
       inputMethod: "manual",
     },
     isDeviceRequired: true,
-    labels: {
-      title: "Edit address",
-      inputLabel: "Address label",
-      applyChanges: "Apply changes",
-      labelValidationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is invalid.",
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is already in use.",
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "Address label is too long.",
-      },
-      addressValidation: {
-        addressPlaceholder: "Address",
-        validatingAddress: "Validating address",
-        validAddress: "Valid address",
-        invalidAddress: "Invalid address",
-        domainNotFound: "Domain not found",
-        sanctionedAddress: "Sanctioned address",
-        validationUnavailable: "Validation unavailable",
-        ensDisclaimer: "ENS addresses are supported.",
-        ensDisclaimerDescription: "ENS names can change over time.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftLabelChange: jest.fn(),
@@ -57,15 +63,21 @@ function createViewModel(
   };
 }
 
+function renderDrawer(props: ContactsRenameAddressDrawerProps) {
+  return render(
+    <I18nTestProvider resources={i18nResources}>
+      <ContactsRenameAddressDialog {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameAddressDrawer", () => {
   it("should render the validation state while open", () => {
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          draftLabel: "Treasury",
-          invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-        })}
-      />,
+    renderDrawer(
+      createViewModel({
+        draftLabel: "Treasury",
+        invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-address-input")).toBeVisible();
@@ -76,14 +88,12 @@ describe("ContactsRenameAddressDrawer", () => {
     const onDraftLabelChange = jest.fn();
     const onConfirm = jest.fn(async () => undefined);
 
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          isConfirmEnabled: true,
-          onDraftLabelChange,
-          onConfirm,
-        })}
-      />,
+    renderDrawer(
+      createViewModel({
+        isConfirmEnabled: true,
+        onDraftLabelChange,
+        onConfirm,
+      }),
     );
 
     fireEvent.changeText(screen.getByTestId("contacts-rename-address-input"), "Treasury");
@@ -94,15 +104,13 @@ describe("ContactsRenameAddressDrawer", () => {
   });
 
   it("should not render its content while closed", () => {
-    render(<ContactsRenameAddressDialog {...createViewModel({ isOpen: false })} />);
+    renderDrawer(createViewModel({ isOpen: false }));
 
     expect(screen.queryByText("Edit address")).not.toBeOnTheScreen();
   });
 
   it("should reserve room for the keyboard so the form stays above it", () => {
-    const { toJSON } = render(
-      <ContactsRenameAddressDialog {...createViewModel({ bottomInset: 8, keyboardInset: 300 })} />,
-    );
+    const { toJSON } = renderDrawer(createViewModel({ bottomInset: 8, keyboardInset: 300 }));
 
     expect(toJSON()).toMatchObject({ props: { style: { paddingBottom: 332 } } });
   });

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
@@ -8,8 +8,15 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  type ContactAddressLabelValidationErrorName,
+} from "@domain/entity-contact";
 import { CONTACTS_NATIVE_ADDRESS_INPUT_PROPS } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsRenameAddressDrawerProps } from "./types";
 import { useEditAddressAddressEntryPresentation } from "./useEditAddressAddressEntryPresentation.native";
 
@@ -22,17 +29,21 @@ export function ContactsRenameAddressDialog({
   isDeviceRequired,
   bottomInset = 0,
   keyboardInset = 0,
-  labels,
   onDraftLabelChange,
   onAddressChange,
   onConfirm,
   addressEntry,
 }: ContactsRenameAddressDrawerProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const labelValidationErrors: Record<ContactAddressLabelValidationErrorName, string> = {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.editAddress.invalidLabelError"),
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.labelTooLong"),
+  };
   const labelValidationError =
-    invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+    invalidLabelError === null ? undefined : labelValidationErrors[invalidLabelError];
   const addressInput = useEditAddressAddressEntryPresentation({
     addressEntry,
-    labels: labels.addressValidation,
     onAddressChange,
   });
 
@@ -40,12 +51,12 @@ export function ContactsRenameAddressDialog({
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
       {isOpen ? (
         <Box lx={{ gap: "s24" }}>
-          <BottomSheetHeader density="expanded" title={labels.title} />
+          <BottomSheetHeader density="expanded" title={t("contacts.editAddress.title")} />
           <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
             <TextInput
               testID="contacts-edit-address-input"
               value={addressInput.value}
-              placeholder={labels.addressValidation.addressPlaceholder}
+              placeholder={t("contacts.addAddressEntry.addressPlaceholder")}
               onChangeText={addressInput.onChangeText}
               status={addressInput.inputStatus}
               helperText={addressInput.helperText}
@@ -55,14 +66,14 @@ export function ContactsRenameAddressDialog({
               <Banner
                 testID="contacts-edit-address-ens-disclaimer"
                 appearance="info"
-                title={labels.addressValidation.ensDisclaimer}
-                description={labels.addressValidation.ensDisclaimerDescription}
+                title={t("contacts.addAddressEntry.ensDisclaimer")}
+                description={t("contacts.addAddressEntry.ensDisclaimerDescription")}
               />
             ) : null}
             <TextInput
               {...CONTACTS_NATIVE_ADDRESS_INPUT_PROPS}
               helperText={labelValidationError}
-              label={labels.inputLabel}
+              label={t("contacts.editAddress.inputLabel")}
               maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
               onChangeText={onDraftLabelChange}
               status={labelValidationError ? "error" : undefined}
@@ -79,7 +90,7 @@ export function ContactsRenameAddressDialog({
               onPress={() => void onConfirm()}
               testID="contacts-rename-address-confirm"
             >
-              {labels.applyChanges}
+              {t("contacts.editAddress.applyChanges")}
             </Button>
           </Box>
         </Box>

--- a/features/flow/flow-contacts-edit-address/src/types.ts
+++ b/features/flow/flow-contacts-edit-address/src/types.ts
@@ -63,18 +63,6 @@ export type UseRenameAddressDialogViewModelOptions = Omit<
     requestSaveApproval?: () => Promise<boolean>;
   }>;
 
-export type ContactsEditAddressValidationLabels = Readonly<{
-  addressPlaceholder: string;
-  validatingAddress: string;
-  validAddress: string;
-  invalidAddress: string;
-  domainNotFound: string;
-  sanctionedAddress: string;
-  validationUnavailable: string;
-  ensDisclaimer: string;
-  ensDisclaimerDescription: string;
-}>;
-
 export type EditAddressAddressEntryPresentation = Readonly<{
   value: string;
   inputStatus?: "error" | "success";
@@ -83,18 +71,9 @@ export type EditAddressAddressEntryPresentation = Readonly<{
   onChangeText: (value: string) => void;
 }>;
 
-export type ContactsRenameAddressLabels = Readonly<{
-  title: string;
-  inputLabel: string;
-  applyChanges: string;
-  labelValidationErrors: Readonly<Record<ContactAddressLabelValidationErrorName, string>>;
-  addressValidation: ContactsEditAddressValidationLabels;
-}>;
-
 export type ContactsRenameAddressDialogProps = RenameAddressDialogViewModel &
   Readonly<{
     isDeviceRequired: boolean;
-    labels: ContactsRenameAddressLabels;
   }>;
 
 export type ContactsRenameAddressDrawerProps = ContactsRenameAddressDialogProps &

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
@@ -1,19 +1,27 @@
+import React from "react";
 import { act, renderHook } from "@testing-library/react-native";
 import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { createInitialEditAddressEntryState } from "./model/addressEntryValidation";
 import { useEditAddressAddressEntryPresentation } from "./useEditAddressAddressEntryPresentation.native";
 
-const labels = {
-  addressPlaceholder: "Address",
-  validatingAddress: "Validating",
-  validAddress: "Valid",
-  invalidAddress: "Invalid",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Sanctioned",
-  validationUnavailable: "Unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
+const i18nResources = {
+  translation: {
+    contacts: {
+      addAddressEntry: {
+        validatingAddress: "Validating",
+        validAddress: "Valid",
+        invalidAddress: "Invalid",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned",
+        validationUnavailable: "Unavailable",
+      },
+    },
+  },
 };
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(I18nTestProvider, { resources: i18nResources }, children);
 
 describe("useEditAddressAddressEntryPresentation", () => {
   it("should expose validation presentation for a valid address entry", () => {
@@ -21,12 +29,13 @@ describe("useEditAddressAddressEntryPresentation", () => {
       ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
     );
     const onAddressChange = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressAddressEntryPresentation({
-        addressEntry: currentAddress,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressAddressEntryPresentation({
+          addressEntry: currentAddress,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     expect(result.current).toMatchObject({
@@ -42,12 +51,13 @@ describe("useEditAddressAddressEntryPresentation", () => {
       ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
     );
     const onAddressChange = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressAddressEntryPresentation({
-        addressEntry: currentAddress,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressAddressEntryPresentation({
+          addressEntry: currentAddress,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     act(() => {

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.ts
@@ -7,20 +7,28 @@ import type {
   ContactsAddressEntryState,
   ContactsAddressInputSource,
 } from "@features/platform-contacts";
-import type {
-  ContactsEditAddressValidationLabels,
-  EditAddressAddressEntryPresentation,
-} from "./types";
+import { useTranslation } from "@shared/i18n";
+import type { EditAddressAddressEntryPresentation } from "./types";
 
 export function useEditAddressAddressEntryPresentation({
   addressEntry,
-  labels,
   onAddressChange,
 }: Readonly<{
   addressEntry: ContactsAddressEntryState;
-  labels: ContactsEditAddressValidationLabels;
   onAddressChange: (value: string, inputMethod: ContactsAddressInputSource) => void;
 }>): EditAddressAddressEntryPresentation {
+  const { t } = useTranslation();
+  const labels = useMemo(
+    () => ({
+      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    }),
+    [t],
+  );
   const presentation = useMemo(
     () => resolveAddressInputPresentation(addressEntry, labels),
     [addressEntry, labels],

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
@@ -1,20 +1,28 @@
+import React from "react";
 import { act, renderHook } from "@testing-library/react";
 import type { ClipboardEvent } from "react";
 import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { createInitialEditAddressEntryState } from "./model/addressEntryValidation";
 import { useEditAddressDialogPresentation } from "./useEditAddressDialogPresentation.web";
 
-const labels = {
-  addressPlaceholder: "Address",
-  validatingAddress: "Validating",
-  validAddress: "Valid",
-  invalidAddress: "Invalid",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Sanctioned",
-  validationUnavailable: "Unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
+const i18nResources = {
+  translation: {
+    contacts: {
+      addAddressEntry: {
+        validatingAddress: "Validating",
+        validAddress: "Valid",
+        invalidAddress: "Invalid",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned",
+        validationUnavailable: "Unavailable",
+      },
+    },
+  },
 };
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(I18nTestProvider, { resources: i18nResources }, children);
 
 describe("useEditAddressDialogPresentation", () => {
   it("should expose validation presentation for a valid address entry", () => {
@@ -22,12 +30,13 @@ describe("useEditAddressDialogPresentation", () => {
       ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
     );
     const onAddressChange = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressDialogPresentation({
-        addressEntry,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressDialogPresentation({
+          addressEntry,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     expect(result.current).toMatchObject({
@@ -49,12 +58,13 @@ describe("useEditAddressDialogPresentation", () => {
     };
     const onAddressChange = jest.fn();
     const preventDefault = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressDialogPresentation({
-        addressEntry,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressDialogPresentation({
+          addressEntry,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     act(() => {

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.ts
@@ -4,17 +4,27 @@ import type {
   ContactsAddressEntryState,
   ContactsAddressInputSource,
 } from "@features/platform-contacts";
-import type { ContactsEditAddressValidationLabels } from "./types";
+import { useTranslation } from "@shared/i18n";
 
 export function useEditAddressDialogPresentation({
   addressEntry,
-  labels,
   onAddressChange,
 }: Readonly<{
   addressEntry: ContactsAddressEntryState;
-  labels: ContactsEditAddressValidationLabels;
   onAddressChange: (value: string, inputMethod: ContactsAddressInputSource) => void;
 }>) {
+  const { t } = useTranslation();
+  const labels = useMemo(
+    () => ({
+      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    }),
+    [t],
+  );
   const presentation = useMemo(
     () => resolveAddressInputPresentation(addressEntry, labels),
     [addressEntry, labels],

--- a/features/flow/flow-contacts-edit-contact/package.json
+++ b/features/flow/flow-contacts-edit-contact/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.test.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.test.tsx
@@ -4,6 +4,7 @@ import {
   DUPLICATE_CONTACT_NAME_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameContactDialog } from ".";
 import type { ContactsRenameContactDialogProps } from "./types";
 
@@ -17,17 +18,6 @@ function createViewModel(
     draftName: "",
     invalidNameError: null,
     isDeviceRequired: false,
-    labels: {
-      title: "Edit contact",
-      namePlaceholder: "Contact name",
-      namingDisclaimer: "Use a nickname or a first name and initial.",
-      applyChanges: "Apply changes",
-      confirmName: "Apply changes",
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: "Special characters are not allowed.",
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: "This contact name is already in use.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftNameChange: jest.fn(),
@@ -36,15 +26,21 @@ function createViewModel(
   };
 }
 
+function renderDialog(props: ContactsRenameContactDialogProps) {
+  return render(
+    <I18nTestProvider>
+      <ContactsRenameContactDialog {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameContactDialog", () => {
   it("renders the shared validation error and disables confirmation", () => {
-    render(
-      <ContactsRenameContactDialog
-        {...createViewModel({
-          draftName: "Cédric",
-          invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        draftName: "Cédric",
+        invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-contact-name-input")).toHaveValue("Cédric");
@@ -54,14 +50,12 @@ describe("ContactsRenameContactDialog", () => {
   it("forwards draft name changes", () => {
     const onDraftNameChange = jest.fn();
 
-    render(
-      <ContactsRenameContactDialog
-        {...createViewModel({
-          draftName: "Ada",
-          isConfirmEnabled: true,
-          onDraftNameChange,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        draftName: "Ada",
+        isConfirmEnabled: true,
+        onDraftNameChange,
+      }),
     );
 
     fireEvent.change(screen.getByTestId("contacts-rename-contact-name-input"), {

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Button, Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { ContactNameDisclaimer, ContactNameInput } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
+import type { ContactNameValidationErrorName } from "@domain/entity-contact";
 import type { ContactsRenameContactDialogProps } from "./types";
 
 const NAMING_DISCLAIMER_ID = "contacts-rename-contact-naming-disclaimer";
@@ -13,13 +15,17 @@ export function ContactsRenameContactDialog({
   draftName,
   invalidNameError,
   isDeviceRequired,
-  labels,
   onClose,
   onDraftNameChange,
   onConfirm,
 }: ContactsRenameContactDialogProps): React.ReactNode {
+  const { t } = useTranslation();
+  const nameValidationErrors: Record<ContactNameValidationErrorName, string> = {
+    InvalidContactNameError: t("contacts.editContact.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -34,19 +40,23 @@ export function ContactsRenameContactDialog({
         className="w-[400px] bg-canvas-sheet pb-24"
         data-testid="contacts-rename-contact-dialog"
       >
-        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogHeader
+          density="expanded"
+          title={t("contacts.editContact.title")}
+          onClose={onClose}
+        />
         <DialogBody className="flex flex-col gap-32 px-24 pb-24">
           <div className="flex flex-col gap-24">
             <ContactNameInput
               testIDPrefix="contacts-rename-contact"
               value={draftName}
-              placeholder={labels.namePlaceholder}
+              placeholder={t("contacts.editContact.namePlaceholder")}
               errorMessage={nameValidationError}
               onChange={onDraftNameChange}
             />
             <ContactNameDisclaimer
               disclaimerId={NAMING_DISCLAIMER_ID}
-              text={labels.namingDisclaimer}
+              text={t("contacts.editContact.namingDisclaimer")}
             />
           </div>
           <Button
@@ -59,7 +69,7 @@ export function ContactsRenameContactDialog({
             onClick={() => void onConfirm()}
             data-testid="contacts-rename-contact-confirm"
           >
-            {labels.applyChanges}
+            {t("contacts.editContact.applyChanges")}
           </Button>
         </DialogBody>
       </DialogContent>

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.test.tsx
@@ -4,8 +4,27 @@ import {
   DUPLICATE_CONTACT_NAME_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameContactDrawer } from ".";
 import type { ContactsRenameContactDrawerProps } from "./types";
+
+const i18nResources = {
+  translation: {
+    contacts: {
+      editContact: {
+        title: "Edit contact",
+        namePlaceholder: "Contact name",
+        namingDisclaimer: "Use a nickname or a first name and initial.",
+        confirmName: "Apply changes",
+        applyChanges: "Apply changes",
+        invalidNameError: "Special characters are not allowed.",
+      },
+      addContactDrawer: {
+        duplicateNameError: "This contact name is already in use.",
+      },
+    },
+  },
+};
 
 const mockFocus = jest.fn();
 
@@ -39,17 +58,6 @@ function createViewModel(
     draftName: "",
     invalidNameError: null,
     isDeviceRequired: false,
-    labels: {
-      title: "Edit contact",
-      namePlaceholder: "Contact name",
-      namingDisclaimer: "Use a nickname or a first name and initial.",
-      applyChanges: "Apply changes",
-      confirmName: "Apply changes",
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: "Special characters are not allowed.",
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: "This contact name is already in use.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftNameChange: jest.fn(),
@@ -58,17 +66,23 @@ function createViewModel(
   };
 }
 
+function renderDrawer(props: ContactsRenameContactDrawerProps) {
+  return render(
+    <I18nTestProvider resources={i18nResources}>
+      <ContactsRenameContactDrawer {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameContactDrawer", () => {
   it("should render the validation state and account for drawer insets", () => {
-    const { toJSON } = render(
-      <ContactsRenameContactDrawer
-        {...createViewModel({
-          draftName: "Ada",
-          invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
-          bottomInset: 8,
-          keyboardInset: 300,
-        })}
-      />,
+    const { toJSON } = renderDrawer(
+      createViewModel({
+        draftName: "Ada",
+        invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+        bottomInset: 8,
+        keyboardInset: 300,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-contact-content")).toBeVisible();
@@ -88,14 +102,12 @@ describe("ContactsRenameContactDrawer", () => {
     const onDraftNameChange = jest.fn();
     const onConfirm = jest.fn(async () => undefined);
 
-    render(
-      <ContactsRenameContactDrawer
-        {...createViewModel({
-          isConfirmEnabled: true,
-          onDraftNameChange,
-          onConfirm,
-        })}
-      />,
+    renderDrawer(
+      createViewModel({
+        isConfirmEnabled: true,
+        onDraftNameChange,
+        onConfirm,
+      }),
     );
 
     fireEvent.changeText(screen.getByTestId("contacts-rename-contact-name-input"), "Ada Lovelace");
@@ -106,17 +118,21 @@ describe("ContactsRenameContactDrawer", () => {
   });
 
   it("should withhold focus until the host grants it", () => {
-    const { rerender } = render(<ContactsRenameContactDrawer {...createViewModel()} />);
+    const { rerender } = renderDrawer(createViewModel());
 
     expect(mockFocus).not.toHaveBeenCalled();
 
-    rerender(<ContactsRenameContactDrawer {...createViewModel({ autoFocus: true })} />);
+    rerender(
+      <I18nTestProvider resources={i18nResources}>
+        <ContactsRenameContactDrawer {...createViewModel({ autoFocus: true })} />
+      </I18nTestProvider>,
+    );
 
     expect(mockFocus).toHaveBeenCalledTimes(1);
   });
 
   it("should not render its content while closed", () => {
-    render(<ContactsRenameContactDrawer {...createViewModel({ isOpen: false })} />);
+    renderDrawer(createViewModel({ isOpen: false }));
 
     expect(screen.queryByTestId("contacts-rename-contact-content")).not.toBeOnTheScreen();
   });

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.tsx
@@ -9,6 +9,8 @@ import {
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "@shared/i18n";
+import type { ContactNameValidationErrorName } from "@domain/entity-contact";
 import type { ContactsRenameContactDrawerProps } from "./types";
 
 export function ContactsRenameContactDrawer({
@@ -21,12 +23,16 @@ export function ContactsRenameContactDrawer({
   bottomInset = 0,
   keyboardInset = 0,
   autoFocus = false,
-  labels,
   onDraftNameChange,
   onConfirm,
 }: ContactsRenameContactDrawerProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const nameValidationErrors: Record<ContactNameValidationErrorName, string> = {
+    InvalidContactNameError: t("contacts.editContact.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
@@ -35,17 +41,17 @@ export function ContactsRenameContactDrawer({
           <BottomSheetHeader />
           <Box lx={{ gap: "s16" }}>
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-              {labels.title}
+              {t("contacts.editContact.title")}
             </Text>
             <ContactNameInput
               testIDPrefix="contacts-rename-contact"
               value={draftName}
-              placeholder={labels.namePlaceholder}
+              placeholder={t("contacts.editContact.namePlaceholder")}
               errorMessage={nameValidationError}
               autoFocus={autoFocus}
               onChangeText={onDraftNameChange}
             />
-            <Banner appearance="info" description={labels.namingDisclaimer} />
+            <Banner appearance="info" description={t("contacts.editContact.namingDisclaimer")} />
           </Box>
           <Button
             appearance="base"
@@ -57,7 +63,7 @@ export function ContactsRenameContactDrawer({
             onPress={() => void onConfirm()}
             testID="contacts-rename-contact-confirm"
           >
-            {labels.confirmName}
+            {t("contacts.editContact.confirmName")}
           </Button>
         </Box>
       ) : null}

--- a/features/flow/flow-contacts-edit-contact/src/types.ts
+++ b/features/flow/flow-contacts-edit-contact/src/types.ts
@@ -28,19 +28,9 @@ export type UseRenameContactDialogViewModelOptions = Readonly<{
   requestSaveApproval?: () => Promise<boolean>;
 }>;
 
-export type ContactsRenameContactLabels = Readonly<{
-  title: string;
-  namePlaceholder: string;
-  namingDisclaimer: string;
-  applyChanges: string;
-  confirmName: string;
-  nameValidationErrors: Readonly<Record<ContactNameValidationErrorName, string>>;
-}>;
-
 export type ContactsRenameContactDialogProps = RenameContactDialogViewModel &
   Readonly<{
     isDeviceRequired: boolean;
-    labels: ContactsRenameContactLabels;
   }>;
 
 export type ContactsRenameContactDrawerProps = ContactsRenameContactDialogProps &

--- a/features/flow/flow-contacts-list/package.json
+++ b/features/flow/flow-contacts-list/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
     "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "tailwind-merge": "catalog:"

--- a/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
@@ -6,6 +6,7 @@ import {
   type SectionListRenderItemInfo,
 } from "react-native";
 import { Box, Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsListItem, ContactsListSection, ContactsListViewNativeProps } from "./types";
 import { createContactsListRowLayouts } from "./utils";
 import { ContactsListHeader } from "./components/ListHeader/ContactsListHeader.native";
@@ -20,7 +21,6 @@ const noContactsListSections: readonly never[] = [];
 
 export function ContactsListView({
   viewModel,
-  labels,
   meAvatarSrc,
   onOpenContact,
   onAddContact,
@@ -29,6 +29,7 @@ export function ContactsListView({
   onSearchQueryChange,
   surface = "base",
 }: ContactsListViewNativeProps): React.JSX.Element {
+  const { t } = useTranslation();
   const isPopulated = viewModel.displayMode === "populated";
   const hasNoResults = "status" in viewModel && viewModel.status === "no-results";
   const me = "me" in viewModel ? viewModel.me : undefined;
@@ -60,12 +61,12 @@ export function ContactsListView({
       <Box onLayout={onContactRowLayout}>
         <ContactsSavedContactListItem
           contact={item}
-          addressCountLabel={labels.formatAddressCount(item.addressCount)}
+          addressCountLabel={t("contacts.addressCount", { count: item.addressCount })}
           onOpen={onOpenContact}
         />
       </Box>
     ),
-    [labels, onContactRowLayout, onOpenContact],
+    [t, onContactRowLayout, onOpenContact],
   );
   const rowLayouts = useMemo(
     () => createContactsListRowLayouts(sections, sectionHeaderHeight, contactRowHeight),
@@ -92,7 +93,6 @@ export function ContactsListView({
   const listHeader = (
     <ContactsListHeader
       me={me}
-      labels={labels}
       meAvatarSrc={meAvatarSrc}
       showAddContact={!isPopulated && !hasNoResults}
       onOpenContact={onOpenContact}
@@ -151,7 +151,7 @@ export function ContactsListView({
     content = (
       <Box lx={{ flex: 1, paddingHorizontal: "s16", paddingTop: "s8" }}>
         {listHeader}
-        <ContactsSearchNoResults message={labels.searchNoResults} />
+        <ContactsSearchNoResults message={t("contacts.searchNoResults")} />
       </Box>
     );
   } else {
@@ -184,7 +184,7 @@ export function ContactsListView({
           }}
         >
           <ContactsSearchInput
-            placeholder={labels.searchPlaceholder}
+            placeholder={t("contacts.searchPlaceholder")}
             value={searchQuery}
             onSearchQueryChange={onSearchQueryChange}
           />
@@ -204,7 +204,7 @@ export function ContactsListView({
           }}
           accessible
           accessibilityRole="progressbar"
-          accessibilityLabel={labels.ledgerSyncCheckingAccessibilityLabel ?? labels.title}
+          accessibilityLabel={t("contacts.ledgerSyncIntroduction.checkingAccessibilityLabel")}
           accessibilityState={{ busy: true }}
         >
           <Spinner testID="contacts-ledger-sync-spinner" />

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ContactId } from "@domain/entity-contact";
 import { mockMeContact, mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import type { ContactsPageViewModel } from "./types";
 import {
   createContactsSearchViewModel,
@@ -10,13 +11,25 @@ import {
 } from "./model/viewModel";
 import { ContactsListView } from "./ContactsListView.web";
 
-const labels = {
-  title: "Contacts",
-  searchPlaceholder: "Search contact",
-  searchNoResults: "No contact found",
-  addContact: "Add contact",
-  ledgerSyncCheckingAccessibilityLabel: "Checking Ledger Sync status",
-  formatAddressCount: (count: number) => `${count} address`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        title: "Contacts",
+        searchPlaceholder: "Search contact",
+        searchNoResults: "No contact found",
+        addContact: "Add contact",
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+        ledgerSyncIntroduction: {
+          checkingAccessibilityLabel: "Checking Ledger Sync status",
+        },
+        me: { myAddresses: "My addresses" },
+        detail: { meDisplayName: "My wallets ({{name}})" },
+      },
+    },
+  },
 };
 
 type RenderContactsPageOptions = Readonly<{
@@ -47,36 +60,37 @@ function renderContactsPage({
   onSearchInputChange = jest.fn(),
 }: RenderContactsPageOptions = {}) {
   render(
-    <ContactsListView
-      viewModel={viewModel}
-      labels={labels}
-      meAvatarSrc="https://example.com/black/user.png"
-      onOpenMe={onOpenMe}
-      onOpenContact={onOpenContact}
-      onAddContact={onAddContact}
-      searchQuery={searchQuery}
-      onSearchInputChange={onSearchInputChange}
-      isLedgerSyncChecking={isLedgerSyncChecking}
-      featureIntroduction={
-        isFeatureIntroductionOpen ? (
-          <div>
-            <p>Introducing Contacts</p>
-            <button onClick={onCompleteFeatureIntroduction}>Try contacts</button>
-          </div>
-        ) : undefined
-      }
-      ledgerSyncIntroduction={
-        isIntroductionOpen ? (
-          <div>
-            <p>
-              Your contacts are end-to-end encrypted with your Ledger and synced across your
-              devices, only you can unlock them.
-            </p>
-            <button onClick={onDismissIntroduction}>Got it</button>
-          </div>
-        ) : undefined
-      }
-    />,
+    <I18nTestProvider resources={resources}>
+      <ContactsListView
+        viewModel={viewModel}
+        meAvatarSrc="https://example.com/black/user.png"
+        onOpenMe={onOpenMe}
+        onOpenContact={onOpenContact}
+        onAddContact={onAddContact}
+        searchQuery={searchQuery}
+        onSearchInputChange={onSearchInputChange}
+        isLedgerSyncChecking={isLedgerSyncChecking}
+        featureIntroduction={
+          isFeatureIntroductionOpen ? (
+            <div>
+              <p>Introducing Contacts</p>
+              <button onClick={onCompleteFeatureIntroduction}>Try contacts</button>
+            </div>
+          ) : undefined
+        }
+        ledgerSyncIntroduction={
+          isIntroductionOpen ? (
+            <div>
+              <p>
+                Your contacts are end-to-end encrypted with your Ledger and synced across your
+                devices, only you can unlock them.
+              </p>
+              <button onClick={onDismissIntroduction}>Got it</button>
+            </div>
+          ) : undefined
+        }
+      />
+    </I18nTestProvider>,
   );
 
   return {
@@ -218,17 +232,18 @@ describe("ContactsPage", () => {
     const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
 
     render(
-      <ContactsListView
-        viewModel={createContactsSearchViewModel(me, contacts, "ben")}
-        labels={labels}
-        meAvatarSrc="https://example.com/black/user.png"
-        onOpenMe={jest.fn()}
-        onOpenContact={jest.fn()}
-        onAddContact={jest.fn()}
-        searchQuery="ben"
-        onSearchInputChange={jest.fn()}
-        isLedgerSyncChecking={false}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsListView
+          viewModel={createContactsSearchViewModel(me, contacts, "ben")}
+          meAvatarSrc="https://example.com/black/user.png"
+          onOpenMe={jest.fn()}
+          onOpenContact={jest.fn()}
+          onAddContact={jest.fn()}
+          searchQuery="ben"
+          onSearchInputChange={jest.fn()}
+          isLedgerSyncChecking={false}
+        />
+      </I18nTestProvider>,
     );
 
     const contactsList = screen.getByTestId("contacts-list");
@@ -243,17 +258,18 @@ describe("ContactsPage", () => {
     const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
 
     render(
-      <ContactsListView
-        viewModel={createContactsSearchViewModel(me, contacts, "unknown")}
-        labels={labels}
-        meAvatarSrc="https://example.com/black/user.png"
-        onOpenMe={jest.fn()}
-        onOpenContact={jest.fn()}
-        onAddContact={jest.fn()}
-        searchQuery="unknown"
-        onSearchInputChange={jest.fn()}
-        isLedgerSyncChecking={false}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsListView
+          viewModel={createContactsSearchViewModel(me, contacts, "unknown")}
+          meAvatarSrc="https://example.com/black/user.png"
+          onOpenMe={jest.fn()}
+          onOpenContact={jest.fn()}
+          onAddContact={jest.fn()}
+          searchQuery="unknown"
+          onSearchInputChange={jest.fn()}
+          isLedgerSyncChecking={false}
+        />
+      </I18nTestProvider>,
     );
 
     const contactsList = screen.getByTestId("contacts-list");

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "@shared/i18n";
 import { isContactsSearchNoResultsViewModel, type ContactsListViewProps } from "./types";
 import { ContactsLedgerSyncLoadingPane } from "./components/LedgerSyncLoadingPane/ContactsLedgerSyncLoadingPane.web";
 import { ContactsList } from "./components/ContactsList/ContactsList.web";
@@ -21,6 +22,7 @@ function renderContactsDetailPane(
 
 export function ContactsListView(props: ContactsListViewProps): React.ReactNode {
   const { isLedgerSyncChecking } = props;
+  const { t } = useTranslation();
   const showAddContact = !isContactsSearchNoResultsViewModel(props.viewModel);
   const contactsList = <ContactsList {...props} />;
 
@@ -32,8 +34,8 @@ export function ContactsListView(props: ContactsListViewProps): React.ReactNode 
         inert={isLedgerSyncChecking}
       >
         <ContactsPageLayout
-          title={props.labels.title}
-          addContactLabel={props.labels.addContact}
+          title={t("contacts.title")}
+          addContactLabel={t("contacts.addContact")}
           showAddContact={showAddContact}
           onAddContact={props.onAddContact}
           list={

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.test.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.test.tsx
@@ -7,11 +7,19 @@ import {
   mockContactWithMultipleAddresses,
 } from "@domain/entity-contact/schema.mock";
 import type { Contact } from "@domain/entity-contact";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { ContactsCompactList } from "../../index.native";
 
-const labels = {
-  emptyAddress: "No saved addresses",
-  formatAddressCount: (count: number) => `${count} saved addresses`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+      },
+    },
+  },
 };
 
 function createContacts(): readonly Contact[] {
@@ -29,19 +37,17 @@ function createContacts(): readonly Contact[] {
 describe("ContactsCompactList", () => {
   it("should render supplied contacts with the appropriate address descriptions", () => {
     render(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={createContacts()} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByText("Zero")).toBeVisible();
-    expect(screen.getByText(labels.emptyAddress)).toBeVisible();
+    expect(screen.getByText("0 address")).toBeVisible();
     expect(screen.getByText("One")).toBeVisible();
     expect(screen.getByText("Main wallet")).toBeVisible();
     expect(screen.getByText("Many")).toBeVisible();
-    expect(screen.getByText("2 saved addresses")).toBeVisible();
+    expect(screen.getByText("2 addresses")).toBeVisible();
     expect(screen.getByTestId("contacts-avatar-contact-zero").props.size).toBe("md");
     expect(screen.getByTestId("contacts-compact-row-contact-zero").props.lx).toEqual({
       marginHorizontal: "-s8",
@@ -55,12 +61,13 @@ describe("ContactsCompactList", () => {
 
   it("should render only the first supplied contacts when maxContacts is set", () => {
     render(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        maxContacts={2}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList
+          contacts={createContacts()}
+          maxContacts={2}
+          onContactSelect={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-compact-row-contact-zero")).toBeVisible();
@@ -70,18 +77,21 @@ describe("ContactsCompactList", () => {
 
   it("should render no rows when contacts are empty or maxContacts is zero", () => {
     const { rerender } = render(
-      <ContactsCompactList contacts={[]} labels={labels} onContactSelect={jest.fn()} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={[]} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.queryByTestId("contacts-compact-row-contact-zero")).toBeNull();
 
     rerender(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        maxContacts={0}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList
+          contacts={createContacts()}
+          maxContacts={0}
+          onContactSelect={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.queryByTestId("contacts-compact-row-contact-zero")).toBeNull();
@@ -93,7 +103,9 @@ describe("ContactsCompactList", () => {
     const user = userEvent.setup();
 
     render(
-      <ContactsCompactList contacts={contacts} labels={labels} onContactSelect={onContactSelect} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} onContactSelect={onContactSelect} />
+      </I18nTestProvider>,
     );
 
     await user.press(screen.getByTestId("contacts-compact-row-contact-one"));

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.tsx
@@ -12,12 +12,14 @@ import {
   getCompactContactAddressDescription,
   getDisplayedCompactContacts,
 } from "./utils/ContactsCompactList.utils";
+import { useTranslation } from "@shared/i18n";
 
 export function ContactsCompactRow({
   contact,
-  labels,
   onContactSelect,
 }: ContactsCompactRowProps): React.JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <ListItem
       testID={`contacts-compact-row-${contact.id}`}
@@ -30,7 +32,11 @@ export function ContactsCompactRow({
         <ListItemContent>
           <ListItemTitle>{contact.name}</ListItemTitle>
           <ListItemDescription>
-            {getCompactContactAddressDescription(contact, labels)}
+            {getCompactContactAddressDescription(
+              contact,
+              t("contacts.addressCount", { count: 0 }),
+              count => t("contacts.addressCount", { count }),
+            )}
           </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
@@ -40,7 +46,6 @@ export function ContactsCompactRow({
 
 export function ContactsCompactList({
   contacts,
-  labels,
   maxContacts,
   onContactSelect,
 }: ContactsCompactListProps): React.JSX.Element {
@@ -49,12 +54,7 @@ export function ContactsCompactList({
   return (
     <>
       {displayedContacts.map(contact => (
-        <ContactsCompactRow
-          key={contact.id}
-          contact={contact}
-          labels={labels}
-          onContactSelect={onContactSelect}
-        />
+        <ContactsCompactRow key={contact.id} contact={contact} onContactSelect={onContactSelect} />
       ))}
     </>
   );

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.test.tsx
@@ -7,11 +7,19 @@ import {
   mockContactWithMultipleAddresses,
 } from "@domain/entity-contact/schema.mock";
 import type { Contact } from "@domain/entity-contact";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { ContactsCompactList } from "../../web";
 
-const labels = {
-  emptyAddress: "No saved addresses",
-  formatAddressCount: (count: number) => `${count} saved addresses`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+      },
+    },
+  },
 };
 
 function createContacts(): readonly Contact[] {
@@ -30,16 +38,20 @@ describe("ContactsCompactList", () => {
   it("should render supplied contacts in order with the appropriate address descriptions", () => {
     const contacts = createContacts();
 
-    render(<ContactsCompactList contacts={contacts} labels={labels} onContactSelect={jest.fn()} />);
+    render(
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
+    );
 
     const [zeroRow, oneRow, manyRow] = screen.getAllByTestId(/^contacts-compact-row-/);
 
     expect(zeroRow).toHaveTextContent("Zero");
-    expect(zeroRow).toHaveTextContent(labels.emptyAddress);
+    expect(zeroRow).toHaveTextContent("0 address");
     expect(oneRow).toHaveTextContent("One");
     expect(oneRow).toHaveTextContent("Main wallet");
     expect(manyRow).toHaveTextContent("Many");
-    expect(manyRow).toHaveTextContent("2 saved addresses");
+    expect(manyRow).toHaveTextContent("2 addresses");
     expect(zeroRow.compareDocumentPosition(oneRow)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(oneRow.compareDocumentPosition(manyRow)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getByTestId("contacts-avatar-contact-zero")).toBeVisible();
@@ -49,12 +61,9 @@ describe("ContactsCompactList", () => {
     const contacts = createContacts();
 
     render(
-      <ContactsCompactList
-        contacts={contacts}
-        labels={labels}
-        maxContacts={2}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} maxContacts={2} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.getAllByTestId(/^contacts-compact-row-/)).toHaveLength(2);
@@ -65,18 +74,21 @@ describe("ContactsCompactList", () => {
 
   it("should render no rows when contacts are empty or maxContacts is zero", () => {
     const { rerender } = render(
-      <ContactsCompactList contacts={[]} labels={labels} onContactSelect={jest.fn()} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={[]} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-compact-list")).toBeEmptyDOMElement();
 
     rerender(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        maxContacts={0}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList
+          contacts={createContacts()}
+          maxContacts={0}
+          onContactSelect={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-compact-list")).toBeEmptyDOMElement();
@@ -87,7 +99,9 @@ describe("ContactsCompactList", () => {
     const onContactSelect = jest.fn();
 
     render(
-      <ContactsCompactList contacts={contacts} labels={labels} onContactSelect={onContactSelect} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} onContactSelect={onContactSelect} />
+      </I18nTestProvider>,
     );
 
     fireEvent.click(screen.getByTestId("contacts-compact-row-contact-one"));

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
@@ -12,13 +12,14 @@ import {
   getCompactContactAddressDescription,
   getDisplayedCompactContacts,
 } from "./utils/ContactsCompactList.utils";
+import { useTranslation } from "@shared/i18n";
 
 export function ContactsCompactList({
   contacts,
-  labels,
   maxContacts,
   onContactSelect,
 }: ContactsCompactListProps): React.JSX.Element {
+  const { t } = useTranslation();
   const displayedContacts = getDisplayedCompactContacts(contacts, maxContacts);
 
   return (
@@ -34,7 +35,11 @@ export function ContactsCompactList({
             <ListItemContent>
               <ListItemTitle>{contact.name}</ListItemTitle>
               <ListItemDescription>
-                {getCompactContactAddressDescription(contact, labels)}
+                {getCompactContactAddressDescription(
+                  contact,
+                  t("contacts.addressCount", { count: 0 }),
+                  count => t("contacts.addressCount", { count }),
+                )}
               </ListItemDescription>
             </ListItemContent>
           </ListItemLeading>

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/utils/ContactsCompactList.utils.ts
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/utils/ContactsCompactList.utils.ts
@@ -1,19 +1,19 @@
 import type { Contact } from "@domain/entity-contact";
-import type { ContactsCompactListProps } from "../../../types";
 
 export function getCompactContactAddressDescription(
   contact: Contact,
-  labels: ContactsCompactListProps["labels"],
+  emptyAddress: string,
+  formatAddressCount: (count: number) => string,
 ): string {
   if (contact.addresses.length === 0) {
-    return labels.emptyAddress;
+    return emptyAddress;
   }
 
   if (contact.addresses.length === 1) {
     return contact.addresses[0].label;
   }
 
-  return labels.formatAddressCount(contact.addresses.length);
+  return formatAddressCount(contact.addresses.length);
 }
 
 export function getDisplayedCompactContacts(

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ContactsList.web.tsx
@@ -9,11 +9,11 @@ import { ContactsAddContactListItem } from "./ListItems/ContactsAddContactListIt
 import { ContactsMeListItem } from "./ListItems/ContactsMeListItem.web";
 import { ContactsSavedListItem } from "./ListItems/ContactsSavedListItem.web";
 import { ContactsSearchNoResults } from "./Search/ContactsSearchNoResults.web";
+import { useTranslation } from "@shared/i18n";
 
 type ContactsListProps = Pick<
   ContactsListViewProps,
   | "viewModel"
-  | "labels"
   | "searchQuery"
   | "meAvatarSrc"
   | "onSearchInputChange"
@@ -24,7 +24,6 @@ type ContactsListProps = Pick<
 
 export function ContactsList({
   viewModel,
-  labels,
   searchQuery,
   meAvatarSrc,
   onSearchInputChange,
@@ -32,6 +31,7 @@ export function ContactsList({
   onOpenContact,
   onAddContact,
 }: ContactsListProps): React.ReactNode {
+  const { t } = useTranslation();
   const savedContactSections = isPopulatedContactsListViewModel(viewModel)
     ? viewModel.sections
     : [];
@@ -41,7 +41,7 @@ export function ContactsList({
 
   let savedContactsContent: React.ReactNode = null;
   if (showNoResults) {
-    savedContactsContent = <ContactsSearchNoResults message={labels.searchNoResults} />;
+    savedContactsContent = <ContactsSearchNoResults message={t("contacts.searchNoResults")} />;
   } else if (savedContactSections.length > 0) {
     savedContactsContent = (
       <div className="flex flex-col gap-16">
@@ -59,7 +59,7 @@ export function ContactsList({
                 <ContactsSavedListItem
                   key={contact.contactId}
                   contact={contact}
-                  formatAddressCount={labels.formatAddressCount}
+                  formatAddressCount={count => t("contacts.addressCount", { count })}
                   onOpen={onOpenContact}
                 />
               ))}
@@ -75,8 +75,8 @@ export function ContactsList({
       <div className="flex shrink-0 flex-col gap-8">
         <SearchInput
           value={searchQuery}
-          placeholder={labels.searchPlaceholder}
-          aria-label={labels.searchPlaceholder}
+          placeholder={t("contacts.searchPlaceholder")}
+          aria-label={t("contacts.searchPlaceholder")}
           data-testid="contacts-list-search"
           onChange={onSearchInputChange}
         />
@@ -84,7 +84,7 @@ export function ContactsList({
           <ContactsMeListItem
             contact={me}
             avatarSrc={meAvatarSrc}
-            formatAddressCount={labels.formatAddressCount}
+            formatAddressCount={count => t("contacts.addressCount", { count })}
             onOpen={onOpenMe}
           />
         ) : null}
@@ -96,7 +96,10 @@ export function ContactsList({
         <div className="flex flex-col gap-16">
           {savedContactsContent}
           {showAddContact ? (
-            <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
+            <ContactsAddContactListItem
+              label={t("contacts.addContact")}
+              onAddContact={onAddContact}
+            />
           ) : null}
         </div>
       </div>

--- a/features/flow/flow-contacts-list/src/components/ListHeader/ContactsListHeader.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ListHeader/ContactsListHeader.native.tsx
@@ -1,12 +1,12 @@
 import React from "react";
+import { useTranslation } from "@shared/i18n";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
-import type { ContactsListItem, ContactsListViewLabels } from "../../types";
+import type { ContactsListItem } from "../../types";
 import { ContactsAddContactListItem } from "../ContactsList/ListItems/ContactsAddContactListItem.native";
 import { ContactsMeListItem } from "../ContactsList/ListItems/ContactsMeListItem.native";
 
 type ContactsListHeaderProps = Readonly<{
   me?: ContactsListItem;
-  labels: ContactsListViewLabels;
   meAvatarSrc: string;
   showAddContact: boolean;
   onOpenContact: (contactId: ContactsListItem["contactId"]) => void;
@@ -15,24 +15,24 @@ type ContactsListHeaderProps = Readonly<{
 
 export function ContactsListHeader({
   me,
-  labels,
   meAvatarSrc,
   showAddContact,
   onOpenContact,
   onAddContact,
 }: ContactsListHeaderProps): React.JSX.Element {
+  const { t } = useTranslation();
   return (
     <Box testID="contacts-list-header" lx={{ gap: "s8" }}>
       {me ? (
         <ContactsMeListItem
           contact={me}
           avatarSrc={meAvatarSrc}
-          addressCountLabel={labels.formatAddressCount(me.addressCount)}
+          addressCountLabel={t("contacts.addressCount", { count: me.addressCount })}
           onOpen={onOpenContact}
         />
       ) : null}
       {showAddContact ? (
-        <ContactsAddContactListItem label={labels.addContact} onPress={onAddContact} />
+        <ContactsAddContactListItem label={t("contacts.addContact")} onPress={onAddContact} />
       ) : null}
     </Box>
   );

--- a/features/flow/flow-contacts-list/src/types.ts
+++ b/features/flow/flow-contacts-list/src/types.ts
@@ -46,37 +46,19 @@ export type ContactsSearchViewModel =
 
 export type ContactsPageViewModel = ContactsListViewModel | ContactsSearchViewModel;
 
-export type ContactsListViewLabels = Readonly<{
-  title: string;
-  searchPlaceholder: string;
-  searchNoResults: string;
-  addContact: string;
-  ledgerSyncCheckingAccessibilityLabel?: string;
-  formatAddressCount: (count: number) => string;
-  formatMeDisplayName?: (name: string) => string;
-}>;
-
-export type ContactsCompactListLabels = Readonly<{
-  emptyAddress: string;
-  formatAddressCount: (count: number) => string;
-}>;
-
 export type ContactsCompactRowProps = Readonly<{
   contact: Contact;
-  labels: ContactsCompactListLabels;
   onContactSelect: (contact: Contact) => void;
 }>;
 
 export type ContactsCompactListProps = Readonly<{
   contacts: readonly Contact[];
-  labels: ContactsCompactListLabels;
   maxContacts?: number;
   onContactSelect: (contact: Contact) => void;
 }>;
 
 export type ContactsPageSharedProps = Readonly<{
   viewModel: ContactsPageViewModel;
-  labels: ContactsListViewLabels;
   searchQuery: string;
   meAvatarSrc: string;
   onOpenContact: (contactId: ContactId) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5601,6 +5601,9 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(e1195c5841184ed5b8a7bbe45de0365d)
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       '@shared/ui-qr-code':
         specifier: workspace:*
         version: link:../../../shared/ui-qr-code
@@ -5752,6 +5755,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@features/platform-feature-flags':
         specifier: workspace:^
@@ -5834,6 +5840,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
@@ -5910,6 +5919,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
@@ -5983,6 +5995,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
@@ -6053,6 +6068,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
@@ -6196,6 +6214,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
@@ -22989,7 +23010,6 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28462,7 +28482,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:


### PR DESCRIPTION
## Summary

- Eliminates props drilling of translation strings from host app ViewModels into Contacts feature packages
- Each feature package now calls `useTranslation` (from `@shared/i18n`) directly via internal label hooks, removing all `labels: XxxLabels` props from public component/view APIs
- Adds `@shared/i18n: workspace:*` to the 6 affected feature packages

**Packages migrated:**
- `flow-contacts-list` — `ContactsListViewLabels`, `ContactsCompactListLabels`
- `flow-contacts-edit-contact` — `ContactsRenameContactLabels`
- `flow-contacts-delete-contact` — `ContactsDeleteContactDialogLabels`
- `flow-contacts-add-contact` — `ContactsAddContactContentLabels`
- `flow-contacts-edit-address` — `ContactsRenameAddressLabels`, `ContactsEditAddressValidationLabels`
- `flow-contacts-add-address` — `AddAddressEntryLabels`, `AddAddressNameLabels`, `ContactsAddAddressReviewLabels`
- `flow/contacts` (detail step) — `ContactDetailLabels`, `ContactDetailActionsLabels`; `useContactDetailSharedState` also internalizes `formatMeDisplayName`

**App-level cleanup:**
- Removed all `labels` / `entryLabels` / `nameLabels` / `reviewLabels` useMemo blocks from `useContactsViewModel.ts` (LLD) and `useContactDetailScreenViewModel.ts` / `useContactDetailPaneAdapter.ts` (LLD + LLM)

## Test plan

- [ ] Contacts list renders with translated strings (LLD + LLM)
- [ ] Add contact dialog/drawer shows correct labels
- [ ] Edit/delete contact flows work end-to-end
- [ ] Add address flow (entry → name → review) works in both apps
- [ ] Contact detail header, empty state, and action buttons render correctly
- [ ] Unit tests for `flow-contacts-add-address` pass (`pnpm jest flow-contacts-add-address`)