### PR TITLE
[LWDM] fix(tezos): stake fee estimation for release (LIVE-37117)

### DIFF
--- a/.changeset/brisk-otters-wander.md
+++ b/.changeset/brisk-otters-wander.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add the error message shown when the protocol refuses a Tezos stake amount as too small

--- a/.changeset/swift-badgers-thread.md
+++ b/.changeset/swift-badgers-thread.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Pass the coin-tezos context to the baker lookups, which now resolve the config themselves instead of taking a resolved one

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7584,6 +7584,9 @@
     "TezosStakeBlockedByPendingUnstake": {
       "title": "Unstaking from your previous validator must finish first"
     },
+    "TezosStakeAmountTooSmall": {
+      "title": "This amount is too small to stake"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -968,6 +968,9 @@
     "TezosStakeBlockedByPendingUnstake": {
       "title": "Unstaking from your previous validator must finish first"
     },
+    "TezosStakeAmountTooSmall": {
+      "title": "This amount is too small to stake"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/libs/ledger-live-common/src/families/tezos/bakers.ts
+++ b/libs/ledger-live-common/src/families/tezos/bakers.ts
@@ -1,7 +1,6 @@
 import type { AccountLike } from "@ledgerhq/types-live";
 import { loadBaker } from "@ledgerhq/coin-tezos/network/bakers";
-import type { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
-import { getCurrencyConfiguration } from "../../config";
+import { buildContext } from "../../bridge/generic-coin-framework/api/context";
 import type { Delegation } from "./types";
 
 export function getAccountDelegationSync(account: AccountLike): Delegation | null | undefined {
@@ -42,9 +41,6 @@ export async function loadAccountDelegation(
 ): Promise<Delegation | null | undefined> {
   const delegation = getAccountDelegationSync(account);
   if (!delegation) return null;
-  const baker = await loadBaker(
-    getCurrencyConfiguration<TezosCoinConfig>("tezos"),
-    delegation.address,
-  );
+  const baker = await loadBaker(buildContext("tezos"), delegation.address);
   return { ...delegation, baker };
 }

--- a/libs/ledger-live-common/src/families/tezos/react.ts
+++ b/libs/ledger-live-common/src/families/tezos/react.ts
@@ -3,8 +3,7 @@ import BigNumber from "bignumber.js";
 import { useEffect, useMemo, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import { bakers } from "@ledgerhq/coin-tezos/network/index";
-import type { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
-import { getCurrencyConfiguration } from "../../config";
+import { buildContext } from "../../bridge/generic-coin-framework/api/context";
 import {
   isDelegationPosition,
   isFinalizablePosition,
@@ -22,9 +21,7 @@ export function useBakers(whitelistAddresses: string[]): Baker[] {
     bakers.listBakersWithDefault(whitelistAddresses),
   );
   useEffect(() => {
-    bakers
-      .listBakers(getCurrencyConfiguration<TezosCoinConfig>("tezos"), whitelistAddresses)
-      .then(setWhitelistedBakers);
+    bakers.listBakers(buildContext("tezos"), whitelistAddresses).then(setWhitelistedBakers);
   }, [whitelistAddresses]);
 
   return whitelistedBakers;
@@ -69,7 +66,7 @@ export function useBaker(addr: string): Baker | undefined {
     }
     let cancelled = false;
     bakers
-      .loadBaker(getCurrencyConfiguration<TezosCoinConfig>("tezos"), addr)
+      .loadBaker(buildContext("tezos"), addr)
       .then(b => {
         if (cancelled) return;
         setBaker(b);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: 9.6.0
       version: 9.6.0
     '@ledgerhq/coin-tezos':
-      specifier: 10.2.2
-      version: 10.2.2
+      specifier: 10.2.4
+      version: 10.2.4
     '@ledgerhq/coin-xrp':
       specifier: 10.1.0
       version: 10.1.0
@@ -11866,7 +11866,7 @@ importers:
         version: link:../../coin-tester
       '@ledgerhq/coin-tezos':
         specifier: 'catalog:'
-        version: 10.2.2
+        version: 10.2.4
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -13033,7 +13033,7 @@ importers:
         version: link:../coin-modules/coin-sui
       '@ledgerhq/coin-tezos':
         specifier: 'catalog:'
-        version: 10.2.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)
+        version: 10.2.4(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/coin-ton':
         specifier: workspace:^
         version: link:../coin-modules/coin-ton
@@ -22353,17 +22353,21 @@ packages:
     peerDependencies:
       '@ledgerhq/live-network': ^3.0.0
 
+  '@ledgerhq/coin-module-framework@8.5.0':
+    resolution: {integrity: sha512-wIEcjk0BZAsDTEIgYEyiTsoeP0J6GXkVVUHfzzIZ8/n+mWCIhu2K0JDoKHNi2sovteCd6Mxw+aoLk/9kmI6e4w==}
+    peerDependencies:
+      '@ledgerhq/live-network': ^3.0.0
+
   '@ledgerhq/coin-stellar@9.6.0':
     resolution: {integrity: sha512-r1Pi5nZ/bvNDbHvMkJVq5PnSoA05wv5+mS8TryCTVNh5BKfPlr4MnFVKDjTV7NWxPYGCHcrChAO9IA1Ri8uA5w==}
     peerDependencies:
       '@ledgerhq/live-network': ^3.0.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/coin-tezos@10.2.2':
-    resolution: {integrity: sha512-yFQQ7adR6xJG0Mv5U9YHEzyv0xP3IdGWuTNAFlEnX9njp6me2y/gZl2+GI2pBpWscIRVqqzjaxkHfB/qdLiw4A==}
+  '@ledgerhq/coin-tezos@10.2.4':
+    resolution: {integrity: sha512-qgBV3NeQSGMPJIbbF8wAor6RRKRLUAF7UZr4e7pC8Br02GYdggqCgXYYRIKApLeWGzhdHQJKaFg4GSnv8fiYRA==}
     peerDependencies:
       '@ledgerhq/live-network': ^3.0.0
-      '@ledgerhq/logs': ^6.17.0
 
   '@ledgerhq/coin-xrp@10.1.0':
     resolution: {integrity: sha512-qkKVgvmJEdGhkIs3Om8X9IQCNGa9w73vdN2CSMT6J/4Je/i8+S/RYEIBiFLe9+0J8wNcEUYr9oxIfIUztQ5XLw==}
@@ -47790,6 +47794,15 @@ snapshots:
       '@ledgerhq/live-network': link:libs/live-network
       bignumber.js: 9.1.2
 
+  '@ledgerhq/coin-module-framework@8.5.0':
+    dependencies:
+      bignumber.js: 9.1.2
+
+  '@ledgerhq/coin-module-framework@8.5.0(@ledgerhq/live-network@libs+live-network)':
+    dependencies:
+      '@ledgerhq/live-network': link:libs/live-network
+      bignumber.js: 9.1.2
+
   '@ledgerhq/coin-stellar@9.6.0(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
     dependencies:
       '@exodus/patch-broken-hermes-typed-arrays': 1.0.0-alpha.1(patch_hash=7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732)
@@ -47801,9 +47814,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ledgerhq/coin-tezos@10.2.2':
+  '@ledgerhq/coin-tezos@10.2.4':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.4.0
+      '@ledgerhq/coin-module-framework': 8.5.0
       '@taquito/ledger-signer': 23.0.1
       '@taquito/rpc': 23.0.1
       '@taquito/taquito': 23.0.1
@@ -47811,11 +47824,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@ledgerhq/coin-tezos@10.2.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@6.19.0)':
+  '@ledgerhq/coin-tezos@10.2.4(@ledgerhq/live-network@libs+live-network)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 8.4.0(@ledgerhq/live-network@libs+live-network)
+      '@ledgerhq/coin-module-framework': 8.5.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network': link:libs/live-network
-      '@ledgerhq/logs': 6.19.0
       '@taquito/ledger-signer': 23.0.1
       '@taquito/rpc': 23.0.1
       '@taquito/taquito': 23.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -215,7 +215,7 @@ catalog:
   "@ledgerhq/coin-hypercore": 2.0.1
   "@ledgerhq/coin-module-framework": 8.4.0
   "@ledgerhq/coin-stellar": 9.6.0
-  "@ledgerhq/coin-tezos": 10.2.2
+  "@ledgerhq/coin-tezos": 10.2.4
   "@ledgerhq/coin-xrp": 10.1.0
   detox: 20.51.3
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Cherry-pick of the LIVE-37117 fix onto `release`. Opening Stake or toggling Use Max on a Tezos account failed fee estimation with a raw `(500) … stake_amount_too_small`; the release branch was cut before either half landed on develop, so it still carries the bug.

Three commits, all merged and reviewed on develop (#21685 and #21735), picked in order and applied with no conflicts:

- the `TezosStakeAmountTooSmall` copy in both apps, which is what an amount below one staking pseudotoken now shows;
- the catalog bump to `@ledgerhq/coin-tezos` 10.2.4, which carries the actual fix (LedgerHQ/coin-modules#873);
- the live-common baker call sites, which 10.2.4 requires because it also brings 10.2.3's context change (LedgerHQ/coin-modules#876) — without them live-common does not build.

Regression tests for the estimation fix live with it in coin-modules #873. Nothing outside the Tezos stake flow is touched, apart from the lockfile.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37117](https://ledgerhq.atlassian.net/browse/LIVE-37117)
- **ADR** (if any): ADR-019 — the coin-module context the baker lookups now take. No new ADR for this PR.


[LIVE-37117]: https://ledgerhq.atlassian.net/browse/LIVE-37117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ