### PR TITLE
[LWM] feat(pay): show the card first on the Pay tab (LIVE-37199)

### DIFF
--- a/.changeset/LIVE-37199-paytab-card-first.md
+++ b/.changeset/LIVE-37199-paytab-card-first.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show the Pay card first and let the Pay tab scroll.

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -55,15 +55,15 @@ export function PayTabView({
       >
         <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
           <TrackScreen category="Pay" balance_filter={balance.filter} />
-          <Balance {...balance} actionTiles={actionTiles} />
-          {isContactsEnabled && <Contacts {...contacts} />}
-          <ContactAddressPicker {...contactAddressPicker} />
           <Card
             title={cardTitle}
             oauthConfig={oauthConfig}
             callback={callback}
             onTrackEvent={balance.onTrackEvent}
           />
+          <Balance {...balance} actionTiles={actionTiles} />
+          {isContactsEnabled && <Contacts {...contacts} />}
+          <ContactAddressPicker {...contactAddressPicker} />
           <FeatureTour {...featureTour} />
           <DepositOptions {...depositOptions} />
           <BankTransferIntro {...bankTransferIntro} />


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On mobile Pay, the card sits under Balance and Contacts, so Freeze / More (and later View) are off-screen. The tab does not scroll.

**Problem:** The card is below the fold and the Pay tab cannot scroll to it.

**Solution:**

- Wrap Pay tab content in a `ScrollView` (pay background stays fixed)
- Render `Card` first, then Balance, Contacts, and the rest

No card-numbers View/Hide here — that stays on #21741.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37199](https://ledgerhq.atlassian.net/browse/LIVE-37199)
- **Depends on**: #21700
- **Follow-up**: #21741 (LIVE-35437)

### 🧪 QA

1. Open Pay on LWM
2. Confirm the card (login or face) is the first block
3. Scroll down to Balance / Contacts / deposit
4. Confirm the pay background does not scroll away

[LIVE-37199]: https://ledgerhq.atlassian.net/browse/LIVE-37199