### PR TITLE
[LWDM] feat(aleo): added staking position to resources (LIVE-32272)

### DIFF
--- a/.changeset/aleo-persist-staking-position.md
+++ b/.changeset/aleo-persist-staking-position.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Persist the Aleo staking position on the account. Each public sync now reads the `credits.aleo` `bonded` and `unbonding` mappings and stores `bondedBalance`, `bondedValidator`, `unbondingBalance` and `unbondingHeight` on `aleoResources`, so a staked position survives serialization and is readable without an extra fetch.

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
@@ -30,6 +30,10 @@ export const mockAleoResources = {
   privateBalance: new BigNumber(1),
   unspentPrivateRecords: [],
   lastPrivateSyncDate: new Date(),
+  bondedBalance: new BigNumber(0),
+  bondedValidator: null,
+  unbondingBalance: new BigNumber(0),
+  unbondingHeight: null,
 } satisfies AleoResources;
 
 export const mockAleoResourcesRaw: AleoResourcesRaw = {
@@ -38,6 +42,10 @@ export const mockAleoResourcesRaw: AleoResourcesRaw = {
   privateBalance: mockAleoResources.privateBalance?.toString() ?? null,
   unspentPrivateRecords: JSON.stringify(mockAleoResources.unspentPrivateRecords),
   lastPrivateSyncDate: mockAleoResources.lastPrivateSyncDate?.toISOString() ?? null,
+  bondedBalance: mockAleoResources.bondedBalance.toString(),
+  bondedValidator: mockAleoResources.bondedValidator ?? null,
+  unbondingBalance: mockAleoResources.unbondingBalance.toString(),
+  unbondingHeight: mockAleoResources.unbondingHeight ?? null,
 };
 
 export const mockUnspentRecord1: AleoUnspentRecord = {

--- a/libs/coin-modules/coin-aleo/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/serialization.test.ts
@@ -113,6 +113,87 @@ describe("serialization", () => {
     });
   });
 
+  describe("staking position round-trip", () => {
+    const stakedResources: AleoResources = {
+      ...mockAleoResources,
+      bondedBalance: new BigNumber("12500000000"),
+      bondedValidator: "aleo1validator",
+      unbondingBalance: new BigNumber("3000000"),
+      unbondingHeight: 987654,
+    };
+
+    it("preserves a fully-populated staking position", () => {
+      const result = fromAleoResourcesRaw(toAleoResourcesRaw(stakedResources));
+
+      expect(result).toEqual(stakedResources);
+    });
+
+    it("leaves the staking fields absent on an account persisted before they existed", () => {
+      // The four fields are absent from every cached account written before this change, and
+      // absent is not the same as zeroed: it means the mappings were never read.
+      const rawWithoutStaking: AleoResourcesRaw = {
+        transparentBalance: mockAleoResourcesRaw.transparentBalance,
+        privateBalance: mockAleoResourcesRaw.privateBalance,
+        provableApi: mockAleoResourcesRaw.provableApi,
+        lastPrivateSyncDate: mockAleoResourcesRaw.lastPrivateSyncDate,
+        unspentPrivateRecords: mockAleoResourcesRaw.unspentPrivateRecords,
+      };
+
+      const result = fromAleoResourcesRaw(rawWithoutStaking);
+
+      expect(result).not.toHaveProperty("bondedBalance");
+      expect(result).not.toHaveProperty("bondedValidator");
+      expect(result).not.toHaveProperty("unbondingBalance");
+      expect(result).not.toHaveProperty("unbondingHeight");
+    });
+
+    it("omits the staking fields when the position was never synced", () => {
+      // Same invariant on the way out: a staking-disabled account must not grow the fields
+      // on its first persist/restore.
+      const {
+        bondedBalance: _b,
+        bondedValidator: _v,
+        unbondingBalance: _u,
+        unbondingHeight: _h,
+        ...withoutStaking
+      } = mockAleoResources;
+
+      const raw = toAleoResourcesRaw(withoutStaking);
+
+      expect(raw).not.toHaveProperty("bondedBalance");
+      expect(raw).not.toHaveProperty("bondedValidator");
+      expect(raw).not.toHaveProperty("unbondingBalance");
+      expect(raw).not.toHaveProperty("unbondingHeight");
+      expect(fromAleoResourcesRaw(raw)).toEqual(withoutStaking);
+    });
+
+    it("keeps a zeroed position that was actually synced", () => {
+      // enableStaking on with nothing bonded: the zeros are a real reading, not an absence.
+      const raw = toAleoResourcesRaw({
+        ...mockAleoResources,
+        bondedBalance: new BigNumber(0),
+        bondedValidator: null,
+        unbondingBalance: new BigNumber(0),
+        unbondingHeight: null,
+      });
+
+      expect(raw.bondedBalance).toBe("0");
+      expect(raw.unbondingBalance).toBe("0");
+      expect(raw.bondedValidator).toBeNull();
+      expect(raw.unbondingHeight).toBeNull();
+    });
+
+    it("keeps a bonded balance beyond the JS safe integer range exact", () => {
+      const huge = "9007199254740993000";
+
+      const result = fromAleoResourcesRaw(
+        toAleoResourcesRaw({ ...mockAleoResources, bondedBalance: new BigNumber(huge) }),
+      );
+
+      expect(result.bondedBalance?.toFixed()).toBe(huge);
+    });
+  });
+
   describe("assignToAccountRaw", () => {
     it("should write serialized resources onto AccountRaw", () => {
       assignToAccountRaw(mockedAccount, mockedAccountRaw);

--- a/libs/coin-modules/coin-aleo/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/serialization.ts
@@ -20,6 +20,12 @@ export function toAleoResourcesRaw(resources: AleoResources): AleoResourcesRaw {
     unspentPrivateRecords: resources.unspentPrivateRecords
       ? JSON.stringify(resources.unspentPrivateRecords)
       : null,
+    ...(BigNumber.isBigNumber(resources.bondedBalance) && {
+      bondedBalance: resources.bondedBalance.toString(),
+      bondedValidator: resources.bondedValidator ?? null,
+      unbondingBalance: resources.unbondingBalance?.toString() ?? "0",
+      unbondingHeight: resources.unbondingHeight ?? null,
+    }),
     ...(typeof resources.hasMigratedPublicTokens === "boolean" && {
       hasMigratedPublicTokens: resources.hasMigratedPublicTokens,
     }),
@@ -40,6 +46,12 @@ export function fromAleoResourcesRaw(rawResources: AleoResourcesRaw): AleoResour
     unspentPrivateRecords: rawResources.unspentPrivateRecords
       ? JSON.parse(rawResources.unspentPrivateRecords)
       : null,
+    ...(typeof rawResources.bondedBalance === "string" && {
+      bondedBalance: new BigNumber(rawResources.bondedBalance),
+      bondedValidator: rawResources.bondedValidator ?? null,
+      unbondingBalance: new BigNumber(rawResources.unbondingBalance ?? 0),
+      unbondingHeight: rawResources.unbondingHeight ?? null,
+    }),
     ...(typeof rawResources.hasMigratedPublicTokens === "boolean" && {
       hasMigratedPublicTokens: rawResources.hasMigratedPublicTokens,
     }),

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -27,7 +27,12 @@ import { AleoApiConfigurationResetError } from "../errors";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import { getMockedRecord, MOCK_ALEO_ADDRESS } from "../__tests__/fixtures/api.fixture";
 import coinConfig from "../config";
-import { accessProvableApi, fetchAllOwnedRecords, patchPublicOperations } from "../network/utils";
+import {
+  accessProvableApi,
+  fetchAllOwnedRecords,
+  getStakingPosition,
+  patchPublicOperations,
+} from "../network/utils";
 import { listPrivateOperations } from "./listPrivateOperations";
 import { getPrivateBalance } from "../logic/getPrivateBalance";
 import {
@@ -49,6 +54,7 @@ jest.mock("../network/utils", () => ({
   ...jest.requireActual("../network/utils"),
   accessProvableApi: jest.fn(),
   fetchAllOwnedRecords: jest.fn(),
+  getStakingPosition: jest.fn(),
   patchPublicOperations: jest.fn(),
 }));
 jest.mock("./listOperations");
@@ -65,6 +71,7 @@ jest.mock("@ledgerhq/logs", () => ({
 const mockGetSyncHash = jest.mocked(getSyncHash);
 const mockGetPublicBalance = jest.mocked(getPublicBalance);
 const mockLastBlock = jest.mocked(lastBlock);
+const mockGetStakingPosition = jest.mocked(getStakingPosition);
 const mockListOperations = jest.mocked(listOperations);
 const mockAccessProvableApi = jest.mocked(accessProvableApi);
 const mockFetchAllOwnedRecords = jest.mocked(fetchAllOwnedRecords);
@@ -78,6 +85,7 @@ describe("sync.ts", () => {
   const mockCurrency = getMockedCurrency();
   const mockConfig = getMockedConfig("mainnet");
   const mockConfigWithTokens = { ...mockConfig, enableTokens: true };
+  const mockConfigWithStaking = { ...mockConfig, enableStaking: true };
   const mockTokenCurrency = getMockedTokenCurrency();
   const mockDerivationMode: DerivationMode = "";
   const mockLedgerAccountId = encodeAccountId({
@@ -124,6 +132,15 @@ describe("sync.ts", () => {
       height: 100,
       hash: "mock-block-hash",
       time: new Date("2024-01-01"),
+    });
+
+    // Nothing bonded by default: staking-specific expectations override this per test.
+    mockGetStakingPosition.mockResolvedValue({
+      bondedBalance: new BigNumber(0),
+      bondedValidator: null,
+      unbondingBalance: new BigNumber(0),
+      unbondingHeight: null,
+      withdrawalAddress: null,
     });
 
     mockListOperations.mockResolvedValue({
@@ -768,6 +785,107 @@ describe("sync.ts", () => {
           options: expect.objectContaining({ cursor: "12345" }),
         }),
       );
+    });
+
+    describe("staking position", () => {
+      const bondedBalance = new BigNumber(70000);
+      const unbondingBalance = new BigNumber(5000);
+      const publicSyncInfo = {
+        index: mockAccount.index,
+        derivationPath: mockAccount.freshAddressPath,
+        address: mockAccount.freshAddress,
+        currency: mockCurrency,
+        derivationMode: mockDerivationMode,
+        initialAccount: undefined,
+      };
+
+      beforeEach(() => {
+        coinConfig.setCoinConfig(() => mockConfigWithStaking);
+        mockGetStakingPosition.mockResolvedValue({
+          bondedBalance,
+          bondedValidator: "aleo1validator",
+          unbondingBalance,
+          unbondingHeight: 250,
+          withdrawalAddress: mockAccount.freshAddress,
+        });
+      });
+
+      it("persists the position onto aleoResources", async () => {
+        const result = await performPublicSync(publicSyncInfo, mockSyncConfig);
+
+        expect(result.aleoResources).toMatchObject({
+          bondedBalance,
+          bondedValidator: "aleo1validator",
+          unbondingBalance,
+          unbondingHeight: 250,
+        });
+      });
+
+      it("counts bonded and unbonding funds in balance but not spendableBalance", async () => {
+        const result = await performPublicSync(publicSyncInfo, mockSyncConfig);
+
+        // no initialAccount, so the private balance is 0 and liquid == transparent
+        expect(result.spendableBalance).toEqual(mockAccount.balance);
+        expect(result.balance).toEqual(
+          mockAccount.balance.plus(bondedBalance).plus(unbondingBalance),
+        );
+      });
+
+      it("does not persist the withdrawal address", async () => {
+        const result = await performPublicSync(publicSyncInfo, mockSyncConfig);
+
+        expect(result.aleoResources).not.toHaveProperty("withdrawalAddress");
+      });
+
+      describe("when enableStaking is off", () => {
+        beforeEach(() => {
+          coinConfig.setCoinConfig(() => mockConfig);
+        });
+
+        it("does not read the staking mappings at all", async () => {
+          await performPublicSync(publicSyncInfo, mockSyncConfig);
+
+          expect(mockGetStakingPosition).not.toHaveBeenCalled();
+        });
+
+        it("leaves the staking fields absent rather than zeroed", async () => {
+          const result = await performPublicSync(publicSyncInfo, mockSyncConfig);
+
+          // absent, not 0/null: the mappings were never read, so there is nothing to claim
+          expect(result.aleoResources).not.toHaveProperty("bondedBalance");
+          expect(result.aleoResources).not.toHaveProperty("bondedValidator");
+          expect(result.aleoResources).not.toHaveProperty("unbondingBalance");
+          expect(result.aleoResources).not.toHaveProperty("unbondingHeight");
+        });
+
+        it("keeps balance and spendableBalance equal, as before the rollout", async () => {
+          const result = await performPublicSync(publicSyncInfo, mockSyncConfig);
+
+          expect(result.balance).toEqual(mockAccount.balance);
+          expect(result.spendableBalance).toEqual(mockAccount.balance);
+        });
+
+        it("drops a previously persisted position, so the flag acts as a kill switch", async () => {
+          const bondedAccount: AleoAccount = {
+            ...mockInitialAccount,
+            aleoResources: {
+              ...mockInitialAccount.aleoResources!,
+              bondedBalance: new BigNumber(70000),
+              bondedValidator: "aleo1validator",
+              unbondingBalance: new BigNumber(5000),
+              unbondingHeight: 250,
+            },
+          };
+
+          const result = await performPublicSync(
+            { ...publicSyncInfo, initialAccount: bondedAccount },
+            mockSyncConfig,
+          );
+
+          expect(result.aleoResources).not.toHaveProperty("bondedBalance");
+          expect(result.balance).toEqual(result.spendableBalance);
+        });
+      });
     });
   });
 
@@ -1910,6 +2028,161 @@ describe("sync.ts", () => {
       // second emission: private result (has lastPrivateSyncDate, updated balance)
       expect(second.aleoResources?.lastPrivateSyncDate).toBeInstanceOf(Date);
       expect(second.aleoResources?.privateBalance).toEqual(new BigNumber(5000));
+    });
+
+    it("public+private sync keeps the freshly-fetched staking position in the private emission", async () => {
+      // Regression guard: the private shape is spread last, so if it read the staking
+      // position from initialAccount instead of the public cycle's result, a bond made
+      // since the last sync would be reverted on every combined sync.
+      const configuredProvableApi = {
+        ...mockAleoResources.provableApi!,
+        scannerStatus: { percentage: 100, synced: true },
+      };
+      mockAccessProvableApi.mockResolvedValue(configuredProvableApi);
+      mockGetPrivateBalance.mockResolvedValue({
+        balance: new BigNumber(5000),
+        unspentRecords: [],
+      });
+      coinConfig.setCoinConfig(() => mockConfigWithStaking);
+
+      const freshlyBonded = new BigNumber(70000);
+      mockGetStakingPosition.mockResolvedValue({
+        bondedBalance: freshlyBonded,
+        bondedValidator: "aleo1freshvalidator",
+        unbondingBalance: new BigNumber(0),
+        unbondingHeight: null,
+        withdrawalAddress: null,
+      });
+
+      const syncedBaseInfo = {
+        ...baseInfo,
+        initialAccount: {
+          ...mockInitialAccount,
+          aleoResources: {
+            ...mockInitialAccount.aleoResources!,
+            lastPrivateSyncDate: new Date("2024-01-01"),
+            // stale: what the account knew before this cycle
+            bondedBalance: new BigNumber(0),
+            bondedValidator: null,
+          },
+        },
+      };
+
+      const { syncs } = buildSyncObservables(syncedBaseInfo, {
+        paginationConfig: {},
+        syncType: SYNC_TYPE_TRANSPARENT | SYNC_TYPE_SHIELDED,
+      });
+
+      const [, second] = await collectAll(syncs[0]);
+
+      expect(second.aleoResources?.bondedBalance).toEqual(freshlyBonded);
+      expect(second.aleoResources?.bondedValidator).toBe("aleo1freshvalidator");
+      // and the bonded amount still counts towards balance but not spendableBalance
+      expect(second.balance).toEqual(second.spendableBalance!.plus(freshlyBonded));
+    });
+
+    it("private-only sync does not re-persist a stale staking position while enableStaking is off", async () => {
+      // A private-only sync receives no freshStakingPosition, so the private path has to
+      // check the flag itself rather than relying on the public path having skipped the fetch.
+      const configuredProvableApi = {
+        ...mockAleoResources.provableApi!,
+        scannerStatus: { percentage: 100, synced: true },
+      };
+      mockAccessProvableApi.mockResolvedValue(configuredProvableApi);
+      coinConfig.setCoinConfig(() => mockConfig);
+
+      const bondedAccount: AleoAccount = {
+        ...mockInitialAccount,
+        aleoResources: {
+          ...mockInitialAccount.aleoResources!,
+          lastPrivateSyncDate: new Date("2024-01-01"),
+          bondedBalance: new BigNumber(70000),
+          bondedValidator: "aleo1validator",
+          unbondingBalance: new BigNumber(5000),
+          unbondingHeight: 250,
+        },
+      };
+
+      const { syncs } = buildSyncObservables(
+        { ...baseInfo, initialAccount: bondedAccount },
+        { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED },
+      );
+
+      const [emission] = await collectAll(syncs[0]);
+
+      expect(emission.aleoResources).not.toHaveProperty("bondedBalance");
+      expect(emission.aleoResources).not.toHaveProperty("unbondingHeight");
+      expect(emission.balance).toEqual(emission.spendableBalance);
+    });
+
+    it("private-only sync leaves the fields absent when no position has ever been synced", async () => {
+      // enableStaking is on but no public cycle ran, so there is no position to carry. Absent
+      // has to stay absent: zeroing it would claim the mappings were read and came back empty.
+      const configuredProvableApi = {
+        ...mockAleoResources.provableApi!,
+        scannerStatus: { percentage: 100, synced: true },
+      };
+      mockAccessProvableApi.mockResolvedValue(configuredProvableApi);
+      coinConfig.setCoinConfig(() => mockConfigWithStaking);
+
+      const neverStakedAccount: AleoAccount = {
+        ...mockInitialAccount,
+        aleoResources: {
+          ...mockInitialAccount.aleoResources!,
+          lastPrivateSyncDate: new Date("2024-01-01"),
+        },
+      };
+
+      const { syncs } = buildSyncObservables(
+        { ...baseInfo, initialAccount: neverStakedAccount },
+        { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED },
+      );
+
+      const [emission] = await collectAll(syncs[0]);
+
+      expect(emission.aleoResources).not.toHaveProperty("bondedBalance");
+      expect(emission.aleoResources).not.toHaveProperty("bondedValidator");
+      expect(emission.aleoResources).not.toHaveProperty("unbondingBalance");
+      expect(emission.aleoResources).not.toHaveProperty("unbondingHeight");
+      expect(emission.balance).toEqual(emission.spendableBalance);
+    });
+
+    it("private-only sync carries an already-synced position through untouched", async () => {
+      // The flip side of the above: a position the account already holds is the best value
+      // available when no public cycle ran, so it must survive rather than be dropped.
+      const configuredProvableApi = {
+        ...mockAleoResources.provableApi!,
+        scannerStatus: { percentage: 100, synced: true },
+      };
+      mockAccessProvableApi.mockResolvedValue(configuredProvableApi);
+      coinConfig.setCoinConfig(() => mockConfigWithStaking);
+
+      const bondedAccount: AleoAccount = {
+        ...mockInitialAccount,
+        aleoResources: {
+          ...mockInitialAccount.aleoResources!,
+          lastPrivateSyncDate: new Date("2024-01-01"),
+          bondedBalance: new BigNumber(70000),
+          bondedValidator: "aleo1validator",
+          unbondingBalance: new BigNumber(5000),
+          unbondingHeight: 250,
+        },
+      };
+
+      const { syncs } = buildSyncObservables(
+        { ...baseInfo, initialAccount: bondedAccount },
+        { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED },
+      );
+
+      const [emission] = await collectAll(syncs[0]);
+
+      expect(emission.aleoResources).toMatchObject({
+        bondedBalance: new BigNumber(70000),
+        bondedValidator: "aleo1validator",
+        unbondingBalance: new BigNumber(5000),
+        unbondingHeight: 250,
+      });
+      expect(emission.balance).toEqual(emission.spendableBalance!.plus(75000));
     });
 
     it("makeGetAccountShape completes immediately with no emissions when syncType is 0", async () => {

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -23,11 +23,18 @@ import {
   isRecordScannerReady,
   splitPrivateAndPublicOperations,
   resolveConfig,
+  sumStakedBalance,
+  toStakingResources,
 } from "../logic/utils";
 import { listOperations } from "./listOperations";
 import { getCalTokens } from "./utils";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
-import { accessProvableApi, fetchAllOwnedRecords, patchPublicOperations } from "../network/utils";
+import {
+  accessProvableApi,
+  fetchAllOwnedRecords,
+  getStakingPosition,
+  patchPublicOperations,
+} from "../network/utils";
 import {
   PROGRESS_AFTER_SCANNER,
   PROGRESS_AFTER_LIST_OPS,
@@ -37,6 +44,7 @@ import {
 } from "../constants";
 import type {
   AleoAccount,
+  AleoStakingResources,
   AleoOperation,
   AleoUnspentRecord,
   Transaction as AleoTransaction,
@@ -77,9 +85,10 @@ export async function performPublicSync(
   });
   const config = resolveConfig(currency.id);
 
-  const [balances, latestBlock] = await Promise.all([
+  const [balances, latestBlock, stakingPosition] = await Promise.all([
     getPublicBalance(config, address),
     lastBlock(config),
+    config.enableStaking ? getStakingPosition(config, address) : undefined,
   ]);
 
   const blockHeight = latestBlock?.height ?? initialAccount?.blockHeight ?? 0;
@@ -144,7 +153,11 @@ export async function performPublicSync(
   const preservedPrivateOps = oldPrivateOps as AleoOperation[];
 
   const preservedPrivateBalance = initialAccount?.aleoResources?.privateBalance ?? null;
-  const totalBalance = transparentBalance.plus(preservedPrivateBalance ?? 0);
+  const stakingResources = stakingPosition ? toStakingResources(stakingPosition) : {};
+  // Bonded and unbonding funds are owned by the account but cannot be spent until they are
+  // unbonded and claimed, so they count towards `balance` but not `spendableBalance`.
+  const liquidBalance = transparentBalance.plus(preservedPrivateBalance ?? 0);
+  const totalBalance = liquidBalance.plus(sumStakedBalance(stakingResources));
 
   // Same reasoning as filteredLatestPublicOperations: patched token sub-account ops have
   // modified senders/recipients that differ from raw API data. sameOp detects the difference
@@ -183,7 +196,7 @@ export async function performPublicSync(
     type: "Account",
     id: ledgerAccountId,
     balance: totalBalance,
-    spendableBalance: totalBalance,
+    spendableBalance: liquidBalance,
     blockHeight,
     operations,
     operationsCount: operations.length,
@@ -196,6 +209,7 @@ export async function performPublicSync(
       privateBalance: preservedPrivateBalance,
       unspentPrivateRecords: initialAccount?.aleoResources?.unspentPrivateRecords ?? null,
       lastPrivateSyncDate: initialAccount?.aleoResources?.lastPrivateSyncDate ?? null,
+      ...stakingResources,
       ...(config.enableTokens && { hasMigratedPublicTokens: true }),
     },
   };
@@ -235,12 +249,17 @@ export function createPublicSyncObservable(
  *   freshly-fetched data rather than the previous cycle's state.
  * @param freshTransparentBalance - The transparent balance from the current
  *   public sync cycle. Used to compute the correct total balance.
+ * @param freshStakingPosition - The staking fields fetched by the current public
+ *   sync cycle. The combined-sync emission spreads the private shape last, so it
+ *   must carry the fresh staking values or it would clobber them with the stale
+ *   initialAccount ones — same reasoning as freshTransparentBalance.
  */
 export async function performPrivateSync({
   info,
   syncConfig: _syncConfig,
   currentPublicOps,
   freshTransparentBalance,
+  freshStakingPosition,
   onProgress,
   signal,
   publicSubAccounts,
@@ -250,6 +269,7 @@ export async function performPrivateSync({
   syncConfig: SyncConfig;
   currentPublicOps: AleoOperation[];
   freshTransparentBalance?: BigNumber;
+  freshStakingPosition?: AleoStakingResources;
   onProgress?: (progress: number) => void;
   signal?: AbortSignal;
   publicSubAccounts?: TokenAccount[];
@@ -474,7 +494,14 @@ export async function performPrivateSync({
   // otherwise fall back to what the account last recorded.
   const transparentBalance =
     freshTransparentBalance ?? initialAccount.aleoResources?.transparentBalance ?? new BigNumber(0);
-  const totalBalance = transparentBalance.plus(privateBalance);
+
+  const stakingSource = freshStakingPosition ?? initialAccount.aleoResources;
+  const stakingResources =
+    config.enableStaking && BigNumber.isBigNumber(stakingSource?.bondedBalance)
+      ? toStakingResources(stakingSource)
+      : {};
+  const liquidBalance = transparentBalance.plus(privateBalance);
+  const totalBalance = liquidBalance.plus(sumStakedBalance(stakingResources));
 
   log("aleo/performPrivateSync", "Private sync completed", {
     ledgerAccountId,
@@ -521,7 +548,7 @@ export async function performPrivateSync({
     type: "Account",
     id: ledgerAccountId,
     balance: totalBalance,
-    spendableBalance: totalBalance,
+    spendableBalance: liquidBalance,
     blockHeight,
     operations: finalOperations,
     operationsCount: finalOperations.length,
@@ -534,6 +561,7 @@ export async function performPrivateSync({
       privateBalance,
       unspentPrivateRecords,
       lastPrivateSyncDate: new Date(),
+      ...stakingResources,
       ...(config.enableTokens && {
         hasMigratedPublicTokens: true,
         hasMigratedPrivateTokens: true,
@@ -549,6 +577,7 @@ export function createPrivateSyncObservable(
   freshTransparentBalance?: BigNumber,
   publicSubAccounts?: TokenAccount[],
   freshSyncHash?: string,
+  freshStakingPosition?: AleoStakingResources,
 ): Observable<Partial<AleoAccount>> {
   const { initialAccount } = info;
   const currencyId = info.currency.id;
@@ -581,6 +610,7 @@ export function createPrivateSyncObservable(
       currentPublicOps: publicOps,
       signal: controller.signal,
       ...(freshTransparentBalance !== undefined && { freshTransparentBalance }),
+      ...(freshStakingPosition !== undefined && { freshStakingPosition }),
       ...(onProgress !== undefined && { onProgress }),
       ...(publicSubAccounts !== undefined && { publicSubAccounts }),
       ...(freshSyncHash !== undefined && { freshSyncHash }),
@@ -684,6 +714,7 @@ export function buildSyncObservables(
               publicResult.aleoResources?.transparentBalance,
               publicResult.subAccounts,
               publicResult.syncHash,
+              publicResult.aleoResources,
             ),
           ),
         ),

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -89,6 +89,9 @@ import {
   hasSpecificIntentData,
   getOperationDetailsExtraFields,
   getAvailableBalance,
+  getClaimableStakingBalance,
+  sumStakedBalance,
+  toStakingResources,
   isSelfTransferTransaction,
   isPublicTransaction,
   isPrivateTransaction,
@@ -1629,6 +1632,102 @@ describe("getAvailableBalance", () => {
     expect(() => getAvailableBalance(mockAccount, transaction)).toThrow(
       `aleo: unsupported tx mode for balance calculation: ${unsupportedMode}`,
     );
+  });
+});
+
+describe("toStakingResources", () => {
+  it("carries a chain position through unchanged, dropping the withdrawal address", () => {
+    const result = toStakingResources({
+      bondedBalance: new BigNumber(70000),
+      bondedValidator: "aleo1validator",
+      unbondingBalance: new BigNumber(5000),
+      unbondingHeight: 250,
+    });
+
+    expect(result).toStrictEqual({
+      bondedBalance: new BigNumber(70000),
+      bondedValidator: "aleo1validator",
+      unbondingBalance: new BigNumber(5000),
+      unbondingHeight: 250,
+    });
+  });
+
+  it("normalizes an account that predates the staking fields to an empty position", () => {
+    expect(toStakingResources({})).toStrictEqual({
+      bondedBalance: new BigNumber(0),
+      bondedValidator: null,
+      unbondingBalance: new BigNumber(0),
+      unbondingHeight: null,
+    });
+  });
+
+  it("normalizes a missing source to an empty position", () => {
+    expect(toStakingResources(undefined)).toStrictEqual({
+      bondedBalance: new BigNumber(0),
+      bondedValidator: null,
+      unbondingBalance: new BigNumber(0),
+      unbondingHeight: null,
+    });
+  });
+});
+
+describe("sumStakedBalance", () => {
+  it("adds the bonded and unbonding amounts", () => {
+    const result = sumStakedBalance({
+      bondedBalance: new BigNumber(70000),
+      unbondingBalance: new BigNumber(5000),
+    });
+
+    expect(result).toStrictEqual(new BigNumber(75000));
+  });
+
+  it("returns zero for the empty slice staking-disabled accounts carry", () => {
+    expect(sumStakedBalance({})).toStrictEqual(new BigNumber(0));
+  });
+});
+
+describe("getClaimableStakingBalance", () => {
+  const unbondingBalance = new BigNumber(50000);
+
+  const accountAt = (blockHeight: number, unbondingHeight: number | null) =>
+    getMockedAccount({
+      blockHeight,
+      aleoResources: { ...mockAleoResources, unbondingBalance, unbondingHeight },
+    });
+
+  it("returns zero while the chain has not reached the unbonding height", () => {
+    expect(getClaimableStakingBalance(accountAt(249, 250))).toStrictEqual(new BigNumber(0));
+  });
+
+  it("returns the full unbonding balance once the height is reached", () => {
+    expect(getClaimableStakingBalance(accountAt(250, 250))).toStrictEqual(unbondingBalance);
+  });
+
+  it("returns the full unbonding balance once the height is passed", () => {
+    expect(getClaimableStakingBalance(accountAt(999, 250))).toStrictEqual(unbondingBalance);
+  });
+
+  it("returns zero when there is no unbonding entry", () => {
+    expect(getClaimableStakingBalance(accountAt(999, null))).toStrictEqual(new BigNumber(0));
+  });
+
+  it("returns zero when the account has never synced a staking position", () => {
+    // the four fields are simply absent on an account cached before they existed
+    const {
+      unbondingBalance: _balance,
+      unbondingHeight: _height,
+      ...neverSynced
+    } = mockAleoResources;
+    const account = getMockedAccount({ blockHeight: 999, aleoResources: neverSynced });
+
+    expect(getClaimableStakingBalance(account)).toStrictEqual(new BigNumber(0));
+  });
+
+  it("returns zero when aleoResources is missing entirely", () => {
+    // @ts-expect-error - testing behavior when aleoResources is explicitly undefined
+    const brokenAccount = getMockedAccount({ blockHeight: 999, aleoResources: undefined });
+
+    expect(getClaimableStakingBalance(brokenAccount)).toStrictEqual(new BigNumber(0));
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -65,6 +65,7 @@ import type {
   AleoTokenType,
   EnrichedPrivateRecord,
   AleoStakingPosition,
+  AleoStakingResources,
   AleoStakingMode,
   AleoValidatorNonEarningReason,
 } from "../types";
@@ -888,6 +889,41 @@ export const getOperationDetailsExtraFields = (
 ): OperationDetailsExtraField[] => {
   return [{ key: "functionId", value: extra.functionId }];
 };
+
+/**
+ * Normalizes a staking position — from the chain or from a previously synced account —
+ * into the slice stored on `aleoResources`.
+ */
+export function toStakingResources(source: AleoStakingResources | undefined): AleoStakingResources {
+  return {
+    bondedBalance: source?.bondedBalance ?? new BigNumber(0),
+    bondedValidator: source?.bondedValidator ?? null,
+    unbondingBalance: source?.unbondingBalance ?? new BigNumber(0),
+    unbondingHeight: source?.unbondingHeight ?? null,
+  };
+}
+
+/**
+ * The part of the balance that is staked: bonded plus unbonding. Owned by the account but
+ * not spendable until unbonded and claimed, so it belongs in `balance` and not
+ * `spendableBalance`. Zero for an empty slice, i.e. whenever staking is disabled.
+ */
+export function sumStakedBalance(resources: AleoStakingResources): BigNumber {
+  return (resources.bondedBalance ?? new BigNumber(0)).plus(resources.unbondingBalance ?? 0);
+}
+
+/**
+ * Unbonded funds become claimable once the chain reaches the height stored in the
+ * credits.aleo `unbonding` mapping. Uses the account's last synced blockHeight.
+ *
+ * Returns zero while staking is disabled, since the slice is then absent.
+ */
+export function getClaimableStakingBalance(account: AleoAccount): BigNumber {
+  const { unbondingBalance, unbondingHeight } = account.aleoResources ?? {};
+  if (!unbondingBalance || unbondingHeight === null || unbondingHeight === undefined)
+    return new BigNumber(0);
+  return account.blockHeight >= unbondingHeight ? unbondingBalance : new BigNumber(0);
+}
 
 /**
  * Returns the spendable balance for a given Aleo transaction mode.

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -136,7 +136,10 @@ export interface AleoResources {
   lastPrivateSyncDate: Date | null;
   hasMigratedPublicTokens?: boolean;
   hasMigratedPrivateTokens?: boolean;
+  bondedBalance?: BigNumber;
   bondedValidator?: string | null;
+  unbondingBalance?: BigNumber;
+  unbondingHeight?: number | null;
 }
 
 export interface AleoResourcesRaw {
@@ -147,8 +150,20 @@ export interface AleoResourcesRaw {
   lastPrivateSyncDate: string | null;
   hasMigratedPublicTokens?: boolean;
   hasMigratedPrivateTokens?: boolean;
+  bondedBalance?: string;
   bondedValidator?: string | null;
+  unbondingBalance?: string;
+  unbondingHeight?: number | null;
 }
+
+/**
+ * The staking slice of {@link AleoResources}. Absent entirely — not zeroed — while the
+ * `enableStaking` flag is off, since the mappings are then never read.
+ */
+export type AleoStakingResources = Pick<
+  AleoResources,
+  "bondedBalance" | "bondedValidator" | "unbondingBalance" | "unbondingHeight"
+>;
 
 export type AleoAccount = Account & {
   aleoResources?: AleoResources;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Puts the Aleo staking position on the account object and fixes the balance arithmetic that comes with it.

Until now nothing about a stake reached the account, so no screen could show one, no validation could check a bonded amount, and the total balance was simply wrong for anyone who had staked. This PR is the persistence + balance half; the flows that read it land separately.

####  The position is carried on `aleoResources`

Four new optional fields next to the existing `transparentBalance` / `privateBalance`, with their raw counterparts and serialisation both ways so they survive a persist/restore:

| field | meaning |
| --- | --- |
| `bondedBalance` | amount currently bonded |
| `bondedValidator` | validator it is bonded to |
| `unbondingBalance` | amount unbonding |
| `unbondingHeight` | block height at which it becomes claimable |

They are populated in the public sync from `getStakingPosition` (LIVE-32273), fetched alongside the existing balance and last-block calls.

**Absent is not the same as zero.** Missing fields mean the `credits.aleo` mappings were never read; `0` means they were read and the account has nothing bonded. Serialisation, both sync paths and the tests all preserve that distinction, because it is what a consumer needs to tell "nothing staked" from "not known yet".

#### Tests

- Serialisation round-trip: fully populated position, absent-stays-absent in both directions, a genuinely synced zero, and a bonded amount beyond `Number.MAX_SAFE_INTEGER`.
- Public sync: position persisted, withdrawal address deliberately not persisted, balance vs spendable split, and the four flag-off cases including the kill switch.
- Combined public+private sync: the freshly fetched position survives the private emission.
- Private-only sync: carries an existing position, leaves an absent one absent, and ignores a stale one while the flag is off.
- Unit coverage for `toStakingResources`, `sumStakedBalance` and `getClaimableStakingBalance`.

Flag disabled: 
<img width="1722" height="748" alt="Screenshot from 2026-09-10 09-00-46" src="https://github.com/user-attachments/assets/5a0d18b8-2263-47cd-9e0b-fa9c99ea6cd3" />

Flag enabled: 
<img width="1722" height="748" alt="Screenshot from 2026-09-10 09-04-45" src="https://github.com/user-attachments/assets/b4096abe-fd07-4f87-aedc-8bc8e4fc82e6" />

Flag disabled again:  (the same state as before enabling it)
<img width="1722" height="748" alt="Screenshot from 2026-09-10 09-12-04" src="https://github.com/user-attachments/assets/784c70e7-bab9-4868-b7d8-df0eca1f8f7c" />


### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-32272](https://ledgerhq.atlassian.net/browse/LIVE-32272)

