### PR TITLE
[LWM] feat(contacts): use @shared/i18n in contacts-list (LIVE-37080)

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -1,5 +1,4 @@
 import {
-  type ContactsListViewLabels,
   type ContactsViewNativeProps,
   useContactsSearchViewModel,
   useContactsMeContact,
@@ -43,20 +42,11 @@ export function useContactsPageViewModel(
   const analytics = useContactsAnalytics();
   const meContact = useContactsMeContact();
   const contacts = useContacts();
-  const labels = useMemo<ContactsListViewLabels>(
-    () => ({
-      title: t("contacts.title"),
-      searchPlaceholder: t("contacts.searchPlaceholder"),
-      searchNoResults: t("contacts.searchNoResults"),
-      addContact: t("contacts.addContact"),
-      ledgerSyncCheckingAccessibilityLabel: t(
-        "contacts.ledgerSyncIntroduction.checkingAccessibilityLabel",
-      ),
-      formatAddressCount: count => t("contacts.addressCount", { count }),
-      formatMeDisplayName: createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
         t("contacts.detail.meDisplayName", { name }),
       ),
-    }),
     [t],
   );
   const preference = useContactsFeatureIntroductionPreference();
@@ -80,7 +70,7 @@ export function useContactsPageViewModel(
     useContactsLedgerSyncActivationDrawer();
   const [isLedgerSyncIntroductionRequested, setIsLedgerSyncIntroductionRequested] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const viewModel = useContactsSearchViewModel(searchQuery, labels.formatMeDisplayName);
+  const viewModel = useContactsSearchViewModel(searchQuery, formatMeDisplayName);
   const onSearchQueryChange = useCallback((query: string) => setSearchQuery(query), []);
   const onOpenContact = useCallback<ContactsViewNativeProps["onOpenContact"]>(
     contactId => {
@@ -143,7 +133,6 @@ export function useContactsPageViewModel(
 
   return {
     viewModel,
-    labels,
     searchQuery,
     onSearchQueryChange,
     meAvatarSrc: USER_AVATAR_URL,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
@@ -7,6 +7,7 @@ import { useContactsFeature } from "@features/platform-contacts";
 import { ScreenName } from "~/const";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { TrackScreen } from "~/analytics";
+import { useTranslation } from "~/context/Locale";
 import { ContactsPageContent } from "./components/ContactsPageContent";
 import { useContactsAddContactDrawerAdapter } from "./hooks/useContactsAddContactDrawerAdapter";
 import { useContactsPageNavigationViewModel } from "./hooks/useContactsPageNavigationViewModel";
@@ -29,6 +30,7 @@ type ContactsPageProps = Readonly<{
 }>;
 
 export function ContactsPage({ title, onSelectContact }: ContactsPageProps) {
+  const { t } = useTranslation();
   const pageViewModel = useContactsPageViewModel(onSelectContact);
   const { onSearchQueryChange } = pageViewModel;
   const onSaveSuccess = useCallback(() => {
@@ -45,7 +47,7 @@ export function ContactsPage({ title, onSelectContact }: ContactsPageProps) {
   };
 
   useContactsPageNavigationViewModel(
-    pageViewModel.labels.addContact,
+    t("contacts.addContact"),
     !isContactsSearchNoResultsViewModel(pageViewModel.viewModel),
     onAddContact,
     title,

--- a/features/flow/contacts/src/ContactsView.types.ts
+++ b/features/flow/contacts/src/ContactsView.types.ts
@@ -1,6 +1,6 @@
 import type { ChangeEvent } from "react";
 import type { ContactId } from "@domain/entity-contact";
-import type { ContactsListViewLabels, ContactsPageViewModel } from "@features/flow-contacts-list";
+import type { ContactsPageViewModel } from "@features/flow-contacts-list";
 import type {
   ContactsFeatureIntroduction,
   ContactsLedgerSyncIntroduction,
@@ -10,7 +10,6 @@ import type { ContactDetailViewProps } from "./steps/Detail/types";
 
 type ContactsPageSharedProps = Readonly<{
   viewModel: ContactsPageViewModel;
-  labels: ContactsListViewLabels;
   searchQuery: string;
   meAvatarSrc: string;
   onOpenContact: (contactId: ContactId) => void;

--- a/features/flow/contacts/src/contactsListFacade.native.ts
+++ b/features/flow/contacts/src/contactsListFacade.native.ts
@@ -10,7 +10,6 @@ export {
   ContactsAddContactHeaderButton,
 } from "@features/flow-contacts-list/native";
 export type {
-  ContactsListViewLabels,
   ContactsPageViewModel,
   ContactsSearchNoResultsViewModel,
   ContactsSearchResultsViewModel,

--- a/features/flow/contacts/src/contactsListFacade.ts
+++ b/features/flow/contacts/src/contactsListFacade.ts
@@ -9,7 +9,6 @@ export {
   isPopulatedContactsListViewModel,
 } from "@features/flow-contacts-list";
 export type {
-  ContactsListViewLabels,
   ContactsPageViewModel,
   ContactsSearchNoResultsViewModel,
   ContactsSearchResultsViewModel,

--- a/features/flow/flow-contacts-list/package.json
+++ b/features/flow/flow-contacts-list/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
     "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "tailwind-merge": "catalog:"

--- a/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
@@ -6,6 +6,7 @@ import {
   type SectionListRenderItemInfo,
 } from "react-native";
 import { Box, Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsListItem, ContactsListSection, ContactsListViewNativeProps } from "./types";
 import { createContactsListRowLayouts } from "./utils";
 import { ContactsListHeader } from "./components/ListHeader/ContactsListHeader.native";
@@ -20,7 +21,6 @@ const noContactsListSections: readonly never[] = [];
 
 export function ContactsListView({
   viewModel,
-  labels,
   meAvatarSrc,
   onOpenContact,
   onAddContact,
@@ -29,6 +29,7 @@ export function ContactsListView({
   onSearchQueryChange,
   surface = "base",
 }: ContactsListViewNativeProps): React.JSX.Element {
+  const { t } = useTranslation();
   const isPopulated = viewModel.displayMode === "populated";
   const hasNoResults = "status" in viewModel && viewModel.status === "no-results";
   const me = "me" in viewModel ? viewModel.me : undefined;
@@ -60,12 +61,12 @@ export function ContactsListView({
       <Box onLayout={onContactRowLayout}>
         <ContactsSavedContactListItem
           contact={item}
-          addressCountLabel={labels.formatAddressCount(item.addressCount)}
+          addressCountLabel={t("contacts.addressCount", { count: item.addressCount })}
           onOpen={onOpenContact}
         />
       </Box>
     ),
-    [labels, onContactRowLayout, onOpenContact],
+    [t, onContactRowLayout, onOpenContact],
   );
   const rowLayouts = useMemo(
     () => createContactsListRowLayouts(sections, sectionHeaderHeight, contactRowHeight),
@@ -92,7 +93,6 @@ export function ContactsListView({
   const listHeader = (
     <ContactsListHeader
       me={me}
-      labels={labels}
       meAvatarSrc={meAvatarSrc}
       showAddContact={!isPopulated && !hasNoResults}
       onOpenContact={onOpenContact}
@@ -151,7 +151,7 @@ export function ContactsListView({
     content = (
       <Box lx={{ flex: 1, paddingHorizontal: "s16", paddingTop: "s8" }}>
         {listHeader}
-        <ContactsSearchNoResults message={labels.searchNoResults} />
+        <ContactsSearchNoResults message={t("contacts.searchNoResults")} />
       </Box>
     );
   } else {
@@ -184,7 +184,7 @@ export function ContactsListView({
           }}
         >
           <ContactsSearchInput
-            placeholder={labels.searchPlaceholder}
+            placeholder={t("contacts.searchPlaceholder")}
             value={searchQuery}
             onSearchQueryChange={onSearchQueryChange}
           />
@@ -204,7 +204,7 @@ export function ContactsListView({
           }}
           accessible
           accessibilityRole="progressbar"
-          accessibilityLabel={labels.ledgerSyncCheckingAccessibilityLabel ?? labels.title}
+          accessibilityLabel={t("contacts.ledgerSyncIntroduction.checkingAccessibilityLabel")}
           accessibilityState={{ busy: true }}
         >
           <Spinner testID="contacts-ledger-sync-spinner" />

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ContactId } from "@domain/entity-contact";
 import { mockMeContact, mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import type { ContactsPageViewModel } from "./types";
 import {
   createContactsSearchViewModel,
@@ -10,13 +11,25 @@ import {
 } from "./model/viewModel";
 import { ContactsListView } from "./ContactsListView.web";
 
-const labels = {
-  title: "Contacts",
-  searchPlaceholder: "Search contact",
-  searchNoResults: "No contact found",
-  addContact: "Add contact",
-  ledgerSyncCheckingAccessibilityLabel: "Checking Ledger Sync status",
-  formatAddressCount: (count: number) => `${count} address`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        title: "Contacts",
+        searchPlaceholder: "Search contact",
+        searchNoResults: "No contact found",
+        addContact: "Add contact",
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+        ledgerSyncIntroduction: {
+          checkingAccessibilityLabel: "Checking Ledger Sync status",
+        },
+        me: { myAddresses: "My addresses" },
+        detail: { meDisplayName: "My wallets ({{name}})" },
+      },
+    },
+  },
 };
 
 type RenderContactsPageOptions = Readonly<{
@@ -47,36 +60,37 @@ function renderContactsPage({
   onSearchInputChange = jest.fn(),
 }: RenderContactsPageOptions = {}) {
   render(
-    <ContactsListView
-      viewModel={viewModel}
-      labels={labels}
-      meAvatarSrc="https://example.com/black/user.png"
-      onOpenMe={onOpenMe}
-      onOpenContact={onOpenContact}
-      onAddContact={onAddContact}
-      searchQuery={searchQuery}
-      onSearchInputChange={onSearchInputChange}
-      isLedgerSyncChecking={isLedgerSyncChecking}
-      featureIntroduction={
-        isFeatureIntroductionOpen ? (
-          <div>
-            <p>Introducing Contacts</p>
-            <button onClick={onCompleteFeatureIntroduction}>Try contacts</button>
-          </div>
-        ) : undefined
-      }
-      ledgerSyncIntroduction={
-        isIntroductionOpen ? (
-          <div>
-            <p>
-              Your contacts are end-to-end encrypted with your Ledger and synced across your
-              devices, only you can unlock them.
-            </p>
-            <button onClick={onDismissIntroduction}>Got it</button>
-          </div>
-        ) : undefined
-      }
-    />,
+    <I18nTestProvider resources={resources}>
+      <ContactsListView
+        viewModel={viewModel}
+        meAvatarSrc="https://example.com/black/user.png"
+        onOpenMe={onOpenMe}
+        onOpenContact={onOpenContact}
+        onAddContact={onAddContact}
+        searchQuery={searchQuery}
+        onSearchInputChange={onSearchInputChange}
+        isLedgerSyncChecking={isLedgerSyncChecking}
+        featureIntroduction={
+          isFeatureIntroductionOpen ? (
+            <div>
+              <p>Introducing Contacts</p>
+              <button onClick={onCompleteFeatureIntroduction}>Try contacts</button>
+            </div>
+          ) : undefined
+        }
+        ledgerSyncIntroduction={
+          isIntroductionOpen ? (
+            <div>
+              <p>
+                Your contacts are end-to-end encrypted with your Ledger and synced across your
+                devices, only you can unlock them.
+              </p>
+              <button onClick={onDismissIntroduction}>Got it</button>
+            </div>
+          ) : undefined
+        }
+      />
+    </I18nTestProvider>,
   );
 
   return {
@@ -218,17 +232,18 @@ describe("ContactsPage", () => {
     const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
 
     render(
-      <ContactsListView
-        viewModel={createContactsSearchViewModel(me, contacts, "ben")}
-        labels={labels}
-        meAvatarSrc="https://example.com/black/user.png"
-        onOpenMe={jest.fn()}
-        onOpenContact={jest.fn()}
-        onAddContact={jest.fn()}
-        searchQuery="ben"
-        onSearchInputChange={jest.fn()}
-        isLedgerSyncChecking={false}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsListView
+          viewModel={createContactsSearchViewModel(me, contacts, "ben")}
+          meAvatarSrc="https://example.com/black/user.png"
+          onOpenMe={jest.fn()}
+          onOpenContact={jest.fn()}
+          onAddContact={jest.fn()}
+          searchQuery="ben"
+          onSearchInputChange={jest.fn()}
+          isLedgerSyncChecking={false}
+        />
+      </I18nTestProvider>,
     );
 
     const contactsList = screen.getByTestId("contacts-list");
@@ -243,17 +258,18 @@ describe("ContactsPage", () => {
     const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
 
     render(
-      <ContactsListView
-        viewModel={createContactsSearchViewModel(me, contacts, "unknown")}
-        labels={labels}
-        meAvatarSrc="https://example.com/black/user.png"
-        onOpenMe={jest.fn()}
-        onOpenContact={jest.fn()}
-        onAddContact={jest.fn()}
-        searchQuery="unknown"
-        onSearchInputChange={jest.fn()}
-        isLedgerSyncChecking={false}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsListView
+          viewModel={createContactsSearchViewModel(me, contacts, "unknown")}
+          meAvatarSrc="https://example.com/black/user.png"
+          onOpenMe={jest.fn()}
+          onOpenContact={jest.fn()}
+          onAddContact={jest.fn()}
+          searchQuery="unknown"
+          onSearchInputChange={jest.fn()}
+          isLedgerSyncChecking={false}
+        />
+      </I18nTestProvider>,
     );
 
     const contactsList = screen.getByTestId("contacts-list");

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "@shared/i18n";
 import { isContactsSearchNoResultsViewModel, type ContactsListViewProps } from "./types";
 import { ContactsLedgerSyncLoadingPane } from "./components/LedgerSyncLoadingPane/ContactsLedgerSyncLoadingPane.web";
 import { ContactsList } from "./components/ContactsList/ContactsList.web";
@@ -21,6 +22,7 @@ function renderContactsDetailPane(
 
 export function ContactsListView(props: ContactsListViewProps): React.ReactNode {
   const { isLedgerSyncChecking } = props;
+  const { t } = useTranslation();
   const showAddContact = !isContactsSearchNoResultsViewModel(props.viewModel);
   const contactsList = <ContactsList {...props} />;
 
@@ -32,8 +34,8 @@ export function ContactsListView(props: ContactsListViewProps): React.ReactNode 
         inert={isLedgerSyncChecking}
       >
         <ContactsPageLayout
-          title={props.labels.title}
-          addContactLabel={props.labels.addContact}
+          title={t("contacts.title")}
+          addContactLabel={t("contacts.addContact")}
           showAddContact={showAddContact}
           onAddContact={props.onAddContact}
           list={

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.test.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.test.tsx
@@ -7,11 +7,19 @@ import {
   mockContactWithMultipleAddresses,
 } from "@domain/entity-contact/schema.mock";
 import type { Contact } from "@domain/entity-contact";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { ContactsCompactList } from "../../index.native";
 
-const labels = {
-  emptyAddress: "No saved addresses",
-  formatAddressCount: (count: number) => `${count} saved addresses`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+      },
+    },
+  },
 };
 
 function createContacts(): readonly Contact[] {
@@ -29,19 +37,17 @@ function createContacts(): readonly Contact[] {
 describe("ContactsCompactList", () => {
   it("should render supplied contacts with the appropriate address descriptions", () => {
     render(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={createContacts()} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByText("Zero")).toBeVisible();
-    expect(screen.getByText(labels.emptyAddress)).toBeVisible();
+    expect(screen.getByText("0 address")).toBeVisible();
     expect(screen.getByText("One")).toBeVisible();
     expect(screen.getByText("Main wallet")).toBeVisible();
     expect(screen.getByText("Many")).toBeVisible();
-    expect(screen.getByText("2 saved addresses")).toBeVisible();
+    expect(screen.getByText("2 addresses")).toBeVisible();
     expect(screen.getByTestId("contacts-avatar-contact-zero").props.size).toBe("md");
     expect(screen.getByTestId("contacts-compact-row-contact-zero").props.lx).toEqual({
       marginHorizontal: "-s8",
@@ -55,12 +61,13 @@ describe("ContactsCompactList", () => {
 
   it("should render only the first supplied contacts when maxContacts is set", () => {
     render(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        maxContacts={2}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList
+          contacts={createContacts()}
+          maxContacts={2}
+          onContactSelect={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-compact-row-contact-zero")).toBeVisible();
@@ -70,18 +77,21 @@ describe("ContactsCompactList", () => {
 
   it("should render no rows when contacts are empty or maxContacts is zero", () => {
     const { rerender } = render(
-      <ContactsCompactList contacts={[]} labels={labels} onContactSelect={jest.fn()} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={[]} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.queryByTestId("contacts-compact-row-contact-zero")).toBeNull();
 
     rerender(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        maxContacts={0}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList
+          contacts={createContacts()}
+          maxContacts={0}
+          onContactSelect={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.queryByTestId("contacts-compact-row-contact-zero")).toBeNull();
@@ -93,7 +103,9 @@ describe("ContactsCompactList", () => {
     const user = userEvent.setup();
 
     render(
-      <ContactsCompactList contacts={contacts} labels={labels} onContactSelect={onContactSelect} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} onContactSelect={onContactSelect} />
+      </I18nTestProvider>,
     );
 
     await user.press(screen.getByTestId("contacts-compact-row-contact-one"));

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.tsx
@@ -12,12 +12,14 @@ import {
   getCompactContactAddressDescription,
   getDisplayedCompactContacts,
 } from "./utils/ContactsCompactList.utils";
+import { useTranslation } from "@shared/i18n";
 
 export function ContactsCompactRow({
   contact,
-  labels,
   onContactSelect,
 }: ContactsCompactRowProps): React.JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <ListItem
       testID={`contacts-compact-row-${contact.id}`}
@@ -30,7 +32,11 @@ export function ContactsCompactRow({
         <ListItemContent>
           <ListItemTitle>{contact.name}</ListItemTitle>
           <ListItemDescription>
-            {getCompactContactAddressDescription(contact, labels)}
+            {getCompactContactAddressDescription(
+              contact,
+              t("contacts.addressCount", { count: 0 }),
+              count => t("contacts.addressCount", { count }),
+            )}
           </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
@@ -40,7 +46,6 @@ export function ContactsCompactRow({
 
 export function ContactsCompactList({
   contacts,
-  labels,
   maxContacts,
   onContactSelect,
 }: ContactsCompactListProps): React.JSX.Element {
@@ -49,12 +54,7 @@ export function ContactsCompactList({
   return (
     <>
       {displayedContacts.map(contact => (
-        <ContactsCompactRow
-          key={contact.id}
-          contact={contact}
-          labels={labels}
-          onContactSelect={onContactSelect}
-        />
+        <ContactsCompactRow key={contact.id} contact={contact} onContactSelect={onContactSelect} />
       ))}
     </>
   );

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.test.tsx
@@ -7,11 +7,19 @@ import {
   mockContactWithMultipleAddresses,
 } from "@domain/entity-contact/schema.mock";
 import type { Contact } from "@domain/entity-contact";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
 import { ContactsCompactList } from "../../web";
 
-const labels = {
-  emptyAddress: "No saved addresses",
-  formatAddressCount: (count: number) => `${count} saved addresses`,
+const resources: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      contacts: {
+        addressCount_zero: "0 address",
+        addressCount_one: "{{count}} address",
+        addressCount_other: "{{count}} addresses",
+      },
+    },
+  },
 };
 
 function createContacts(): readonly Contact[] {
@@ -30,16 +38,20 @@ describe("ContactsCompactList", () => {
   it("should render supplied contacts in order with the appropriate address descriptions", () => {
     const contacts = createContacts();
 
-    render(<ContactsCompactList contacts={contacts} labels={labels} onContactSelect={jest.fn()} />);
+    render(
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
+    );
 
     const [zeroRow, oneRow, manyRow] = screen.getAllByTestId(/^contacts-compact-row-/);
 
     expect(zeroRow).toHaveTextContent("Zero");
-    expect(zeroRow).toHaveTextContent(labels.emptyAddress);
+    expect(zeroRow).toHaveTextContent("0 address");
     expect(oneRow).toHaveTextContent("One");
     expect(oneRow).toHaveTextContent("Main wallet");
     expect(manyRow).toHaveTextContent("Many");
-    expect(manyRow).toHaveTextContent("2 saved addresses");
+    expect(manyRow).toHaveTextContent("2 addresses");
     expect(zeroRow.compareDocumentPosition(oneRow)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(oneRow.compareDocumentPosition(manyRow)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getByTestId("contacts-avatar-contact-zero")).toBeVisible();
@@ -49,12 +61,9 @@ describe("ContactsCompactList", () => {
     const contacts = createContacts();
 
     render(
-      <ContactsCompactList
-        contacts={contacts}
-        labels={labels}
-        maxContacts={2}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} maxContacts={2} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.getAllByTestId(/^contacts-compact-row-/)).toHaveLength(2);
@@ -65,18 +74,21 @@ describe("ContactsCompactList", () => {
 
   it("should render no rows when contacts are empty or maxContacts is zero", () => {
     const { rerender } = render(
-      <ContactsCompactList contacts={[]} labels={labels} onContactSelect={jest.fn()} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={[]} onContactSelect={jest.fn()} />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-compact-list")).toBeEmptyDOMElement();
 
     rerender(
-      <ContactsCompactList
-        contacts={createContacts()}
-        labels={labels}
-        maxContacts={0}
-        onContactSelect={jest.fn()}
-      />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList
+          contacts={createContacts()}
+          maxContacts={0}
+          onContactSelect={jest.fn()}
+        />
+      </I18nTestProvider>,
     );
 
     expect(screen.getByTestId("contacts-compact-list")).toBeEmptyDOMElement();
@@ -87,7 +99,9 @@ describe("ContactsCompactList", () => {
     const onContactSelect = jest.fn();
 
     render(
-      <ContactsCompactList contacts={contacts} labels={labels} onContactSelect={onContactSelect} />,
+      <I18nTestProvider resources={resources}>
+        <ContactsCompactList contacts={contacts} onContactSelect={onContactSelect} />
+      </I18nTestProvider>,
     );
 
     fireEvent.click(screen.getByTestId("contacts-compact-row-contact-one"));

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
@@ -12,13 +12,14 @@ import {
   getCompactContactAddressDescription,
   getDisplayedCompactContacts,
 } from "./utils/ContactsCompactList.utils";
+import { useTranslation } from "@shared/i18n";
 
 export function ContactsCompactList({
   contacts,
-  labels,
   maxContacts,
   onContactSelect,
 }: ContactsCompactListProps): React.JSX.Element {
+  const { t } = useTranslation();
   const displayedContacts = getDisplayedCompactContacts(contacts, maxContacts);
 
   return (
@@ -34,7 +35,11 @@ export function ContactsCompactList({
             <ListItemContent>
               <ListItemTitle>{contact.name}</ListItemTitle>
               <ListItemDescription>
-                {getCompactContactAddressDescription(contact, labels)}
+                {getCompactContactAddressDescription(
+                  contact,
+                  t("contacts.addressCount", { count: 0 }),
+                  count => t("contacts.addressCount", { count }),
+                )}
               </ListItemDescription>
             </ListItemContent>
           </ListItemLeading>

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/utils/ContactsCompactList.utils.ts
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/utils/ContactsCompactList.utils.ts
@@ -1,19 +1,19 @@
 import type { Contact } from "@domain/entity-contact";
-import type { ContactsCompactListProps } from "../../../types";
 
 export function getCompactContactAddressDescription(
   contact: Contact,
-  labels: ContactsCompactListProps["labels"],
+  emptyAddress: string,
+  formatAddressCount: (count: number) => string,
 ): string {
   if (contact.addresses.length === 0) {
-    return labels.emptyAddress;
+    return emptyAddress;
   }
 
   if (contact.addresses.length === 1) {
     return contact.addresses[0].label;
   }
 
-  return labels.formatAddressCount(contact.addresses.length);
+  return formatAddressCount(contact.addresses.length);
 }
 
 export function getDisplayedCompactContacts(

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ContactsList.web.tsx
@@ -9,11 +9,11 @@ import { ContactsAddContactListItem } from "./ListItems/ContactsAddContactListIt
 import { ContactsMeListItem } from "./ListItems/ContactsMeListItem.web";
 import { ContactsSavedListItem } from "./ListItems/ContactsSavedListItem.web";
 import { ContactsSearchNoResults } from "./Search/ContactsSearchNoResults.web";
+import { useTranslation } from "@shared/i18n";
 
 type ContactsListProps = Pick<
   ContactsListViewProps,
   | "viewModel"
-  | "labels"
   | "searchQuery"
   | "meAvatarSrc"
   | "onSearchInputChange"
@@ -24,7 +24,6 @@ type ContactsListProps = Pick<
 
 export function ContactsList({
   viewModel,
-  labels,
   searchQuery,
   meAvatarSrc,
   onSearchInputChange,
@@ -32,6 +31,7 @@ export function ContactsList({
   onOpenContact,
   onAddContact,
 }: ContactsListProps): React.ReactNode {
+  const { t } = useTranslation();
   const savedContactSections = isPopulatedContactsListViewModel(viewModel)
     ? viewModel.sections
     : [];
@@ -41,7 +41,7 @@ export function ContactsList({
 
   let savedContactsContent: React.ReactNode = null;
   if (showNoResults) {
-    savedContactsContent = <ContactsSearchNoResults message={labels.searchNoResults} />;
+    savedContactsContent = <ContactsSearchNoResults message={t("contacts.searchNoResults")} />;
   } else if (savedContactSections.length > 0) {
     savedContactsContent = (
       <div className="flex flex-col gap-16">
@@ -59,7 +59,7 @@ export function ContactsList({
                 <ContactsSavedListItem
                   key={contact.contactId}
                   contact={contact}
-                  formatAddressCount={labels.formatAddressCount}
+                  formatAddressCount={count => t("contacts.addressCount", { count })}
                   onOpen={onOpenContact}
                 />
               ))}
@@ -75,8 +75,8 @@ export function ContactsList({
       <div className="flex shrink-0 flex-col gap-8">
         <SearchInput
           value={searchQuery}
-          placeholder={labels.searchPlaceholder}
-          aria-label={labels.searchPlaceholder}
+          placeholder={t("contacts.searchPlaceholder")}
+          aria-label={t("contacts.searchPlaceholder")}
           data-testid="contacts-list-search"
           onChange={onSearchInputChange}
         />
@@ -84,7 +84,7 @@ export function ContactsList({
           <ContactsMeListItem
             contact={me}
             avatarSrc={meAvatarSrc}
-            formatAddressCount={labels.formatAddressCount}
+            formatAddressCount={count => t("contacts.addressCount", { count })}
             onOpen={onOpenMe}
           />
         ) : null}
@@ -96,7 +96,10 @@ export function ContactsList({
         <div className="flex flex-col gap-16">
           {savedContactsContent}
           {showAddContact ? (
-            <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
+            <ContactsAddContactListItem
+              label={t("contacts.addContact")}
+              onAddContact={onAddContact}
+            />
           ) : null}
         </div>
       </div>

--- a/features/flow/flow-contacts-list/src/components/ListHeader/ContactsListHeader.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ListHeader/ContactsListHeader.native.tsx
@@ -1,12 +1,12 @@
 import React from "react";
+import { useTranslation } from "@shared/i18n";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
-import type { ContactsListItem, ContactsListViewLabels } from "../../types";
+import type { ContactsListItem } from "../../types";
 import { ContactsAddContactListItem } from "../ContactsList/ListItems/ContactsAddContactListItem.native";
 import { ContactsMeListItem } from "../ContactsList/ListItems/ContactsMeListItem.native";
 
 type ContactsListHeaderProps = Readonly<{
   me?: ContactsListItem;
-  labels: ContactsListViewLabels;
   meAvatarSrc: string;
   showAddContact: boolean;
   onOpenContact: (contactId: ContactsListItem["contactId"]) => void;
@@ -15,24 +15,24 @@ type ContactsListHeaderProps = Readonly<{
 
 export function ContactsListHeader({
   me,
-  labels,
   meAvatarSrc,
   showAddContact,
   onOpenContact,
   onAddContact,
 }: ContactsListHeaderProps): React.JSX.Element {
+  const { t } = useTranslation();
   return (
     <Box testID="contacts-list-header" lx={{ gap: "s8" }}>
       {me ? (
         <ContactsMeListItem
           contact={me}
           avatarSrc={meAvatarSrc}
-          addressCountLabel={labels.formatAddressCount(me.addressCount)}
+          addressCountLabel={t("contacts.addressCount", { count: me.addressCount })}
           onOpen={onOpenContact}
         />
       ) : null}
       {showAddContact ? (
-        <ContactsAddContactListItem label={labels.addContact} onPress={onAddContact} />
+        <ContactsAddContactListItem label={t("contacts.addContact")} onPress={onAddContact} />
       ) : null}
     </Box>
   );

--- a/features/flow/flow-contacts-list/src/types.ts
+++ b/features/flow/flow-contacts-list/src/types.ts
@@ -46,37 +46,19 @@ export type ContactsSearchViewModel =
 
 export type ContactsPageViewModel = ContactsListViewModel | ContactsSearchViewModel;
 
-export type ContactsListViewLabels = Readonly<{
-  title: string;
-  searchPlaceholder: string;
-  searchNoResults: string;
-  addContact: string;
-  ledgerSyncCheckingAccessibilityLabel?: string;
-  formatAddressCount: (count: number) => string;
-  formatMeDisplayName?: (name: string) => string;
-}>;
-
-export type ContactsCompactListLabels = Readonly<{
-  emptyAddress: string;
-  formatAddressCount: (count: number) => string;
-}>;
-
 export type ContactsCompactRowProps = Readonly<{
   contact: Contact;
-  labels: ContactsCompactListLabels;
   onContactSelect: (contact: Contact) => void;
 }>;
 
 export type ContactsCompactListProps = Readonly<{
   contacts: readonly Contact[];
-  labels: ContactsCompactListLabels;
   maxContacts?: number;
   onContactSelect: (contact: Contact) => void;
 }>;
 
 export type ContactsPageSharedProps = Readonly<{
   viewModel: ContactsPageViewModel;
-  labels: ContactsListViewLabels;
   searchQuery: string;
   meAvatarSrc: string;
   onOpenContact: (contactId: ContactId) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5601,6 +5601,9 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(e1195c5841184ed5b8a7bbe45de0365d)
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       '@shared/ui-qr-code':
         specifier: workspace:*
         version: link:../../../shared/ui-qr-code
@@ -5752,6 +5755,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@features/platform-feature-flags':
         specifier: workspace:^
@@ -5834,6 +5840,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
@@ -5910,6 +5919,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
@@ -5983,6 +5995,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
@@ -6053,6 +6068,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
@@ -6196,6 +6214,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1


### PR DESCRIPTION
## Summary

- Remove `useContactsListLabels` hook (dissolved)
- Call `useTranslation` + inline `t("key")` directly in `ContactsListView`, `ContactsCompactList`, `ContactsListHeader`, `ContactsList`
- Add `@shared/i18n` dependency to `flow-contacts-list`
- Clean up `useContactsPageViewModel` (mobile) — remove labels props building

Part of stack: LIVE-37080 (1/7)

## Test plan
- [ ] Contacts list renders correctly with translations
- [ ] "Me" display name formats correctly