### PR TITLE
feat(contacts): use @shared/i18n in edit-contact (LIVE-37080)

### DIFF
--- a/features/flow/flow-contacts-edit-contact/package.json
+++ b/features/flow/flow-contacts-edit-contact/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.test.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.test.tsx
@@ -4,6 +4,7 @@ import {
   DUPLICATE_CONTACT_NAME_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameContactDialog } from ".";
 import type { ContactsRenameContactDialogProps } from "./types";
 
@@ -17,17 +18,6 @@ function createViewModel(
     draftName: "",
     invalidNameError: null,
     isDeviceRequired: false,
-    labels: {
-      title: "Edit contact",
-      namePlaceholder: "Contact name",
-      namingDisclaimer: "Use a nickname or a first name and initial.",
-      applyChanges: "Apply changes",
-      confirmName: "Apply changes",
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: "Special characters are not allowed.",
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: "This contact name is already in use.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftNameChange: jest.fn(),
@@ -36,15 +26,21 @@ function createViewModel(
   };
 }
 
+function renderDialog(props: ContactsRenameContactDialogProps) {
+  return render(
+    <I18nTestProvider>
+      <ContactsRenameContactDialog {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameContactDialog", () => {
   it("renders the shared validation error and disables confirmation", () => {
-    render(
-      <ContactsRenameContactDialog
-        {...createViewModel({
-          draftName: "Cédric",
-          invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        draftName: "Cédric",
+        invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-contact-name-input")).toHaveValue("Cédric");
@@ -54,14 +50,12 @@ describe("ContactsRenameContactDialog", () => {
   it("forwards draft name changes", () => {
     const onDraftNameChange = jest.fn();
 
-    render(
-      <ContactsRenameContactDialog
-        {...createViewModel({
-          draftName: "Ada",
-          isConfirmEnabled: true,
-          onDraftNameChange,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        draftName: "Ada",
+        isConfirmEnabled: true,
+        onDraftNameChange,
+      }),
     );
 
     fireEvent.change(screen.getByTestId("contacts-rename-contact-name-input"), {

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDialog.web.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Button, Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { ContactNameDisclaimer, ContactNameInput } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
+import type { ContactNameValidationErrorName } from "@domain/entity-contact";
 import type { ContactsRenameContactDialogProps } from "./types";
 
 const NAMING_DISCLAIMER_ID = "contacts-rename-contact-naming-disclaimer";
@@ -13,13 +15,17 @@ export function ContactsRenameContactDialog({
   draftName,
   invalidNameError,
   isDeviceRequired,
-  labels,
   onClose,
   onDraftNameChange,
   onConfirm,
 }: ContactsRenameContactDialogProps): React.ReactNode {
+  const { t } = useTranslation();
+  const nameValidationErrors: Record<ContactNameValidationErrorName, string> = {
+    InvalidContactNameError: t("contacts.editContact.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -34,19 +40,23 @@ export function ContactsRenameContactDialog({
         className="w-[400px] bg-canvas-sheet pb-24"
         data-testid="contacts-rename-contact-dialog"
       >
-        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogHeader
+          density="expanded"
+          title={t("contacts.editContact.title")}
+          onClose={onClose}
+        />
         <DialogBody className="flex flex-col gap-32 px-24 pb-24">
           <div className="flex flex-col gap-24">
             <ContactNameInput
               testIDPrefix="contacts-rename-contact"
               value={draftName}
-              placeholder={labels.namePlaceholder}
+              placeholder={t("contacts.editContact.namePlaceholder")}
               errorMessage={nameValidationError}
               onChange={onDraftNameChange}
             />
             <ContactNameDisclaimer
               disclaimerId={NAMING_DISCLAIMER_ID}
-              text={labels.namingDisclaimer}
+              text={t("contacts.editContact.namingDisclaimer")}
             />
           </div>
           <Button
@@ -59,7 +69,7 @@ export function ContactsRenameContactDialog({
             onClick={() => void onConfirm()}
             data-testid="contacts-rename-contact-confirm"
           >
-            {labels.applyChanges}
+            {t("contacts.editContact.applyChanges")}
           </Button>
         </DialogBody>
       </DialogContent>

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.test.tsx
@@ -4,8 +4,27 @@ import {
   DUPLICATE_CONTACT_NAME_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameContactDrawer } from ".";
 import type { ContactsRenameContactDrawerProps } from "./types";
+
+const i18nResources = {
+  translation: {
+    contacts: {
+      editContact: {
+        title: "Edit contact",
+        namePlaceholder: "Contact name",
+        namingDisclaimer: "Use a nickname or a first name and initial.",
+        confirmName: "Apply changes",
+        applyChanges: "Apply changes",
+        invalidNameError: "Special characters are not allowed.",
+      },
+      addContactDrawer: {
+        duplicateNameError: "This contact name is already in use.",
+      },
+    },
+  },
+};
 
 const mockFocus = jest.fn();
 
@@ -39,17 +58,6 @@ function createViewModel(
     draftName: "",
     invalidNameError: null,
     isDeviceRequired: false,
-    labels: {
-      title: "Edit contact",
-      namePlaceholder: "Contact name",
-      namingDisclaimer: "Use a nickname or a first name and initial.",
-      applyChanges: "Apply changes",
-      confirmName: "Apply changes",
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: "Special characters are not allowed.",
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: "This contact name is already in use.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftNameChange: jest.fn(),
@@ -58,17 +66,23 @@ function createViewModel(
   };
 }
 
+function renderDrawer(props: ContactsRenameContactDrawerProps) {
+  return render(
+    <I18nTestProvider resources={i18nResources}>
+      <ContactsRenameContactDrawer {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameContactDrawer", () => {
   it("should render the validation state and account for drawer insets", () => {
-    const { toJSON } = render(
-      <ContactsRenameContactDrawer
-        {...createViewModel({
-          draftName: "Ada",
-          invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
-          bottomInset: 8,
-          keyboardInset: 300,
-        })}
-      />,
+    const { toJSON } = renderDrawer(
+      createViewModel({
+        draftName: "Ada",
+        invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+        bottomInset: 8,
+        keyboardInset: 300,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-contact-content")).toBeVisible();
@@ -88,14 +102,12 @@ describe("ContactsRenameContactDrawer", () => {
     const onDraftNameChange = jest.fn();
     const onConfirm = jest.fn(async () => undefined);
 
-    render(
-      <ContactsRenameContactDrawer
-        {...createViewModel({
-          isConfirmEnabled: true,
-          onDraftNameChange,
-          onConfirm,
-        })}
-      />,
+    renderDrawer(
+      createViewModel({
+        isConfirmEnabled: true,
+        onDraftNameChange,
+        onConfirm,
+      }),
     );
 
     fireEvent.changeText(screen.getByTestId("contacts-rename-contact-name-input"), "Ada Lovelace");
@@ -106,17 +118,21 @@ describe("ContactsRenameContactDrawer", () => {
   });
 
   it("should withhold focus until the host grants it", () => {
-    const { rerender } = render(<ContactsRenameContactDrawer {...createViewModel()} />);
+    const { rerender } = renderDrawer(createViewModel());
 
     expect(mockFocus).not.toHaveBeenCalled();
 
-    rerender(<ContactsRenameContactDrawer {...createViewModel({ autoFocus: true })} />);
+    rerender(
+      <I18nTestProvider resources={i18nResources}>
+        <ContactsRenameContactDrawer {...createViewModel({ autoFocus: true })} />
+      </I18nTestProvider>,
+    );
 
     expect(mockFocus).toHaveBeenCalledTimes(1);
   });
 
   it("should not render its content while closed", () => {
-    render(<ContactsRenameContactDrawer {...createViewModel({ isOpen: false })} />);
+    renderDrawer(createViewModel({ isOpen: false }));
 
     expect(screen.queryByTestId("contacts-rename-contact-content")).not.toBeOnTheScreen();
   });

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.tsx
@@ -9,6 +9,8 @@ import {
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "@shared/i18n";
+import type { ContactNameValidationErrorName } from "@domain/entity-contact";
 import type { ContactsRenameContactDrawerProps } from "./types";
 
 export function ContactsRenameContactDrawer({
@@ -21,12 +23,16 @@ export function ContactsRenameContactDrawer({
   bottomInset = 0,
   keyboardInset = 0,
   autoFocus = false,
-  labels,
   onDraftNameChange,
   onConfirm,
 }: ContactsRenameContactDrawerProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const nameValidationErrors: Record<ContactNameValidationErrorName, string> = {
+    InvalidContactNameError: t("contacts.editContact.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
@@ -35,17 +41,17 @@ export function ContactsRenameContactDrawer({
           <BottomSheetHeader />
           <Box lx={{ gap: "s16" }}>
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-              {labels.title}
+              {t("contacts.editContact.title")}
             </Text>
             <ContactNameInput
               testIDPrefix="contacts-rename-contact"
               value={draftName}
-              placeholder={labels.namePlaceholder}
+              placeholder={t("contacts.editContact.namePlaceholder")}
               errorMessage={nameValidationError}
               autoFocus={autoFocus}
               onChangeText={onDraftNameChange}
             />
-            <Banner appearance="info" description={labels.namingDisclaimer} />
+            <Banner appearance="info" description={t("contacts.editContact.namingDisclaimer")} />
           </Box>
           <Button
             appearance="base"
@@ -57,7 +63,7 @@ export function ContactsRenameContactDrawer({
             onPress={() => void onConfirm()}
             testID="contacts-rename-contact-confirm"
           >
-            {labels.confirmName}
+            {t("contacts.editContact.confirmName")}
           </Button>
         </Box>
       ) : null}

--- a/features/flow/flow-contacts-edit-contact/src/types.ts
+++ b/features/flow/flow-contacts-edit-contact/src/types.ts
@@ -28,19 +28,9 @@ export type UseRenameContactDialogViewModelOptions = Readonly<{
   requestSaveApproval?: () => Promise<boolean>;
 }>;
 
-export type ContactsRenameContactLabels = Readonly<{
-  title: string;
-  namePlaceholder: string;
-  namingDisclaimer: string;
-  applyChanges: string;
-  confirmName: string;
-  nameValidationErrors: Readonly<Record<ContactNameValidationErrorName, string>>;
-}>;
-
 export type ContactsRenameContactDialogProps = RenameContactDialogViewModel &
   Readonly<{
     isDeviceRequired: boolean;
-    labels: ContactsRenameContactLabels;
   }>;
 
 export type ContactsRenameContactDrawerProps = ContactsRenameContactDialogProps &


### PR DESCRIPTION
## Summary

- Call `useTranslation` inline in `ContactsRenameContactDialog.web` and `ContactsRenameContactDrawer.native`
- Remove labels props from `flow-contacts-edit-contact`
- Add `@shared/i18n` dependency

Part of stack: LIVE-37080 (2/7) — stacks on #21755

## Test plan
- [ ] Rename contact dialog/drawer shows correct translations