### PR TITLE
feat(contacts): use @shared/i18n in delete-contact (LIVE-37080)

### DIFF
--- a/features/flow/flow-contacts-delete-contact/package.json
+++ b/features/flow/flow-contacts-delete-contact/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native.tsx
+++ b/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native.tsx
@@ -1,16 +1,24 @@
 import React from "react";
 import { Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { ContactConfirmationBottomSheet } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsDeleteContactDrawerProps } from "./types";
 
 export function ContactsDeleteContactDialog({
   isOpen,
   isDeleting,
   bottomInset = 0,
-  labels,
   onConfirm,
   onCancel,
 }: ContactsDeleteContactDrawerProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.deleteContact.title"),
+    description: t("contacts.deleteContact.mobileDescription"),
+    confirm: t("contacts.deleteContact.confirm"),
+    cancel: t("contacts.deleteContact.cancel"),
+  };
+
   return (
     <ContactConfirmationBottomSheet
       isOpen={isOpen}

--- a/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web.tsx
+++ b/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web.tsx
@@ -1,15 +1,31 @@
 import React from "react";
 import { ContactConfirmationDialog } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsDeleteContactDialogProps } from "./types";
 
-export function ContactsDeleteContactDialog(
-  props: ContactsDeleteContactDialogProps,
-): React.ReactNode {
+export function ContactsDeleteContactDialog({
+  isOpen,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}: ContactsDeleteContactDialogProps): React.ReactNode {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.deleteContact.title"),
+    description: t("contacts.deleteContact.description"),
+    confirm: t("contacts.deleteContact.confirm"),
+    cancel: t("contacts.deleteContact.cancel"),
+  };
+
   return (
     <ContactConfirmationDialog
-      {...props}
+      isOpen={isOpen}
+      isDeleting={isDeleting}
+      labels={labels}
       dialogTestId="contacts-delete-contact-dialog"
       confirmTestId="contacts-delete-contact-confirm"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
     />
   );
 }

--- a/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/types.ts
+++ b/features/flow/flow-contacts-delete-contact/src/components/ContactsDeleteContactDialog/types.ts
@@ -1,14 +1,6 @@
-export type ContactsDeleteContactDialogLabels = Readonly<{
-  title: string;
-  description: string;
-  confirm: string;
-  cancel: string;
-}>;
-
 export type ContactsDeleteContactDialogProps = Readonly<{
   isOpen: boolean;
   isDeleting: boolean;
-  labels: ContactsDeleteContactDialogLabels;
   onConfirm: () => Promise<void>;
   onCancel: () => void;
 }>;


### PR DESCRIPTION
## Summary

- Call `useTranslation` inline in `ContactsDeleteContactDialog.web` and `.native`
- Remove labels props from `flow-contacts-delete-contact`
- Add `@shared/i18n` dependency

Part of stack: LIVE-37080 (3/7) — stacks on #21756

## Test plan
- [ ] Delete contact dialog shows correct translations