### PR TITLE
[LWD] feat(contacts): use @shared/i18n in add-contact (LIVE-37080)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
@@ -1,12 +1,7 @@
-import {
-  type Contact,
-  DUPLICATE_CONTACT_NAME_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
-} from "@domain/entity-contact";
+import type { Contact } from "@domain/entity-contact";
 import { type AddContactAppAdapterResult, useAddContactAppAdapter } from "@features/flow-contacts";
 import { createContactCreationPort } from "@features/flow-contacts-add-contact";
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import { v4 as uuid } from "uuid";
 import { useDispatch } from "LLD/hooks/redux";
 import { useContactsAnalytics } from "../../analytics";
@@ -15,30 +10,15 @@ export function useAddContactDialogAdapter(
   onSaveSuccess: (contact: Contact) => void,
 ): AddContactAppAdapterResult {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
   const analytics = useContactsAnalytics();
   const contactCreation = useMemo(
     () => createContactCreationPort({ dispatch, generateId: uuid }),
     [dispatch],
-  );
-  const labels = useMemo(
-    () => ({
-      title: t("contacts.addContact"),
-      namePlaceholder: t("contacts.addContactDrawer.namePlaceholder"),
-      namingDisclaimer: t("contacts.addContactDrawer.namingDisclaimer"),
-      confirmName: t("contacts.addContact"),
-      nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.invalidNameError"),
-        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
-      },
-    }),
-    [t],
   );
 
   return useAddContactAppAdapter({
     analytics,
     contactCreation,
     onSaveSuccess,
-    labels,
   });
 }

--- a/features/flow/contacts/src/hooks/useAddContactAppAdapter.ts
+++ b/features/flow/contacts/src/hooks/useAddContactAppAdapter.ts
@@ -1,6 +1,5 @@
 import {
   type ContactCreationPort,
-  type ContactsAddContactContentLabels,
   type AddContactDialogViewModel,
   useAddContactDialogViewModel,
 } from "@features/flow-contacts-add-contact";
@@ -12,7 +11,6 @@ export type UseAddContactAppAdapterOptions = Readonly<{
   analytics: ContactsAnalyticsHelper;
   contactCreation: ContactCreationPort;
   onSaveSuccess: (contact: Contact) => void;
-  labels: ContactsAddContactContentLabels;
 }>;
 
 export type AddContactAppAdapterResult = AddContactDialogViewModel;
@@ -21,7 +19,6 @@ export function useAddContactAppAdapter({
   analytics,
   contactCreation,
   onSaveSuccess,
-  labels,
 }: UseAddContactAppAdapterOptions): AddContactAppAdapterResult {
   const { callbacks, onSaveSuccess: handleSaveSuccess } = useContactsAddContactAnalytics(
     analytics,
@@ -30,7 +27,6 @@ export function useAddContactAppAdapter({
 
   return useAddContactDialogViewModel({
     contactCreation,
-    labels,
     onSaveSuccess: handleSaveSuccess,
     callbacks,
   });

--- a/features/flow/flow-contacts-add-contact/package.json
+++ b/features/flow/flow-contacts-add-contact/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Banner, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "@shared/i18n";
 import { ContactNameInput } from "@features/platform-contacts";
 import type { ContactsAddContactContentNativeProps } from "./types";
 
@@ -8,29 +9,33 @@ export function ContactsAddContactContent({
   isSaving,
   draftName,
   invalidNameError,
-  labels,
   autoFocus,
   onDraftNameChange,
   onConfirm,
 }: ContactsAddContactContentNativeProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const nameValidationErrors = {
+    InvalidContactNameError: t("contacts.addContactDrawer.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   return (
     <Box testID="contacts-add-contact-content" lx={{ gap: "s24" }}>
       <Box lx={{ gap: "s16" }}>
         <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-          {labels.title}
+          {t("contacts.addContact")}
         </Text>
         <ContactNameInput
           value={draftName}
-          placeholder={labels.namePlaceholder}
+          placeholder={t("contacts.addContactDrawer.namePlaceholder")}
           errorMessage={nameValidationError}
           isEditable={!isSaving}
           autoFocus={autoFocus}
           onChangeText={onDraftNameChange}
         />
-        <Banner appearance="info" description={labels.namingDisclaimer} />
+        <Banner appearance="info" description={t("contacts.addContactDrawer.namingDisclaimer")} />
       </Box>
       <Button
         appearance="base"
@@ -41,7 +46,7 @@ export function ContactsAddContactContent({
         onPress={onConfirm}
         testID="contacts-add-contact-save"
       >
-        {labels.confirmName}
+        {t("contacts.addContactDrawer.confirmName")}
       </Button>
     </Box>
   );

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.web.tsx
@@ -1,5 +1,6 @@
 import React, { useId } from "react";
 import { Button } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "@shared/i18n";
 import { ContactNameDisclaimer, ContactNameInput } from "@features/platform-contacts";
 import type { ContactsAddContactContentProps } from "./types";
 
@@ -8,24 +9,31 @@ export function ContactsAddContactContent({
   isSaving,
   draftName,
   invalidNameError,
-  labels,
   onDraftNameChange,
   onConfirm,
 }: ContactsAddContactContentProps): React.ReactNode {
+  const { t } = useTranslation();
   const namingDisclaimerId = useId();
+  const nameValidationErrors = {
+    InvalidContactNameError: t("contacts.addContactDrawer.invalidNameError"),
+    DuplicateContactNameError: t("contacts.addContactDrawer.duplicateNameError"),
+  };
   const nameValidationError =
-    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+    invalidNameError === null ? undefined : nameValidationErrors[invalidNameError];
 
   return (
     <div aria-describedby={namingDisclaimerId} className="flex flex-col gap-24 px-24 pb-24 pt-12">
       <ContactNameInput
         value={draftName}
-        placeholder={labels.namePlaceholder}
+        placeholder={t("contacts.addContactDrawer.namePlaceholder")}
         errorMessage={nameValidationError}
         isEditable={!isSaving}
         onChange={onDraftNameChange}
       />
-      <ContactNameDisclaimer disclaimerId={namingDisclaimerId} text={labels.namingDisclaimer} />
+      <ContactNameDisclaimer
+        disclaimerId={namingDisclaimerId}
+        text={t("contacts.addContactDrawer.namingDisclaimer")}
+      />
       <Button
         appearance="base"
         size="lg"
@@ -35,7 +43,7 @@ export function ContactsAddContactContent({
         onClick={() => void onConfirm()}
         data-testid="contacts-add-contact-save"
       >
-        {labels.confirmName}
+        {t("contacts.addContactDrawer.confirmName")}
       </Button>
     </div>
   );

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.tsx
@@ -1,20 +1,22 @@
 import React from "react";
 import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "@shared/i18n";
 import { ContactsAddContactContent } from "./ContactsAddContactContent.web";
 import type { AddContactDialogViewModel } from "./types";
 
 export function ContactsAddContactDialog({
   isOpen,
   onClose,
-  labels,
   ...contentProps
 }: AddContactDialogViewModel): React.ReactNode {
+  const { t } = useTranslation();
+
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
       <DialogContent className="pb-24" data-testid="contacts-add-contact-dialog">
-        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogHeader density="expanded" title={t("contacts.addContact")} onClose={onClose} />
         <DialogBody className="p-0">
-          <ContactsAddContactContent labels={labels} {...contentProps} />
+          <ContactsAddContactContent {...contentProps} />
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/types.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/types.ts
@@ -17,18 +17,7 @@ export type UseAddContactContentViewModelOptions = Readonly<{
   onSaveSuccess: (contact: Contact) => void;
 }>;
 
-export type ContactsAddContactContentLabels = Readonly<{
-  title: string;
-  namePlaceholder: string;
-  namingDisclaimer: string;
-  confirmName: string;
-  nameValidationErrors: Readonly<Record<ContactNameValidationErrorName, string>>;
-}>;
-
-export type ContactsAddContactContentProps = AddContactContentViewModel &
-  Readonly<{
-    labels: ContactsAddContactContentLabels;
-  }>;
+export type ContactsAddContactContentProps = AddContactContentViewModel;
 
 export type ContactsAddContactContentNativeProps = ContactsAddContactContentProps &
   Readonly<{
@@ -45,7 +34,6 @@ export type AddContactDialogLifecycleCallbacks = Readonly<{
 
 export type UseAddContactDialogViewModelOptions = Readonly<{
   contactCreation: ContactCreationPort;
-  labels: ContactsAddContactContentLabels;
   onSaveSuccess: (contact: Contact) => void;
   callbacks?: AddContactDialogLifecycleCallbacks;
 }>;
@@ -53,7 +41,6 @@ export type UseAddContactDialogViewModelOptions = Readonly<{
 export type AddContactDialogViewModel = AddContactContentViewModel &
   Readonly<{
     isOpen: boolean;
-    labels: ContactsAddContactContentLabels;
     onOpen: () => void;
     onClose: () => void;
   }>;

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDialogViewModel.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDialogViewModel.ts
@@ -9,7 +9,6 @@ import type { AddContactDialogViewModel, UseAddContactDialogViewModelOptions } f
  */
 export function useAddContactDialogViewModel({
   contactCreation,
-  labels,
   onSaveSuccess,
   callbacks,
 }: UseAddContactDialogViewModelOptions): AddContactDialogViewModel {
@@ -59,7 +58,6 @@ export function useAddContactDialogViewModel({
   return {
     ...contentViewModel,
     isOpen,
-    labels,
     onOpen,
     onClose,
     onConfirm,


### PR DESCRIPTION
## Summary

- Call `useTranslation` inline in `ContactsAddContactContent.native` and `.web`
- Remove labels props from `flow-contacts-add-contact`
- Clean up `useAddContactAppAdapter` and `useAddContactDialogAdapter`
- Add `@shared/i18n` dependency

Part of stack: LIVE-37080 (4/7) — stacks on #21757

## Test plan
- [ ] Add contact flow shows correct translations