### PR TITLE
feat(contacts): use @shared/i18n in edit-address (LIVE-37080)

### DIFF
--- a/features/flow/flow-contacts-edit-address/package.json
+++ b/features/flow/flow-contacts-edit-address/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
@@ -1,13 +1,40 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressValueSchema,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameAddressDialog } from ".";
 import type { ContactsRenameAddressDialogProps } from "./types";
+
+const i18nResources = {
+  translation: {
+    contacts: {
+      editAddress: {
+        title: "Edit address",
+        inputLabel: "Address label",
+        applyChanges: "Apply changes",
+        invalidLabelError: "Address label is invalid.",
+      },
+      addAddressName: {
+        duplicateLabel: "Address label is already in use.",
+        tooLongLabel: "Address label is too long.",
+      },
+      addAddressEntry: {
+        addressPlaceholder: "Address",
+        validatingAddress: "Validating address",
+        validAddress: "Valid address",
+        invalidAddress: "Invalid address",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned address",
+        validationUnavailable: "Validation unavailable",
+        ensDisclaimer: "ENS addresses are supported.",
+        ensDisclaimerDescription: "ENS names can change over time.",
+      },
+    },
+  },
+};
 
 function createViewModel(
   overrides: Partial<ContactsRenameAddressDialogProps> = {},
@@ -27,27 +54,6 @@ function createViewModel(
       inputMethod: "manual",
     },
     isDeviceRequired: true,
-    labels: {
-      title: "Edit address",
-      inputLabel: "Address label",
-      applyChanges: "Apply changes",
-      labelValidationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is invalid.",
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is already in use.",
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "Address label is too long.",
-      },
-      addressValidation: {
-        addressPlaceholder: "Address",
-        validatingAddress: "Validating address",
-        validAddress: "Valid address",
-        invalidAddress: "Invalid address",
-        domainNotFound: "Domain not found",
-        sanctionedAddress: "Sanctioned address",
-        validationUnavailable: "Validation unavailable",
-        ensDisclaimer: "ENS addresses are supported.",
-        ensDisclaimerDescription: "ENS names can change over time.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftLabelChange: jest.fn(),
@@ -57,15 +63,21 @@ function createViewModel(
   };
 }
 
+function renderDialog(props: ContactsRenameAddressDialogProps) {
+  return render(
+    <I18nTestProvider resources={i18nResources}>
+      <ContactsRenameAddressDialog {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameAddressDialog", () => {
   it("should render the label validation error and disable confirmation", () => {
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          draftLabel: "Treasury",
-          invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        draftLabel: "Treasury",
+        invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-address-input")).toHaveValue("Treasury");
@@ -80,14 +92,12 @@ describe("ContactsRenameAddressDialog", () => {
     const onDraftLabelChange = jest.fn();
     const onConfirm = jest.fn(async () => undefined);
 
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          isConfirmEnabled: true,
-          onDraftLabelChange,
-          onConfirm,
-        })}
-      />,
+    renderDialog(
+      createViewModel({
+        isConfirmEnabled: true,
+        onDraftLabelChange,
+        onConfirm,
+      }),
     );
 
     fireEvent.change(screen.getByTestId("contacts-rename-address-input"), {

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.tsx
@@ -10,7 +10,14 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  type ContactAddressLabelValidationErrorName,
+} from "@domain/entity-contact";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsRenameAddressDialogProps } from "./types";
 import { useEditAddressDialogPresentation } from "./useEditAddressDialogPresentation.web";
 
@@ -22,17 +29,21 @@ export function ContactsRenameAddressDialog({
   invalidLabelError,
   addressEntry,
   isDeviceRequired,
-  labels,
   onClose,
   onDraftLabelChange,
   onAddressChange,
   onConfirm,
 }: ContactsRenameAddressDialogProps): React.ReactNode {
+  const { t } = useTranslation();
+  const labelValidationErrors: Record<ContactAddressLabelValidationErrorName, string> = {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.editAddress.invalidLabelError"),
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+  };
   const labelValidationError =
-    invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+    invalidLabelError === null ? undefined : labelValidationErrors[invalidLabelError];
   const addressInput = useEditAddressDialogPresentation({
     addressEntry,
-    labels: labels.addressValidation,
     onAddressChange,
   });
 
@@ -48,7 +59,11 @@ export function ContactsRenameAddressDialog({
         className="w-[400px] bg-canvas-sheet pb-24"
         data-testid="contacts-rename-address-dialog"
       >
-        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogHeader
+          density="expanded"
+          title={t("contacts.editAddress.title")}
+          onClose={onClose}
+        />
         <DialogBody className="flex flex-col gap-32 px-24 pt-2 pb-24">
           <AddressInput
             autoComplete="off"
@@ -57,7 +72,7 @@ export function ContactsRenameAddressDialog({
             helperText={addressInput.helperText}
             onChange={addressInput.onChange}
             onPaste={addressInput.onPaste}
-            placeholder={labels.addressValidation.addressPlaceholder}
+            placeholder={t("contacts.addAddressEntry.addressPlaceholder")}
             prefix=""
             spellCheck={false}
             status={addressInput.inputStatus}
@@ -67,8 +82,8 @@ export function ContactsRenameAddressDialog({
             <Banner
               appearance="info"
               data-testid="contacts-edit-address-ens-disclaimer"
-              title={labels.addressValidation.ensDisclaimer}
-              description={labels.addressValidation.ensDisclaimerDescription}
+              title={t("contacts.addAddressEntry.ensDisclaimer")}
+              description={t("contacts.addAddressEntry.ensDisclaimerDescription")}
             />
           ) : null}
           <TextInput
@@ -76,7 +91,7 @@ export function ContactsRenameAddressDialog({
             autoCorrect="off"
             data-testid="contacts-rename-address-input"
             helperText={labelValidationError}
-            label={labels.inputLabel}
+            label={t("contacts.editAddress.inputLabel")}
             maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
             maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
             onChange={event => onDraftLabelChange(event.target.value)}
@@ -94,7 +109,7 @@ export function ContactsRenameAddressDialog({
             onClick={() => void onConfirm()}
             data-testid="contacts-rename-address-confirm"
           >
-            {labels.applyChanges}
+            {t("contacts.editAddress.applyChanges")}
           </Button>
         </DialogBody>
       </DialogContent>

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
@@ -1,13 +1,40 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressValueSchema,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { ContactsRenameAddressDialog } from ".";
 import type { ContactsRenameAddressDrawerProps } from "./types";
+
+const i18nResources = {
+  translation: {
+    contacts: {
+      editAddress: {
+        title: "Edit address",
+        inputLabel: "Address label",
+        applyChanges: "Apply changes",
+        invalidLabelError: "Address label is invalid.",
+      },
+      addAddressName: {
+        duplicateLabel: "Address label is already in use.",
+        tooLongLabel: "Address label is too long.",
+      },
+      addAddressEntry: {
+        addressPlaceholder: "Address",
+        validatingAddress: "Validating address",
+        validAddress: "Valid address",
+        invalidAddress: "Invalid address",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned address",
+        validationUnavailable: "Validation unavailable",
+        ensDisclaimer: "ENS addresses are supported.",
+        ensDisclaimerDescription: "ENS names can change over time.",
+      },
+    },
+  },
+};
 
 function createViewModel(
   overrides: Partial<ContactsRenameAddressDrawerProps> = {},
@@ -27,27 +54,6 @@ function createViewModel(
       inputMethod: "manual",
     },
     isDeviceRequired: true,
-    labels: {
-      title: "Edit address",
-      inputLabel: "Address label",
-      applyChanges: "Apply changes",
-      labelValidationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is invalid.",
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Address label is already in use.",
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "Address label is too long.",
-      },
-      addressValidation: {
-        addressPlaceholder: "Address",
-        validatingAddress: "Validating address",
-        validAddress: "Valid address",
-        invalidAddress: "Invalid address",
-        domainNotFound: "Domain not found",
-        sanctionedAddress: "Sanctioned address",
-        validationUnavailable: "Validation unavailable",
-        ensDisclaimer: "ENS addresses are supported.",
-        ensDisclaimerDescription: "ENS names can change over time.",
-      },
-    },
     onOpen: jest.fn(),
     onClose: jest.fn(),
     onDraftLabelChange: jest.fn(),
@@ -57,15 +63,21 @@ function createViewModel(
   };
 }
 
+function renderDrawer(props: ContactsRenameAddressDrawerProps) {
+  return render(
+    <I18nTestProvider resources={i18nResources}>
+      <ContactsRenameAddressDialog {...props} />
+    </I18nTestProvider>,
+  );
+}
+
 describe("ContactsRenameAddressDrawer", () => {
   it("should render the validation state while open", () => {
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          draftLabel: "Treasury",
-          invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-        })}
-      />,
+    renderDrawer(
+      createViewModel({
+        draftLabel: "Treasury",
+        invalidLabelError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      }),
     );
 
     expect(screen.getByTestId("contacts-rename-address-input")).toBeVisible();
@@ -76,14 +88,12 @@ describe("ContactsRenameAddressDrawer", () => {
     const onDraftLabelChange = jest.fn();
     const onConfirm = jest.fn(async () => undefined);
 
-    render(
-      <ContactsRenameAddressDialog
-        {...createViewModel({
-          isConfirmEnabled: true,
-          onDraftLabelChange,
-          onConfirm,
-        })}
-      />,
+    renderDrawer(
+      createViewModel({
+        isConfirmEnabled: true,
+        onDraftLabelChange,
+        onConfirm,
+      }),
     );
 
     fireEvent.changeText(screen.getByTestId("contacts-rename-address-input"), "Treasury");
@@ -94,15 +104,13 @@ describe("ContactsRenameAddressDrawer", () => {
   });
 
   it("should not render its content while closed", () => {
-    render(<ContactsRenameAddressDialog {...createViewModel({ isOpen: false })} />);
+    renderDrawer(createViewModel({ isOpen: false }));
 
     expect(screen.queryByText("Edit address")).not.toBeOnTheScreen();
   });
 
   it("should reserve room for the keyboard so the form stays above it", () => {
-    const { toJSON } = render(
-      <ContactsRenameAddressDialog {...createViewModel({ bottomInset: 8, keyboardInset: 300 })} />,
-    );
+    const { toJSON } = renderDrawer(createViewModel({ bottomInset: 8, keyboardInset: 300 }));
 
     expect(toJSON()).toMatchObject({ props: { style: { paddingBottom: 332 } } });
   });

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
@@ -8,8 +8,15 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  type ContactAddressLabelValidationErrorName,
+} from "@domain/entity-contact";
 import { CONTACTS_NATIVE_ADDRESS_INPUT_PROPS } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 import type { ContactsRenameAddressDrawerProps } from "./types";
 import { useEditAddressAddressEntryPresentation } from "./useEditAddressAddressEntryPresentation.native";
 
@@ -22,17 +29,21 @@ export function ContactsRenameAddressDialog({
   isDeviceRequired,
   bottomInset = 0,
   keyboardInset = 0,
-  labels,
   onDraftLabelChange,
   onAddressChange,
   onConfirm,
   addressEntry,
 }: ContactsRenameAddressDrawerProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const labelValidationErrors: Record<ContactAddressLabelValidationErrorName, string> = {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.editAddress.invalidLabelError"),
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.labelTooLong"),
+  };
   const labelValidationError =
-    invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+    invalidLabelError === null ? undefined : labelValidationErrors[invalidLabelError];
   const addressInput = useEditAddressAddressEntryPresentation({
     addressEntry,
-    labels: labels.addressValidation,
     onAddressChange,
   });
 
@@ -40,12 +51,12 @@ export function ContactsRenameAddressDialog({
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
       {isOpen ? (
         <Box lx={{ gap: "s24" }}>
-          <BottomSheetHeader density="expanded" title={labels.title} />
+          <BottomSheetHeader density="expanded" title={t("contacts.editAddress.title")} />
           <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
             <TextInput
               testID="contacts-edit-address-input"
               value={addressInput.value}
-              placeholder={labels.addressValidation.addressPlaceholder}
+              placeholder={t("contacts.addAddressEntry.addressPlaceholder")}
               onChangeText={addressInput.onChangeText}
               status={addressInput.inputStatus}
               helperText={addressInput.helperText}
@@ -55,14 +66,14 @@ export function ContactsRenameAddressDialog({
               <Banner
                 testID="contacts-edit-address-ens-disclaimer"
                 appearance="info"
-                title={labels.addressValidation.ensDisclaimer}
-                description={labels.addressValidation.ensDisclaimerDescription}
+                title={t("contacts.addAddressEntry.ensDisclaimer")}
+                description={t("contacts.addAddressEntry.ensDisclaimerDescription")}
               />
             ) : null}
             <TextInput
               {...CONTACTS_NATIVE_ADDRESS_INPUT_PROPS}
               helperText={labelValidationError}
-              label={labels.inputLabel}
+              label={t("contacts.editAddress.inputLabel")}
               maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
               onChangeText={onDraftLabelChange}
               status={labelValidationError ? "error" : undefined}
@@ -79,7 +90,7 @@ export function ContactsRenameAddressDialog({
               onPress={() => void onConfirm()}
               testID="contacts-rename-address-confirm"
             >
-              {labels.applyChanges}
+              {t("contacts.editAddress.applyChanges")}
             </Button>
           </Box>
         </Box>

--- a/features/flow/flow-contacts-edit-address/src/types.ts
+++ b/features/flow/flow-contacts-edit-address/src/types.ts
@@ -63,18 +63,6 @@ export type UseRenameAddressDialogViewModelOptions = Omit<
     requestSaveApproval?: () => Promise<boolean>;
   }>;
 
-export type ContactsEditAddressValidationLabels = Readonly<{
-  addressPlaceholder: string;
-  validatingAddress: string;
-  validAddress: string;
-  invalidAddress: string;
-  domainNotFound: string;
-  sanctionedAddress: string;
-  validationUnavailable: string;
-  ensDisclaimer: string;
-  ensDisclaimerDescription: string;
-}>;
-
 export type EditAddressAddressEntryPresentation = Readonly<{
   value: string;
   inputStatus?: "error" | "success";
@@ -83,18 +71,9 @@ export type EditAddressAddressEntryPresentation = Readonly<{
   onChangeText: (value: string) => void;
 }>;
 
-export type ContactsRenameAddressLabels = Readonly<{
-  title: string;
-  inputLabel: string;
-  applyChanges: string;
-  labelValidationErrors: Readonly<Record<ContactAddressLabelValidationErrorName, string>>;
-  addressValidation: ContactsEditAddressValidationLabels;
-}>;
-
 export type ContactsRenameAddressDialogProps = RenameAddressDialogViewModel &
   Readonly<{
     isDeviceRequired: boolean;
-    labels: ContactsRenameAddressLabels;
   }>;
 
 export type ContactsRenameAddressDrawerProps = ContactsRenameAddressDialogProps &

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
@@ -1,19 +1,27 @@
+import React from "react";
 import { act, renderHook } from "@testing-library/react-native";
 import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { createInitialEditAddressEntryState } from "./model/addressEntryValidation";
 import { useEditAddressAddressEntryPresentation } from "./useEditAddressAddressEntryPresentation.native";
 
-const labels = {
-  addressPlaceholder: "Address",
-  validatingAddress: "Validating",
-  validAddress: "Valid",
-  invalidAddress: "Invalid",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Sanctioned",
-  validationUnavailable: "Unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
+const i18nResources = {
+  translation: {
+    contacts: {
+      addAddressEntry: {
+        validatingAddress: "Validating",
+        validAddress: "Valid",
+        invalidAddress: "Invalid",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned",
+        validationUnavailable: "Unavailable",
+      },
+    },
+  },
 };
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(I18nTestProvider, { resources: i18nResources }, children);
 
 describe("useEditAddressAddressEntryPresentation", () => {
   it("should expose validation presentation for a valid address entry", () => {
@@ -21,12 +29,13 @@ describe("useEditAddressAddressEntryPresentation", () => {
       ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
     );
     const onAddressChange = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressAddressEntryPresentation({
-        addressEntry: currentAddress,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressAddressEntryPresentation({
+          addressEntry: currentAddress,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     expect(result.current).toMatchObject({
@@ -42,12 +51,13 @@ describe("useEditAddressAddressEntryPresentation", () => {
       ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
     );
     const onAddressChange = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressAddressEntryPresentation({
-        addressEntry: currentAddress,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressAddressEntryPresentation({
+          addressEntry: currentAddress,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     act(() => {

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.ts
@@ -7,20 +7,28 @@ import type {
   ContactsAddressEntryState,
   ContactsAddressInputSource,
 } from "@features/platform-contacts";
-import type {
-  ContactsEditAddressValidationLabels,
-  EditAddressAddressEntryPresentation,
-} from "./types";
+import { useTranslation } from "@shared/i18n";
+import type { EditAddressAddressEntryPresentation } from "./types";
 
 export function useEditAddressAddressEntryPresentation({
   addressEntry,
-  labels,
   onAddressChange,
 }: Readonly<{
   addressEntry: ContactsAddressEntryState;
-  labels: ContactsEditAddressValidationLabels;
   onAddressChange: (value: string, inputMethod: ContactsAddressInputSource) => void;
 }>): EditAddressAddressEntryPresentation {
+  const { t } = useTranslation();
+  const labels = useMemo(
+    () => ({
+      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    }),
+    [t],
+  );
   const presentation = useMemo(
     () => resolveAddressInputPresentation(addressEntry, labels),
     [addressEntry, labels],

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
@@ -1,20 +1,28 @@
+import React from "react";
 import { act, renderHook } from "@testing-library/react";
 import type { ClipboardEvent } from "react";
 import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { createInitialEditAddressEntryState } from "./model/addressEntryValidation";
 import { useEditAddressDialogPresentation } from "./useEditAddressDialogPresentation.web";
 
-const labels = {
-  addressPlaceholder: "Address",
-  validatingAddress: "Validating",
-  validAddress: "Valid",
-  invalidAddress: "Invalid",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Sanctioned",
-  validationUnavailable: "Unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
+const i18nResources = {
+  translation: {
+    contacts: {
+      addAddressEntry: {
+        validatingAddress: "Validating",
+        validAddress: "Valid",
+        invalidAddress: "Invalid",
+        domainNotFound: "Domain not found",
+        sanctionedAddress: "Sanctioned",
+        validationUnavailable: "Unavailable",
+      },
+    },
+  },
 };
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(I18nTestProvider, { resources: i18nResources }, children);
 
 describe("useEditAddressDialogPresentation", () => {
   it("should expose validation presentation for a valid address entry", () => {
@@ -22,12 +30,13 @@ describe("useEditAddressDialogPresentation", () => {
       ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
     );
     const onAddressChange = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressDialogPresentation({
-        addressEntry,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressDialogPresentation({
+          addressEntry,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     expect(result.current).toMatchObject({
@@ -49,12 +58,13 @@ describe("useEditAddressDialogPresentation", () => {
     };
     const onAddressChange = jest.fn();
     const preventDefault = jest.fn();
-    const { result } = renderHook(() =>
-      useEditAddressDialogPresentation({
-        addressEntry,
-        labels,
-        onAddressChange,
-      }),
+    const { result } = renderHook(
+      () =>
+        useEditAddressDialogPresentation({
+          addressEntry,
+          onAddressChange,
+        }),
+      { wrapper },
     );
 
     act(() => {

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.ts
@@ -4,17 +4,27 @@ import type {
   ContactsAddressEntryState,
   ContactsAddressInputSource,
 } from "@features/platform-contacts";
-import type { ContactsEditAddressValidationLabels } from "./types";
+import { useTranslation } from "@shared/i18n";
 
 export function useEditAddressDialogPresentation({
   addressEntry,
-  labels,
   onAddressChange,
 }: Readonly<{
   addressEntry: ContactsAddressEntryState;
-  labels: ContactsEditAddressValidationLabels;
   onAddressChange: (value: string, inputMethod: ContactsAddressInputSource) => void;
 }>) {
+  const { t } = useTranslation();
+  const labels = useMemo(
+    () => ({
+      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    }),
+    [t],
+  );
   const presentation = useMemo(
     () => resolveAddressInputPresentation(addressEntry, labels),
     [addressEntry, labels],


### PR DESCRIPTION
## Summary

- Call `useTranslation` inline in `ContactsRenameAddressDialog.web` and `ContactsRenameAddressDrawer.native`
- Bug fix: native used wrong key `tooLongLabel` → corrected to `labelTooLong`
- Remove labels props from `flow-contacts-edit-address`
- Add `@shared/i18n` dependency

Part of stack: LIVE-37080 (5/7) — stacks on #21758

## Test plan
- [ ] Edit address label validation errors show correct translations on both platforms