### PR TITLE
[LWDM] feat(contacts): use @shared/i18n in add-address (LIVE-37080)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { DialogFlow, type DialogFlowScreenRegistry } from "LLD/components/DialogFlow";
 import { ModularDialogFlow } from "LLD/features/ModularDialog/ModularDialogFlow";
 import {
@@ -11,10 +12,7 @@ import type { ContactsAddAddressFlowDialogProps } from "./types";
 
 export function ContactsAddAddressFlowDialog({
   state,
-  entryLabels,
   sanctionedAddressBanner,
-  nameLabels,
-  reviewLabels,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -23,6 +21,7 @@ export function ContactsAddAddressFlowDialog({
   onBack,
   onClose,
 }: ContactsAddAddressFlowDialogProps): React.JSX.Element | null {
+  const { t } = useTranslation();
   if (state.status === "closed") {
     return null;
   }
@@ -33,15 +32,13 @@ export function ContactsAddAddressFlowDialog({
     <ModularDialogFlow fillAvailableHeight={isSelectingCurrency} onClose={onClose}>
       {modularDialog => {
         const currentStep = resolveAddAddressWebFlowStep(state);
+        const entryTitle = t("contacts.addAddressEntry.title");
         const flowContent =
           state.status === "selectingCurrency" ? (
             modularDialog.content
           ) : (
             <ContactsAddAddressFlowContent
-              entryLabels={entryLabels}
               sanctionedAddressBanner={sanctionedAddressBanner}
-              nameLabels={nameLabels}
-              reviewLabels={reviewLabels}
               onAddressChange={onAddressChange}
               onAddressLabelChange={onAddressLabelChange}
               onContinueFromAddressDetails={onContinueFromAddressDetails}
@@ -65,28 +62,28 @@ export function ContactsAddAddressFlowDialog({
           address: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: true,
             },
           },
           name: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: true,
             },
           },
           review: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: true,
             },
           },
           success: {
             content: flowContent,
             options: {
-              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              dialogHeaderProps: { density: "expanded", title: entryTitle },
               hasBackButton: false,
             },
           },

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
@@ -1,18 +1,12 @@
 import type {
-  AddAddressEntryLabels,
   AddAddressFlowState,
   AddAddressInputSource,
-  ContactsAddAddressNameLabels,
-  ContactsAddAddressReviewLabels,
   SanctionedAddressBannerProps,
 } from "@features/flow-contacts-add-address";
 
 export type ContactsAddAddressFlowDialogProps = Readonly<{
   state: AddAddressFlowState;
-  entryLabels: AddAddressEntryLabels;
   sanctionedAddressBanner: SanctionedAddressBannerProps;
-  nameLabels: ContactsAddAddressNameLabels;
-  reviewLabels: ContactsAddAddressReviewLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -5,19 +5,11 @@ import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
 import { v4 as uuid } from "uuid";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  addAddress,
-  contactAddress,
-  type ContactId,
-} from "@domain/entity-contact";
+import { addAddress, contactAddress, type ContactId } from "@domain/entity-contact";
 import {
   createContactsListViewModel,
   createContactsSearchViewModel,
   type ContactAddressDetailDialogProps,
-  type ContactsListViewLabels,
   CONTACTS_EVENT_SOURCE,
   CONTACTS_FLOW,
   CONTACTS_PAGE_PROPERTY,
@@ -32,10 +24,7 @@ import {
   useAddAddressCurrencySelectionViewModel,
   useAddAddressFlowViewModel,
   type AddAddressContact,
-  type AddAddressEntryLabels,
   type AddAddressFlowState,
-  type ContactsAddAddressNameLabels,
-  type ContactsAddAddressReviewLabels,
 } from "@features/flow-contacts-add-address";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
@@ -300,61 +289,14 @@ export function useContactsViewModel(): ContactsPageViewModel {
     goBackAddAddress();
     selectCurrencyForContact(selectedContactId);
   }, [addAddressFlowState, goBackAddAddress, selectCurrencyForContact]);
-  const addAddressEntryLabels = useMemo<AddAddressEntryLabels>(
-    () => ({
-      title: t("contacts.addAddressEntry.title"),
-      addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-      confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
-      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-      ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-      ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-    }),
-    [t],
-  );
-  const addAddressNameLabels = useMemo<ContactsAddAddressNameLabels>(
-    () => ({
-      inputLabel: t("contacts.addAddressName.inputLabel"),
-      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-      namingDisclaimerAccessibilityLabel: t(
-        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
-      ),
-      continueToReview: t("contacts.addAddressName.continueToReview"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      validationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
-      },
-    }),
-    [t],
-  );
-  const addAddressReviewLabels = useMemo<ContactsAddAddressReviewLabels>(
-    () => ({
-      title: t("contacts.addAddressReview.title"),
-      addressLabel: t("contacts.addAddressReview.addressLabel"),
-      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
-      networkLabel: t("contacts.addAddressReview.networkLabel"),
-      nameLabel: t("contacts.addAddressReview.nameLabel"),
-      continue: t("contacts.addAddressReview.continue"),
-    }),
-    [t],
-  );
   const addAddressFlowDialog = useMemo<ContactsAddAddressFlowDialogProps>(
     () => ({
       state: addAddressFlowState,
-      entryLabels: addAddressEntryLabels,
       sanctionedAddressBanner: {
         description: t("contacts.addAddressEntry.sanctioned.description"),
         actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
         onAction: handleSanctionedAddressLearnMore,
       },
-      nameLabels: addAddressNameLabels,
-      reviewLabels: addAddressReviewLabels,
       onAddressChange: (address, inputMethod) => {
         void updateAddress(address, inputMethod);
       },
@@ -366,10 +308,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       onClose: onCloseAddAddress,
     }),
     [
-      addAddressEntryLabels,
       handleSanctionedAddressLearnMore,
-      addAddressNameLabels,
-      addAddressReviewLabels,
       addAddressFlowState,
       onBackAddAddress,
       onCloseAddAddress,
@@ -396,17 +335,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
       isContactsEntryAvailable: true,
       preference,
     });
-  const labels = useMemo<ContactsListViewLabels>(
-    () => ({
-      title: t("contacts.title"),
-      searchPlaceholder: t("contacts.searchPlaceholder"),
-      searchNoResults: t("contacts.searchNoResults"),
-      addContact: t("contacts.addContact"),
-      formatAddressCount: count => t("contacts.addressCount", { count }),
-      formatMeDisplayName: createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
+  const formatMeDisplayName = useMemo(
+    () =>
+      createMeDisplayNameFormatter(t("contacts.me.myAddresses"), name =>
         t("contacts.detail.meDisplayName", { name }),
       ),
-    }),
     [t],
   );
   const featureIntroductionHighlights = useMemo(
@@ -420,16 +353,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
   );
   const viewModel = useMemo(() => {
     if (searchQuery.trim().length > 0) {
-      return createContactsSearchViewModel(
-        meContact,
-        contacts,
-        searchQuery,
-        labels.formatMeDisplayName,
-      );
+      return createContactsSearchViewModel(meContact, contacts, searchQuery, formatMeDisplayName);
     }
 
-    return createContactsListViewModel(meContact, contacts, labels.formatMeDisplayName);
-  }, [contacts, labels.formatMeDisplayName, meContact, searchQuery]);
+    return createContactsListViewModel(meContact, contacts, formatMeDisplayName);
+  }, [contacts, formatMeDisplayName, meContact, searchQuery]);
   const onSearchInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
   }, []);
@@ -485,7 +413,6 @@ export function useContactsViewModel(): ContactsPageViewModel {
     editDeleteDialogs,
     addressDetailActionsDialogs,
     viewModel,
-    labels,
     searchQuery,
     meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
     onSearchInputChange,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -1,14 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { v4 as uuid } from "uuid";
-import {
-  addAddress,
-  contactAddress,
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  type Contact,
-} from "@domain/entity-contact";
+import { addAddress, contactAddress, type Contact } from "@domain/entity-contact";
 import { SEND_FLOW_STEP, type SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
 import { resolvePrefillAddAddressParams } from "@ledgerhq/live-common/flows/send/recipient/utils/resolvePrefillAddAddressParams";
 import { getMinVersion } from "@ledgerhq/live-common/apps/support";
@@ -25,9 +17,6 @@ import {
 import {
   isPrefillAddAddressFlowOpen,
   useAddAddressFlowViewModel,
-  type AddAddressEntryLabels,
-  type ContactsAddAddressNameLabels,
-  type ContactsAddAddressReviewLabels,
   type PrefillAddAddressFlowVisibleState,
 } from "@features/flow-contacts-add-address";
 import { useContactsAddressValidationAdapter } from "LLD/features/Contacts/hooks/useContactsAddressValidationAdapter";
@@ -46,9 +35,6 @@ import { track, trackPage } from "~/renderer/analytics/segment";
 
 export type SendPrefillAddAddressPhase = Readonly<{
   state: PrefillAddAddressFlowVisibleState;
-  entryLabels: AddAddressEntryLabels;
-  nameLabels: ContactsAddAddressNameLabels;
-  reviewLabels: ContactsAddAddressReviewLabels;
   dieProps: ContactsDeviceIntentExecutorProps | undefined;
   onAddressLabelChange: (value: string) => void;
   onContinueFromName: () => void;
@@ -75,7 +61,6 @@ export function useSendPrefillAddAddressFlow({
   idleHeaderState,
   contactType,
 }: UseSendPrefillAddAddressFlowOptions): SendPrefillAddAddressFlow {
-  const { t } = useTranslation();
   const dispatch = useDispatch();
   const { navigation } = useFlowWizard<SendFlowStep>();
   const { state, recipientSearch } = useSendFlowData();
@@ -287,56 +272,9 @@ export function useSendPrefillAddAddressFlow({
     [navigation, recipientSearch.value, startWithPrefilled, state.account.currency],
   );
 
-  const entryLabels = useMemo<AddAddressEntryLabels>(
-    () => ({
-      title: t("contacts.addAddressEntry.title"),
-      addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-      confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
-      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-      ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-      ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-    }),
-    [t],
-  );
-  const nameLabels = useMemo<ContactsAddAddressNameLabels>(
-    () => ({
-      inputLabel: t("contacts.addAddressName.inputLabel"),
-      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-      namingDisclaimerAccessibilityLabel: t(
-        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
-      ),
-      continueToReview: t("contacts.addAddressName.continueToReview"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
-      validationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
-      },
-    }),
-    [t],
-  );
-  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
-    () => ({
-      title: t("contacts.addAddressReview.title"),
-      addressLabel: t("contacts.addAddressReview.addressLabel"),
-      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
-      networkLabel: t("contacts.addAddressReview.networkLabel"),
-      nameLabel: t("contacts.addAddressReview.nameLabel"),
-      continue: t("contacts.addAddressReview.continue"),
-    }),
-    [t],
-  );
   const addressPhase = isAddressPhase
     ? {
         state: addressFlowState,
-        entryLabels,
-        nameLabels,
-        reviewLabels,
         dieProps,
         onAddressLabelChange: updateAddressLabel,
         onContinueFromName: () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/AddNewContactAddressView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/AddNewContactAddressView.tsx
@@ -19,9 +19,6 @@ export function AddNewContactAddressView({ addressPhase }: AddNewContactAddressV
     >
       <ContactsAddAddressFlowContent
         state={addressPhase.state}
-        entryLabels={addressPhase.entryLabels}
-        nameLabels={addressPhase.nameLabels}
-        reviewLabels={addressPhase.reviewLabels}
         onAddressChange={() => undefined}
         onContinueFromAddressDetails={() => undefined}
         onAddressLabelChange={addressPhase.onAddressLabelChange}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -1,10 +1,5 @@
 import { useCallback } from "react";
 import { Linking, Platform } from "react-native";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
 import { useTranslation } from "~/context/Locale";
 import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
@@ -67,19 +62,6 @@ export function useContactsAddAddressFlowDrawerViewModel({
       state.status === "enteringAddress"
         ? {
             addressEntry: state.addressEntry,
-            labels: {
-              title: t("contacts.addAddressEntry.title"),
-              addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
-              confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
-              validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
-              validAddress: t("contacts.addAddressEntry.validAddress"),
-              invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
-              domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
-              sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
-              validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
-              ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
-              ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
-            },
             sanctionedAddressBanner: {
               description: t("contacts.addAddressEntry.sanctioned.description"),
               actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
@@ -95,23 +77,6 @@ export function useContactsAddAddressFlowDrawerViewModel({
       state.status === "namingAddress" || state.status === "confirmationRequired"
         ? {
             addressLabel: state.addressLabel,
-            labels: {
-              title: t("contacts.addAddressName.title"),
-              inputLabel: t("contacts.addAddressName.inputLabel"),
-              namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-              continueToReview: t("common.continue"),
-              validationErrors: {
-                [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
-                  "contacts.addAddressName.invalidLabel",
-                ),
-                [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
-                  "contacts.addAddressName.duplicateLabel",
-                ),
-                [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(
-                  "contacts.addAddressName.labelTooLong",
-                ),
-              },
-            },
             bottomOffset,
             onChangeText: onAddressNameChange,
             onContinue: onContinueFromName,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactAddressScreens.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactAddressScreens.tsx
@@ -1,18 +1,9 @@
-import React, { useMemo } from "react";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
-import {
-  ContactsAddAddressFlowContent,
-  type ContactsAddAddressReviewLabels,
-} from "@features/flow-contacts-add-address";
+import React from "react";
+import { ContactsAddAddressFlowContent } from "@features/flow-contacts-add-address";
 import type {
   QueuedDrawerFlowOptions,
   QueuedDrawerFlowScreen,
 } from "LLM/components/QueuedDrawerFlow";
-import { useTranslation } from "~/context/Locale";
 import type { SendPrefillAddAddressPhase } from "LLM/features/Send/hooks/useSendPrefillAddAddressFlow";
 
 const LOCKED_STEP_OPTIONS = {
@@ -37,33 +28,6 @@ export function useAddNewContactAddressScreens({
   addressPhase,
   bottomOffset,
 }: UseAddNewContactAddressScreensOptions): AddNewContactAddressScreens {
-  const { t } = useTranslation();
-  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
-    () => ({
-      title: t("contacts.addAddressReview.title"),
-      addressLabel: t("contacts.addAddressReview.addressLabel"),
-      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
-      networkLabel: t("contacts.addAddressReview.networkLabel"),
-      nameLabel: t("contacts.addAddressReview.nameLabel"),
-      continue: t("contacts.addAddressReview.continue"),
-    }),
-    [t],
-  );
-  const nameLabels = useMemo(
-    () => ({
-      title: t("contacts.addAddressName.title"),
-      inputLabel: t("contacts.addAddressName.inputLabel"),
-      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
-      continueToReview: t("contacts.addAddressName.continueToReview"),
-      validationErrors: {
-        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
-        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
-        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.labelTooLong"),
-      },
-    }),
-    [t],
-  );
-
   if (addressPhase === null) {
     return {
       name: { content: null, options: LOCKED_STEP_OPTIONS },
@@ -80,7 +44,6 @@ export function useAddNewContactAddressScreens({
           addressEntryProps={null}
           addressNameProps={{
             addressLabel: state.addressLabel,
-            labels: nameLabels,
             bottomOffset,
             onChangeText: addressPhase.onAddressLabelChange,
             onContinue: addressPhase.onContinueFromName,
@@ -101,7 +64,6 @@ export function useAddNewContactAddressScreens({
             currency: state.displayContext.assetDisplayName,
             network: state.displayContext.network.displayName,
             name: state.addressLabel.label ?? state.addressLabel.value,
-            labels: reviewLabels,
             bottomOffset,
             onContinue: addressPhase.onContinueFromReview,
           }}

--- a/features/flow/flow-contacts-add-address/package.json
+++ b/features/flow/flow-contacts-add-address/package.json
@@ -27,7 +27,8 @@
     "@domain/entity-contact": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
@@ -1,23 +1,12 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { ContactAddressValueSchema } from "@domain/entity-contact";
-import type { AddAddressEntryLabels, AddAddressEntryState } from "../../../../state/types";
+import type { AddAddressEntryState } from "../../../../state/types";
 import { ContactsAddAddressEntry } from "./ContactsAddAddressEntry";
 
-const labels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address or ENS",
-  confirmAddress: "Confirm address",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "No address found for this domain",
-  sanctionedAddress: "This address is sanctioned and cannot be used.",
-  validationUnavailable: "Address validation is unavailable",
-  ensDisclaimer: "ENS names resolve to wallet addresses.",
-  ensDisclaimerDescription:
-    "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
-};
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 const VALID_ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
 
@@ -29,7 +18,6 @@ function renderEntry(addressEntry: AddAddressEntryState, bottomOffset?: number) 
   render(
     <ContactsAddAddressEntry
       addressEntry={addressEntry}
-      labels={labels}
       {...(bottomOffset === undefined ? {} : { bottomOffset })}
       onChangeText={onChangeText}
       onConfirm={onConfirm}
@@ -50,8 +38,10 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     const addressInput = screen.getByTestId("contacts-add-address-input");
-    expect(screen.UNSAFE_getByProps({ title: "Enter address" }).props.title).toBe("Enter address");
-    expect(addressInput.props.placeholder).toBe("Address or ENS");
+    expect(screen.UNSAFE_getByProps({ title: "contacts.addAddressEntry.title" }).props.title).toBe(
+      "contacts.addAddressEntry.title",
+    );
+    expect(addressInput.props.placeholder).toBe("contacts.addAddressEntry.addressPlaceholder");
     expect(screen.getByTestId("contacts-add-address-entry-screen")).toHaveStyle({
       bottom: 0,
       paddingBottom: 32,
@@ -135,7 +125,7 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-input").props.helperText).toBe(
-      "Validating address",
+      "contacts.addAddressEntry.validatingAddress",
     );
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
   });
@@ -150,7 +140,6 @@ describe("ContactsAddAddressEntry", () => {
           inputMethod: "manual",
           error: "sanctioned",
         }}
-        labels={labels}
         sanctionedAddressBanner={{
           description: "This wallet address is sanctioned.",
           actionLabel: "Learn more",
@@ -179,7 +168,7 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
-      helperText: "Valid address",
+      helperText: "contacts.addAddressEntry.validAddress",
       status: "success",
     });
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(false);
@@ -190,9 +179,9 @@ describe("ContactsAddAddressEntry", () => {
   });
 
   it.each([
-    ["invalid_format", "Invalid address"],
-    ["domain_not_found", "No address found for this domain"],
-    ["sanctioned", "This address is sanctioned and cannot be used."],
+    ["invalid_format", "contacts.addAddressEntry.invalidAddress"],
+    ["domain_not_found", "contacts.addAddressEntry.domainNotFound"],
+    ["sanctioned", "contacts.addAddressEntry.sanctionedAddress"],
   ] as const)("should render the %s error", (error, expectedMessage) => {
     renderEntry({
       status: "invalid",
@@ -218,7 +207,7 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
-      helperText: "Address validation is unavailable",
+      helperText: "contacts.addAddressEntry.validationUnavailable",
       status: "error",
     });
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
@@ -233,10 +222,10 @@ describe("ContactsAddAddressEntry", () => {
     });
 
     expect(screen.getByTestId("contacts-add-address-ens-disclaimer").props.title).toBe(
-      "ENS names resolve to wallet addresses.",
+      "contacts.addAddressEntry.ensDisclaimer",
     );
     expect(screen.getByTestId("contacts-add-address-ens-disclaimer").props.description).toBe(
-      "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
+      "contacts.addAddressEntry.ensDisclaimerDescription",
     );
   });
 });

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.ts
@@ -9,7 +9,6 @@ export type { SanctionedAddressBannerProps } from "../../../../components/Sancti
 
 export type ContactsAddAddressEntryProps = Readonly<{
   addressEntry: AddAddressEntryState;
-  labels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
   bottomOffset?: number;
   onChangeText: (value: string, inputMethod: AddAddressInputSource) => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.web.ts
@@ -10,7 +10,6 @@ import type {
 
 export type AddressLabelConfiguration = Readonly<{
   addressLabel: AddAddressLabelState;
-  nameLabels: ContactsAddAddressNameLabels;
   onAddressLabelChange: (value: string) => void;
 }>;
 
@@ -36,7 +35,6 @@ type WithoutAddressLabelViewConfiguration = Readonly<{
 
 type ContactsAddAddressEntryWebBaseProps = Readonly<{
   addressEntry: AddAddressEntryState;
-  labels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onConfirm?: () => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.native.ts
@@ -8,16 +8,30 @@ import type {
   ContactsAddAddressEntryViewProps,
 } from "../components/ContactsAddAddressEntry/ContactsAddAddressEntry.types";
 import { classifyNativeAddressInputMethod } from "@features/platform-contacts";
+import { useTranslation } from "@shared/i18n";
 
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
-  labels,
   sanctionedAddressBanner,
   bottomOffset = 0,
   onChangeText,
   onConfirm,
   onQrCodeClick,
 }: ContactsAddAddressEntryProps): ContactsAddAddressEntryViewProps {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.addAddressEntry.title"),
+    addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+    confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+    validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+    domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+    sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+    validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+    ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+  };
   const presentation = resolveAddAddressEntryPresentation(addressEntry, labels);
   const showSanctionedAddressBanner = shouldShowSanctionedAddressBanner(
     addressEntry,

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
@@ -4,48 +4,23 @@ import {
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   ContactAddressValueSchema,
 } from "@domain/entity-contact";
-import type { ContactsAddAddressNameLabels } from "../../AddressName/types";
 import type { ContactsAddAddressEntryWebProps } from "../components/ContactsAddAddressEntry/ContactsAddAddressEntry";
-import type { AddAddressEntryLabels } from "../../../state/types";
 import { useContactsAddAddressEntryViewModel } from "./useContactsAddAddressEntryViewModel";
 
-const labels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address or ENS",
-  confirmAddress: "Continue to review",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "This address is sanctioned and cannot be used.",
-  validationUnavailable: "Address validation is temporarily unavailable.",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
-};
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
   "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
 );
-const nameLabels: ContactsAddAddressNameLabels = {
-  inputLabel: "Address name",
-  namingDisclaimer: "Address naming disclaimer",
-  namingDisclaimerAccessibilityLabel: "Address name information",
-  continueToReview: "Continue to review",
-  validAddress: "Valid address",
-  validationErrors: {
-    InvalidContactAddressLabelError: "Special characters are not allowed.",
-    DuplicateContactAddressLabelError: "Duplicate address name.",
-    ContactAddressLabelTooLongError: "Address name is too long.",
-  },
-};
 
 type ContactsAddAddressEntryWebBaseOverrides = Partial<
-  Omit<ContactsAddAddressEntryWebProps, "addressLabel" | "nameLabels" | "onAddressLabelChange">
+  Omit<ContactsAddAddressEntryWebProps, "addressLabel" | "onAddressLabelChange">
 >;
 
 type ContactsAddAddressEntryWebWithLabelOverrides = ContactsAddAddressEntryWebBaseOverrides &
-  Required<
-    Pick<ContactsAddAddressEntryWebProps, "addressLabel" | "nameLabels" | "onAddressLabelChange">
-  >;
+  Required<Pick<ContactsAddAddressEntryWebProps, "addressLabel" | "onAddressLabelChange">>;
 
 function renderViewModel(
   overrides:
@@ -55,7 +30,6 @@ function renderViewModel(
   const onAddressChange = jest.fn();
   const props: ContactsAddAddressEntryWebProps = {
     addressEntry: { status: "empty", value: "", resolvedAddress: null, inputMethod: null },
-    labels,
     onAddressChange,
     ...overrides,
   } as ContactsAddAddressEntryWebProps;
@@ -123,7 +97,7 @@ describe("useContactsAddAddressEntryViewModel", () => {
 
     expect(result.current).toMatchObject({
       inputStatus: "success",
-      helperText: "Valid address",
+      helperText: "contacts.addAddressEntry.validAddress",
       showEnsDisclaimer: true,
       isConfirmEnabled: true,
     });
@@ -161,7 +135,7 @@ describe("useContactsAddAddressEntryViewModel", () => {
 
     expect(result.current).toMatchObject({
       inputStatus: "error",
-      helperText: "This address is sanctioned and cannot be used.",
+      helperText: "contacts.addAddressEntry.sanctionedAddress",
       isConfirmEnabled: false,
     });
     expect(result.current.sanctionedAddressBanner).toEqual({
@@ -186,13 +160,12 @@ describe("useContactsAddAddressEntryViewModel", () => {
         label: null,
         validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
-      nameLabels,
       onAddressLabelChange,
       onConfirm: jest.fn(),
     });
 
     expect(result.current.isConfirmEnabled).toBe(false);
-    expect(result.current.nameValidationMessage).toBe("Special characters are not allowed.");
+    expect(result.current.nameValidationMessage).toBe("contacts.addAddressName.invalidLabel");
 
     act(() => {
       result.current.onAddressLabelChange?.({

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type ChangeEvent, type ClipboardEvent } from "react";
+import { useCallback, type ChangeEvent, type ClipboardEvent } from "react";
 import { getPastedValue } from "@features/platform-contacts";
 import {
   resolveAddAddressEntryPresentation,
@@ -9,30 +9,57 @@ import type {
   ContactsAddAddressEntryWebProps,
   ContactsAddAddressEntryWebViewProps,
 } from "../components/ContactsAddAddressEntry/ContactsAddAddressEntry.types";
+import { useTranslation } from "@shared/i18n";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
 
 function getAddressLabelConfiguration({
   addressLabel,
-  nameLabels,
   onAddressLabelChange,
 }: Partial<AddressLabelConfiguration>): AddressLabelConfiguration | undefined {
-  return addressLabel && nameLabels && onAddressLabelChange
-    ? { addressLabel, nameLabels, onAddressLabelChange }
-    : undefined;
+  return addressLabel && onAddressLabelChange ? { addressLabel, onAddressLabelChange } : undefined;
 }
 
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
-  labels,
   sanctionedAddressBanner,
   onAddressChange,
   onConfirm,
   ...addressLabelProps
 }: ContactsAddAddressEntryWebProps): ContactsAddAddressEntryWebViewProps {
+  const { t } = useTranslation();
+  const labels = {
+    title: t("contacts.addAddressEntry.title"),
+    addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+    confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+    validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+    domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+    sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+    validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+    ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+    ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+  };
+  const nameLabels = {
+    inputLabel: t("contacts.addAddressName.inputLabel"),
+    namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+    namingDisclaimerAccessibilityLabel: t(
+      "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+    ),
+    continueToReview: t("contacts.addAddressName.continueToReview"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    validationErrors: {
+      [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+      [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+      [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+    },
+  };
   const addressLabelConfiguration = getAddressLabelConfiguration(addressLabelProps);
-  const presentation = useMemo(
-    () => resolveAddAddressEntryPresentation(addressEntry, labels),
-    [addressEntry, labels],
-  );
+  const presentation = resolveAddAddressEntryPresentation(addressEntry, labels);
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => onAddressChange(event.target.value, "manual"),
     [onAddressChange],
@@ -49,15 +76,9 @@ export function useContactsAddAddressEntryViewModel({
       addressLabelConfiguration?.onAddressLabelChange(event.target.value),
     [addressLabelConfiguration],
   );
-  const nameValidationMessage = useMemo(
-    () =>
-      addressLabelConfiguration?.addressLabel.validationError
-        ? addressLabelConfiguration.nameLabels.validationErrors[
-            addressLabelConfiguration.addressLabel.validationError
-          ]
-        : undefined,
-    [addressLabelConfiguration],
-  );
+  const nameValidationMessage = addressLabelConfiguration?.addressLabel.validationError
+    ? nameLabels.validationErrors[addressLabelConfiguration.addressLabel.validationError]
+    : undefined;
   const isNameValid =
     addressLabelConfiguration === undefined ||
     addressLabelConfiguration.addressLabel.status === "valid";
@@ -69,7 +90,7 @@ export function useContactsAddAddressEntryViewModel({
   const addressLabelViewProps = addressLabelConfiguration
     ? {
         addressLabel: addressLabelConfiguration.addressLabel,
-        nameLabels: addressLabelConfiguration.nameLabels,
+        nameLabels,
         nameValidationMessage,
         onAddressLabelChange: onNameChange,
       }

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.test.tsx
@@ -7,21 +7,12 @@ import {
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
-import type { AddAddressLabelState, AddAddressNameLabels } from "../../state/types";
+import type { AddAddressLabelState } from "../../state/types";
 import { ContactsAddAddressName } from "./ContactsAddAddressName";
 
-const labels: AddAddressNameLabels = {
-  title: "Name address",
-  inputLabel: "Address name",
-  namingDisclaimer: "Only you can see this name.",
-  continueToReview: "Continue to review",
-  validationErrors: {
-    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
-    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
-      "This address name is already used for this contact.",
-    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
-  },
-};
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 describe("ContactsAddAddressName", () => {
   it("should render the default label with an enabled review action", () => {
@@ -36,21 +27,23 @@ describe("ContactsAddAddressName", () => {
           label: ContactAddressLabelSchema.parse("Ethereum"),
           validationError: null,
         }}
-        labels={labels}
+
         onChangeText={onChangeText}
         onContinue={onContinue}
       />,
     );
 
-    expect(screen.UNSAFE_getByProps({ title: "Name address" }).props.title).toBe("Name address");
+    expect(screen.UNSAFE_getByProps({ title: "contacts.addAddressName.title" }).props.title).toBe(
+      "contacts.addAddressName.title",
+    );
     expect(screen.getByTestId("contacts-add-address-name-input").props).toMatchObject({
-      label: "Address name",
+      label: "contacts.addAddressName.inputLabel",
       maxLength: CONTACT_ADDRESS_LABEL_MAX_LENGTH,
       value: "Ethereum",
     });
     expect(screen.getByTestId("contacts-add-address-name-count")).toHaveTextContent("8/32");
     expect(screen.getByTestId("contacts-add-address-name-disclaimer").props.description).toBe(
-      "Only you can see this name.",
+      "contacts.addAddressName.namingDisclaimer",
     );
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
     expect(screen.getByTestId("contacts-add-address-name-continue").props.icon).toEqual(
@@ -73,7 +66,7 @@ describe("ContactsAddAddressName", () => {
           label: ContactAddressLabelSchema.parse("Ethereum"),
           validationError: null,
         }}
-        labels={labels}
+
         bottomOffset={320}
         onChangeText={jest.fn()}
         onContinue={jest.fn()}
@@ -95,7 +88,7 @@ describe("ContactsAddAddressName", () => {
         label: null,
         validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
-      helperText: "Special characters are not allowed.",
+      helperText: "contacts.addAddressName.invalidLabel",
     },
     {
       name: "duplicate label",
@@ -105,7 +98,7 @@ describe("ContactsAddAddressName", () => {
         label: null,
         validationError: DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
-      helperText: "This address name is already used for this contact.",
+      helperText: "contacts.addAddressName.duplicateLabel",
     },
     {
       name: "too long label",
@@ -115,7 +108,7 @@ describe("ContactsAddAddressName", () => {
         label: null,
         validationError: CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
       },
-      helperText: "This address name is too long.",
+      helperText: "contacts.addAddressName.labelTooLong",
     },
     {
       name: "empty label",
@@ -135,7 +128,7 @@ describe("ContactsAddAddressName", () => {
     render(
       <ContactsAddAddressName
         addressLabel={addressLabel}
-        labels={labels}
+
         onChangeText={jest.fn()}
         onContinue={jest.fn()}
       />,

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressName.native.tsx
@@ -9,12 +9,17 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
-import type { AddAddressLabelState, AddAddressNameLabels } from "../../state/types";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import type { AddAddressLabelState } from "../../state/types";
+import { useTranslation } from "@shared/i18n";
 
 export type ContactsAddAddressNameProps = Readonly<{
   addressLabel: AddAddressLabelState;
-  labels: AddAddressNameLabels;
   bottomOffset?: number;
   onChangeText: (value: string) => void;
   onContinue: () => void;
@@ -22,13 +27,18 @@ export type ContactsAddAddressNameProps = Readonly<{
 
 export function ContactsAddAddressName({
   addressLabel,
-  labels,
   bottomOffset = 0,
   onChangeText,
   onContinue,
 }: ContactsAddAddressNameProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const validationErrors = {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.labelTooLong"),
+  };
   const validationMessage = addressLabel.validationError
-    ? labels.validationErrors[addressLabel.validationError]
+    ? validationErrors[addressLabel.validationError]
     : undefined;
 
   return (
@@ -36,7 +46,7 @@ export function ContactsAddAddressName({
       testID="contacts-add-address-name-screen"
       style={{ bottom: 0, paddingBottom: bottomOffset > 0 ? bottomOffset : 32 }}
     >
-      <BottomSheetHeader density="expanded" title={labels.title} />
+      <BottomSheetHeader density="expanded" title={t("contacts.addAddressName.title")} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
         <Box lx={{ gap: "s16" }}>
           <Box lx={{ gap: "s8" }}>
@@ -44,7 +54,7 @@ export function ContactsAddAddressName({
               testID="contacts-add-address-name-input"
               autoFocus
               autoCorrect={false}
-              label={labels.inputLabel}
+              label={t("contacts.addAddressName.inputLabel")}
               value={addressLabel.value}
               helperText={validationMessage}
               maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
@@ -65,7 +75,7 @@ export function ContactsAddAddressName({
           <Banner
             testID="contacts-add-address-name-disclaimer"
             appearance="info"
-            description={labels.namingDisclaimer}
+            description={t("contacts.addAddressName.namingDisclaimer")}
           />
         </Box>
         <Button
@@ -77,7 +87,7 @@ export function ContactsAddAddressName({
           icon={LedgerLogo}
           onPress={onContinue}
         >
-          {labels.continueToReview}
+          {t("contacts.addAddressName.continueToReview")}
         </Button>
       </Box>
     </BottomSheetView>

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/types.ts
@@ -14,7 +14,6 @@ export type ContactsAddAddressNameLabels = Readonly<{
 export type ContactsAddAddressNameProps = Readonly<{
   addressEntry: ValidAddAddressEntryState;
   addressLabel: AddAddressLabelState;
-  labels: ContactsAddAddressNameLabels;
   showConfirmedAddress?: boolean;
   onAddressLabelChange: (value: string) => void;
   onContinue: () => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/useContactsAddAddressNameViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/useContactsAddAddressNameViewModel.web.ts
@@ -1,21 +1,37 @@
-import { useCallback, useMemo, type ChangeEvent } from "react";
+import { useCallback, type ChangeEvent } from "react";
 import type { ContactsAddAddressNameProps, ContactsAddAddressNameViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
 
 export function useContactsAddAddressNameViewModel({
   addressEntry,
   addressLabel,
-  labels,
   showConfirmedAddress = true,
   onAddressLabelChange,
   onContinue,
 }: ContactsAddAddressNameProps): ContactsAddAddressNameViewProps {
-  const validationMessage = useMemo(
-    () =>
-      addressLabel.validationError
-        ? labels.validationErrors[addressLabel.validationError]
-        : undefined,
-    [addressLabel.validationError, labels.validationErrors],
-  );
+  const { t } = useTranslation();
+  const labels = {
+    inputLabel: t("contacts.addAddressName.inputLabel"),
+    namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+    namingDisclaimerAccessibilityLabel: t(
+      "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+    ),
+    continueToReview: t("contacts.addAddressName.continueToReview"),
+    validAddress: t("contacts.addAddressEntry.validAddress"),
+    validationErrors: {
+      [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+      [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+      [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+    },
+  };
+  const validationMessage = addressLabel.validationError
+    ? labels.validationErrors[addressLabel.validationError]
+    : undefined;
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => onAddressLabelChange(event.target.value),
     [onAddressLabelChange],

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
@@ -1,43 +1,17 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
-import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  ContactAddressLabelSchema,
-  ContactAddressValueSchema,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-} from "@domain/entity-contact";
-import type { AddAddressEntryLabels, AddAddressNameLabels } from "../../state/types";
+import { ContactAddressLabelSchema, ContactAddressValueSchema } from "@domain/entity-contact";
 import {
   ContactsAddAddressFlowContent,
   type ContactsAddAddressFlowContentProps,
 } from "./ContactsAddAddressFlowContent";
 
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 const address = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
-const entryLabels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address or ENS",
-  confirmAddress: "Confirm address",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Address is sanctioned",
-  validationUnavailable: "Address validation is unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
-};
-const nameLabels: AddAddressNameLabels = {
-  title: "Address name",
-  inputLabel: "Name",
-  namingDisclaimer: "Only you can see this name.",
-  continueToReview: "Continue to review",
-  validationErrors: {
-    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Invalid characters",
-    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Duplicate name",
-    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "Name is too long",
-  },
-};
+
 function createProps(
   step: ContactsAddAddressFlowContentProps["step"],
 ): ContactsAddAddressFlowContentProps {
@@ -50,7 +24,6 @@ function createProps(
         resolvedAddress: address,
         inputMethod: "manual",
       },
-      labels: entryLabels,
       onChangeText: jest.fn(),
       onConfirm: jest.fn(),
       onQrCodeClick: jest.fn(),
@@ -62,7 +35,6 @@ function createProps(
         label: ContactAddressLabelSchema.parse("Ethereum"),
         validationError: null,
       },
-      labels: nameLabels,
       onChangeText: jest.fn(),
       onContinue: jest.fn(),
     },
@@ -71,14 +43,6 @@ function createProps(
       currency: "Ethereum",
       network: "Ethereum",
       name: "Ethereum",
-      labels: {
-        title: "Review address",
-        addressLabel: "Address",
-        currencyLabel: "Currency",
-        networkLabel: "Network",
-        nameLabel: "Address name",
-        continue: "Confirm address",
-      },
       onContinue: jest.fn(),
     },
   };

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -4,10 +4,9 @@ import {
   ContactAddressLabelSchema,
   ContactAddressValueSchema,
   type ContactAddress,
-  type ContactAddressLabelValidationErrorName,
   type ContactId,
 } from "@domain/entity-contact";
-import type { AddAddressEntryLabels, AddAddressFlowState } from "../../state/types";
+import type { AddAddressFlowState } from "../../state/types";
 import {
   ContactsAddAddressFlowContent,
   type ContactsAddAddressFlowContentProps,
@@ -15,8 +14,10 @@ import {
   shouldUseAddAddressFlowBackNavigation,
   type AddAddressWebFlowStep,
 } from "./ContactsAddAddressFlowContent";
-import type { ContactsAddAddressNameLabels } from "../AddressName/types";
-import type { ContactsAddAddressReviewLabels } from "../Review/types";
+
+jest.mock("@shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 type OpenAddAddressFlowState = Exclude<AddAddressFlowState, { status: "closed" }>;
 
@@ -24,35 +25,6 @@ function createState(status: OpenAddAddressFlowState["status"]): OpenAddAddressF
   return { status } as OpenAddAddressFlowState;
 }
 
-const entryLabels: AddAddressEntryLabels = {
-  title: "Enter address",
-  addressPlaceholder: "Address",
-  confirmAddress: "Continue",
-  validatingAddress: "Validating address",
-  validAddress: "Valid address",
-  invalidAddress: "Invalid address",
-  domainNotFound: "Domain not found",
-  sanctionedAddress: "Address is sanctioned",
-  validationUnavailable: "Address validation is unavailable",
-  ensDisclaimer: "ENS disclaimer",
-  ensDisclaimerDescription: "ENS names can change over time.",
-};
-const nameLabels: ContactsAddAddressNameLabels = {
-  inputLabel: "Address name",
-  namingDisclaimer: "Address naming disclaimer",
-  namingDisclaimerAccessibilityLabel: "Address name information",
-  continueToReview: "Continue to review",
-  validAddress: "Valid address",
-  validationErrors: {} as Record<ContactAddressLabelValidationErrorName, string>,
-};
-const reviewLabels: ContactsAddAddressReviewLabels = {
-  title: "Review address",
-  addressLabel: "Address",
-  currencyLabel: "Currency",
-  networkLabel: "Network",
-  nameLabel: "Address name",
-  continue: "Confirm address",
-};
 const address = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
 const label = ContactAddressLabelSchema.parse("Ethereum");
 
@@ -91,9 +63,6 @@ function createContentProps(
 ): ContactsAddAddressFlowContentProps {
   return {
     state,
-    entryLabels,
-    nameLabels,
-    reviewLabels,
     onAddressChange: jest.fn(),
     onContinueFromAddressDetails: jest.fn(),
     onAddressLabelChange: jest.fn(),

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.tsx
@@ -2,13 +2,8 @@ import React from "react";
 import { ContactsAddAddressEntry } from "../AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry";
 import type { SanctionedAddressBannerProps } from "../../components/SanctionedAddressBanner/types";
 import { ContactsAddAddressNameInput } from "../AddressName/components/Input/ContactsAddAddressNameInput";
-import type { ContactsAddAddressNameLabels } from "../AddressName/types";
-import { ContactsAddAddressReview, type ContactsAddAddressReviewLabels } from "../Review";
-import type {
-  AddAddressEntryLabels,
-  AddAddressFlowState,
-  AddAddressInputSource,
-} from "../../state/types";
+import { ContactsAddAddressReview } from "../Review";
+import type { AddAddressFlowState, AddAddressInputSource } from "../../state/types";
 
 export type AddAddressWebFlowStep = "currency" | "address" | "name" | "review" | "success";
 
@@ -17,10 +12,7 @@ type AddAddressFlowContentState = Exclude<OpenAddAddressFlowState, { status: "se
 
 export type ContactsAddAddressFlowContentProps = Readonly<{
   state: AddAddressFlowContentState;
-  entryLabels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
-  nameLabels: ContactsAddAddressNameLabels;
-  reviewLabels?: ContactsAddAddressReviewLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;
@@ -57,10 +49,7 @@ export function shouldUseAddAddressFlowBackNavigation(state: OpenAddAddressFlowS
 
 export function ContactsAddAddressFlowContent({
   state,
-  entryLabels,
   sanctionedAddressBanner,
-  nameLabels,
-  reviewLabels,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -73,9 +62,7 @@ export function ContactsAddAddressFlowContent({
         <ContactsAddAddressEntry
           addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
-          labels={entryLabels}
           sanctionedAddressBanner={sanctionedAddressBanner}
-          nameLabels={nameLabels}
           onAddressChange={onAddressChange}
           onAddressLabelChange={onAddressLabelChange}
           onConfirm={onContinueFromAddressDetails}
@@ -86,7 +73,6 @@ export function ContactsAddAddressFlowContent({
         <ContactsAddAddressNameInput
           addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
-          labels={nameLabels}
           showConfirmedAddress={state.entryMode === "mad"}
           onAddressLabelChange={onAddressLabelChange}
           onContinue={onContinueFromName}
@@ -95,17 +81,12 @@ export function ContactsAddAddressFlowContent({
     case "confirmationRequired":
       return null;
     case "reviewingAddress":
-      if (
-        state.entryMode === "prefilled" &&
-        state.displayContext !== null &&
-        reviewLabels !== undefined
-      ) {
+      if (state.entryMode === "prefilled" && state.displayContext !== null) {
         return (
           <ContactsAddAddressReview
             addressEntry={state.addressEntry}
             addressLabel={state.addressLabel}
             displayContext={state.displayContext}
-            labels={reviewLabels}
             onContinue={onContinueFromReview}
           />
         );

--- a/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.native.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { ContactsAddAddressReviewViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
 
 function ReviewRow({
   label,
@@ -24,7 +25,10 @@ function ReviewRow({
   );
 }
 
-export type ContactsAddAddressReviewNativeProps = ContactsAddAddressReviewViewProps &
+export type ContactsAddAddressReviewNativeProps = Omit<
+  ContactsAddAddressReviewViewProps,
+  "labels"
+> &
   Readonly<{
     bottomOffset?: number;
   }>;
@@ -34,35 +38,35 @@ export function ContactsAddAddressReview({
   currency,
   network,
   name,
-  labels,
   bottomOffset = 0,
   onContinue,
 }: ContactsAddAddressReviewNativeProps): React.JSX.Element {
+  const { t } = useTranslation();
   return (
     <BottomSheetView
       testID="contacts-add-address-review"
       style={{ bottom: 0, paddingBottom: 32 + bottomOffset }}
     >
-      <BottomSheetHeader density="expanded" title={labels.title} />
+      <BottomSheetHeader density="expanded" title={t("contacts.addAddressReview.title")} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
         <Box lx={{ gap: "s16" }}>
           <ReviewRow
-            label={labels.addressLabel}
+            label={t("contacts.addAddressReview.addressLabel")}
             testID="contacts-add-address-review-address"
             value={address}
           />
           <ReviewRow
-            label={labels.currencyLabel}
+            label={t("contacts.addAddressReview.currencyLabel")}
             testID="contacts-add-address-review-currency"
             value={currency}
           />
           <ReviewRow
-            label={labels.networkLabel}
+            label={t("contacts.addAddressReview.networkLabel")}
             testID="contacts-add-address-review-network"
             value={network}
           />
           <ReviewRow
-            label={labels.nameLabel}
+            label={t("contacts.addAddressReview.nameLabel")}
             testID="contacts-add-address-review-name"
             value={name}
           />
@@ -75,7 +79,7 @@ export function ContactsAddAddressReview({
           icon={LedgerLogo}
           onPress={onContinue}
         >
-          {labels.continue}
+          {t("contacts.addAddressReview.continue")}
         </Button>
       </Box>
     </BottomSheetView>

--- a/features/flow/flow-contacts-add-address/src/screens/Review/types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/types.ts
@@ -17,7 +17,6 @@ export type ContactsAddAddressReviewProps = Readonly<{
   addressEntry: ValidAddAddressEntryState;
   addressLabel: ValidAddAddressLabelState;
   displayContext: AddAddressDisplayContext;
-  labels: ContactsAddAddressReviewLabels;
   onContinue: () => void;
 }>;
 

--- a/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.ts
@@ -1,18 +1,26 @@
 import type { ContactsAddAddressReviewProps, ContactsAddAddressReviewViewProps } from "./types";
+import { useTranslation } from "@shared/i18n";
 
 export function useContactsAddAddressReviewViewModel({
   addressEntry,
   addressLabel,
   displayContext,
-  labels,
   onContinue,
 }: ContactsAddAddressReviewProps): ContactsAddAddressReviewViewProps {
+  const { t } = useTranslation();
   return {
     address: addressEntry.resolvedAddress,
     currency: displayContext.assetDisplayName,
     network: displayContext.network.displayName,
     name: addressLabel.label,
-    labels,
+    labels: {
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    },
     onContinue,
   };
 }


### PR DESCRIPTION
## Summary

- Delete `useAddAddressLabels` hook (dissolved)
- Call `useTranslation` inline in `useContactsAddAddressEntryViewModel`, `ContactsAddAddressName`, `useContactsAddAddressNameViewModel`, `ContactsAddAddressReview`, `useContactsAddAddressReviewViewModel`
- Update all 5 test files: mock `@shared/i18n` instead of the old hook
- Clean up `useContactsViewModel` (desktop) — remove 3 `useMemo` label blocks
- Add `@shared/i18n` dependency

Part of stack: LIVE-37080 (6/7) — stacks on #21759

## Test plan
- [ ] Add address flow (entry → name → review) shows correct translations
- [ ] Tests pass with `@shared/i18n` mock