### PR TITLE
fix(contacts): reject latin diacritics in names (LIVE-37180)

### DIFF
--- a/.changeset/contacts-reject-name-diacritics.md
+++ b/.changeset/contacts-reject-name-diacritics.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-contact": minor
+---
+
+Reject Latin diacritics in contact names so device add-address does not fail on unsupported glyphs, while still allowing letters from other scripts.

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -16,11 +16,12 @@ This package describes what Contacts flows manipulate:
 
 `currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. `address` is intentionally stored as a generic non-empty string because address parsing and currency-specific validation belong to later flow or integration adapters. Asset names, tickers, icons, and network display data are also resolved later by those adapters.
 
-Contact names and address labels are limited to 32 characters. Address labels must contain at least
-one letter or number and may also include punctuation and spaces. The domain validation helpers
-treat a blank draft as incomplete without surfacing an error and can reject labels already used by
-the same contact. Input schemas trim surrounding whitespace and normalize Unicode NFC before
-validation. Duplicate comparison ignores casing.
+Contact names and address labels are limited to 32 characters. Names may use letters from any
+script, digits, spaces, apostrophes, and hyphens, but not Latin diacritics. Address labels must
+contain at least one letter or number and may also include punctuation and spaces. The domain
+validation helpers treat a blank draft as incomplete without surfacing an error and can reject
+labels already used by the same contact. Input schemas trim surrounding whitespace and normalize
+Unicode NFC before validation. Duplicate comparison ignores casing.
 
 Each contact with one or more addresses carries `deviceCredentials` returned by Device Intents.
 Each address carries its own device context: `blockchainFamily`, `chainId`, and `hmacRest`.

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -48,15 +48,19 @@ describe("ContactSchema", () => {
   });
 
   it("accepts international contact names with numbers", () => {
-    expect(ContactNameInputSchema.parse(" E\u0301lodie ")).toBe("Élodie");
+    expect(ContactNameInputSchema.parse(" Jean-Luc ")).toBe("Jean-Luc");
     expect(ContactNameSchema.parse("Jean-Luc O'Connor")).toBe("Jean-Luc O'Connor");
     expect(ContactNameSchema.parse("Coinbase 1")).toBe("Coinbase 1");
     expect(ContactNameSchema.parse("Web3")).toBe("Web3");
     expect(ContactNameSchema.parse("Алексей")).toBe("Алексей");
     expect(ContactNameSchema.parse("مريم")).toBe("مريم");
+    expect(ContactNameSchema.parse("田中")).toBe("田中");
+    expect(ContactNameSchema.parse("नमस्ते")).toBe("नमस्ते");
   });
 
   it("rejects unsupported contact name characters", () => {
+    expect(() => ContactNameSchema.parse("Élodie")).toThrow();
+    expect(() => ContactNameSchema.parse("E\u0301lodie")).toThrow();
     expect(() => ContactNameSchema.parse("\u0301")).toThrow();
     expect(() => ContactNameSchema.parse("1Password")).toThrow();
     expect(() => ContactNameSchema.parse("@Olive")).toThrow();

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -18,6 +18,7 @@ export const ContactCurrencyIdSchema = z.union([CryptoCurrencyIdSchema, TokenCur
 
 const ContactNamePattern =
   /^\p{L}[\p{L}\p{Mn}\p{Mc}\p{Nd}]*(?:[\p{Zs}'\u2019-][\p{L}\p{Nd}][\p{L}\p{Mn}\p{Mc}\p{Nd}]*)*$/u;
+const LatinDiacriticPattern = /\p{Script=Latin}\p{M}/u;
 const ContactAddressLabelPattern = /^(?=.*[A-Za-z0-9])[\x20-\x7E]+$/;
 
 export const CONTACT_NAME_MAX_LENGTH = 32;
@@ -30,6 +31,9 @@ export const ContactNameSchema = z
     error: () => new InvalidContactNameError().name,
   })
   .regex(ContactNamePattern, {
+    error: () => new InvalidContactNameError().name,
+  })
+  .refine(name => !LatinDiacriticPattern.test(name.normalize("NFD")), {
     error: () => new InvalidContactNameError().name,
   })
   .brand<"ContactName">();

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -39,29 +39,18 @@ describe("contact name validation", () => {
   it("reports the stable InvalidContactNameError name for a non-empty invalid draft name", () => {
     expect(getContactNameValidationError("Olive@2")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
     expect(getContactNameValidationError("1Password")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(getContactNameValidationError("Élodie")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
   });
 
   it("reports a duplicate name after trimming, normalizing, and folding case", () => {
-    const existingNames = [ContactNameSchema.parse("Élodie")];
+    const existingNames = [ContactNameSchema.parse("Алексей")];
 
-    expect(getContactNameValidationError(" e\u0301LODIE ", existingNames)).toBe(
+    expect(getContactNameValidationError(" алексей ", existingNames)).toBe(
       DUPLICATE_CONTACT_NAME_ERROR_NAME,
     );
-    expect(isValidContactName(" e\u0301LODIE ", existingNames)).toBe(false);
-    expect(normalizeContactNameForComparison(" Élodie ")).toBe(
-      normalizeContactNameForComparison("e\u0301LODIE"),
-    );
-  });
-
-  it("reports a duplicate name after trimming, normalizing, and folding case", () => {
-    const existingNames = [ContactNameSchema.parse("Élodie")];
-
-    expect(getContactNameValidationError(" e\u0301LODIE ", existingNames)).toBe(
-      DUPLICATE_CONTACT_NAME_ERROR_NAME,
-    );
-    expect(isValidContactName(" e\u0301LODIE ", existingNames)).toBe(false);
-    expect(normalizeContactNameForComparison(" Élodie ")).toBe(
-      normalizeContactNameForComparison("e\u0301LODIE"),
+    expect(isValidContactName(" алексей ", existingNames)).toBe(false);
+    expect(normalizeContactNameForComparison(" Алексей ")).toBe(
+      normalizeContactNameForComparison("алексей"),
     );
   });
 
@@ -87,8 +76,8 @@ describe("contact name validation", () => {
     expect(parseContactName("  Ben  ")).toBe("Ben");
   });
 
-  it("parseContactName returns a NFC-normalized name", () => {
-    expect(parseContactName(" E\u0301lodie ")).toBe("Élodie");
+  it("parseContactName returns a trimmed name", () => {
+    expect(parseContactName(" Алексей ")).toBe("Алексей");
   });
 });
 

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/model/controller.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/model/controller.web.test.ts
@@ -68,19 +68,11 @@ describe("createAddContactController", () => {
     expect(createContact).toHaveBeenCalledWith({ name: "Olivia" });
   });
 
-  it("normalizes a contact name before calling the creation port", async () => {
-    const createContact = jest.fn(async ({ name }) =>
-      contact({
-        id: "contact-elodie",
-        isMe: false,
-        name,
-        addresses: [],
-      }),
-    );
+  it("rejects a contact name with diacritics before calling the creation port", async () => {
+    const createContact = jest.fn();
     const controller = createAddContactController(stubContactCreationPort(createContact));
 
-    await controller.save(" E\u0301lodie ");
-
-    expect(createContact).toHaveBeenCalledWith({ name: "Élodie" });
+    await expect(controller.save(" E\u0301lodie ")).rejects.toThrow();
+    expect(createContact).not.toHaveBeenCalled();
   });
 });

--- a/features/flow/flow-contacts-list/src/model/viewModel.web.test.ts
+++ b/features/flow/flow-contacts-list/src/model/viewModel.web.test.ts
@@ -24,7 +24,7 @@ describe("createEmptyContactsListViewModel", () => {
 
   it("derives the initial and address count from Me", () => {
     const me = mockMeContact({
-      name: "Élodie",
+      name: "Алексей",
       addresses: [mockContactAddress()],
     });
 
@@ -32,8 +32,8 @@ describe("createEmptyContactsListViewModel", () => {
       displayMode: "empty",
       me: {
         contactId: "contact-me",
-        name: "Élodie (Me)",
-        initial: "É",
+        name: "Алексей (Me)",
+        initial: "А",
         addressCount: 1,
       },
     });
@@ -152,17 +152,17 @@ describe("createPopulatedContactsListViewModel", () => {
     const contacts = [
       me,
       mockContact({
-        id: "contact-elodie",
-        name: "Élodie",
+        id: "contact-alexei",
+        name: "Алексей",
         addresses: [mockContactAddress(), mockContactAddress({ id: "address-polygon" })],
       }),
     ];
 
     expect(createPopulatedContactsListViewModel(me, contacts).savedContacts).toEqual([
       {
-        contactId: "contact-elodie",
-        name: "Élodie",
-        initial: "É",
+        contactId: "contact-alexei",
+        name: "Алексей",
+        initial: "А",
         addressCount: 2,
       },
     ]);

--- a/libs/live-e2e-shared/src/contacts.ts
+++ b/libs/live-e2e-shared/src/contacts.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 // Every separator a user can type. The straight `'` is excluded: iOS rewrites it to `’` on input.
-const CONTACT_NAME_FORMAT_SAMPLE = "O’Neil-Zoé";
+const CONTACT_NAME_FORMAT_SAMPLE = "O’Neil-Zoe";
 
 /**
  * Valid contact name, unique per call — duplicates are rejected on save.


### PR DESCRIPTION
## Summary
- Fixes [LIVE-37180](https://ledgerhq.atlassian.net/browse/LIVE-37180): adding an address to a contact whose name has Latin accents (`é`, `î`, …) fails on device with "Your ledger device rejected the contact details".
- Contact names now reject Latin diacritics at the domain schema, while still allowing other scripts (Cyrillic, Arabic, CJK), digits, spaces, apostrophes, and hyphens.

LWD

<img width="488" height="176" alt="Screenshot 2026-09-10 at 11 43 48 AM" src="https://github.com/user-attachments/assets/4b50e844-ee2c-4f3b-90da-9af31875a42a" />

LWM

https://github.com/user-attachments/assets/4d730f0d-1800-44e3-9416-16fea4b07121


## Test plan
- [ ] Add/rename a contact to `Elodie` — save succeeds.
- [ ] Add/rename a contact to `Élodie` or `élodie` — invalid name, save stays disabled.
- [ ] Names like `Алексей`, `مريم`, `Jean-Luc O'Connor` still save.
- [ ] Confirm add-address is no longer reachable for a newly created accented name.

[LIVE-37180]: https://ledgerhq.atlassian.net/browse/LIVE-37180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ