### PR TITLE
[LWDM] feat(pay-card): orchestrate the flow display state (LIVE-37217)

### DIFF
--- a/.changeset/LIVE-37217-pay-card-display-state.md
+++ b/.changeset/LIVE-37217-pay-card-display-state.md
@@ -1,0 +1,8 @@
+---
+"@features/flow-pay-card-auth": minor
+"@features/flow-pay-card": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Resolve a single Pay Card display state so the card face, onboarding widget and login CTA no longer overlap, and hold them back until the stored session is read

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/index.test.tsx
@@ -82,15 +82,26 @@ describe("RightPanel", () => {
   });
 
   describe("card variant", () => {
-    it("renders the Pay Card visual with the mock balance and no swap webview", () => {
+    it("renders the bare artwork while the card session is unresolved, and no swap webview", () => {
       render(<RightPanel variant="card" />);
+
+      expect(screen.getByTestId("pay-card-container")).toBeVisible();
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.queryByTestId("card-visual")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("swap-webview-embedded")).not.toBeInTheDocument();
+      expect(mockUseSwapViewModel).not.toHaveBeenCalled();
+    });
+
+    it("hands the countervalue formatter and the balance label to the visual once signed in", () => {
+      render(<RightPanel variant="card" />, {
+        initialState: { payCardAuth: { hasCard: true, status: "signedIn" } },
+      });
 
       expect(screen.getByTestId("pay-card-container")).toBeVisible();
       expect(screen.getByTestId("card-visual")).toBeVisible();
       expect(screen.getByTestId("card-visual-amount")).toBeVisible();
       expect(screen.getByText("Balance")).toBeVisible();
       expect(screen.queryByTestId("swap-webview-embedded")).not.toBeInTheDocument();
-      expect(mockUseSwapViewModel).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/payCardRestore.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/payCardRestore.test.ts
@@ -44,6 +44,6 @@ describe("the payCard blob restored into the desktop store", () => {
   it("keeps the runtime auth slice out of the restore", () => {
     const state = restoreAll(blob);
 
-    expect(state.payCardAuth).toEqual({ hasCard: false, isSignedIn: false });
+    expect(state.payCardAuth).toEqual({ hasCard: false, status: "unknown" });
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/__tests__/payCardRestore.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/payCardRestore.test.ts
@@ -44,6 +44,6 @@ describe("the payCard blob restored into the mobile store", () => {
   it("keeps the runtime auth slice out of the restore", () => {
     const state = restoreAll(blob);
 
-    expect(state.payCardAuth).toEqual({ hasCard: false, isSignedIn: false });
+    expect(state.payCardAuth).toEqual({ hasCard: false, status: "unknown" });
   });
 });

--- a/features/flow/pay-card-auth/src/components/CardLogin/__tests__/useCardLoginViewModel.web.test.tsx
+++ b/features/flow/pay-card-auth/src/components/CardLogin/__tests__/useCardLoginViewModel.web.test.tsx
@@ -53,7 +53,6 @@ describe("mapSnapshotToViewModel", () => {
   });
 
   it.each([
-    "hydrating",
     "preparingAttempt",
     "awaitingHostedLogin",
     "validatingCallback",
@@ -66,9 +65,10 @@ describe("mapSnapshotToViewModel", () => {
     expect(mapSnapshotToViewModel(value, null, copy, onLoginPress, intro)?.isLoading).toBe(true);
   });
 
-  it("offers nothing once the card holder is signed in", () => {
-    // `More` holds the screen from here, and it reads the same flag to know it.
-    expect(mapSnapshotToViewModel("ready", null, copy, onLoginPress, intro)).toBeNull();
+  it.each(["hydrating", "ready"] as const)("offers nothing in %s", value => {
+    // `hydrating` is still reading the stored session, so a CTA here would flash for a holder who
+    // turns out to be signed in; `ready` means they already are, and `More` holds the screen.
+    expect(mapSnapshotToViewModel(value, null, copy, onLoginPress, intro)).toBeNull();
   });
 
   it("shows no message while there is no error", () => {
@@ -180,7 +180,7 @@ async function completeLogin(
   act(() => result.current?.onLoginPress());
   act(() => result.current?.intro.onActionPress("logIn"));
 
-  await waitFor(() => expect(store.getState().payCardAuth.isSignedIn).toBe(true));
+  await waitFor(() => expect(store.getState().payCardAuth.status).toBe("signedIn"));
 }
 
 describe("useCardLoginViewModel intro", () => {

--- a/features/flow/pay-card-auth/src/components/CardLogin/useCardLoginViewModel.ts
+++ b/features/flow/pay-card-auth/src/components/CardLogin/useCardLoginViewModel.ts
@@ -69,8 +69,10 @@ export function mapSnapshotToViewModel(
   onLoginPress: () => void,
   intro: CardLoginIntroViewProps,
 ): CardLoginViewModel {
-  // The card holder is signed in, so there is no login left to offer. `More` holds the screen.
-  if (value === "ready") {
+  // Nothing to offer yet. `hydrating` is still reading the stored session, so a login CTA here would
+  // flash for a holder who turns out to be signed in; `ready` means they already are, and `More`
+  // holds the screen.
+  if (value === "hydrating" || value === "ready") {
     return null;
   }
 

--- a/features/flow/pay-card-auth/src/hooks/__tests__/useCardAuthStatus.web.test.tsx
+++ b/features/flow/pay-card-auth/src/hooks/__tests__/useCardAuthStatus.web.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { payCardAuthSlice, setSignedIn } from "../../state/slice";
+import { useCardAuthStatus } from "../useCardAuthStatus";
+
+function renderCardAuthStatus(dispatchSignedIn?: boolean) {
+  const store = configureStore({ reducer: { payCardAuth: payCardAuthSlice.reducer } });
+  if (dispatchSignedIn !== undefined) {
+    store.dispatch(setSignedIn(dispatchSignedIn));
+  }
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return renderHook(() => useCardAuthStatus(), { wrapper });
+}
+
+describe("useCardAuthStatus", () => {
+  it("answers unknown while the session is still being resolved", () => {
+    expect(renderCardAuthStatus().result.current).toBe("unknown");
+  });
+
+  it("answers signedOut once the machine reports nobody is signed in", () => {
+    expect(renderCardAuthStatus(false).result.current).toBe("signedOut");
+  });
+
+  it("answers signedIn while a Card session is live", () => {
+    expect(renderCardAuthStatus(true).result.current).toBe("signedIn");
+  });
+});

--- a/features/flow/pay-card-auth/src/hooks/useCardAuthStatus.ts
+++ b/features/flow/pay-card-auth/src/hooks/useCardAuthStatus.ts
@@ -1,0 +1,12 @@
+import { useSelector } from "react-redux";
+import { selectCardAuthStatus } from "../state/selectors";
+import type { PayCardAuthStatus } from "../state/types";
+
+/**
+ * Where the Card session stands, for hosts that compose the Card flow around it. Unlike
+ * {@link useIsCardSignedIn}, this tells "still resolving" (`unknown`) from "signed out", so a host
+ * can hold the login CTA back until the login machine has hydrated the stored session.
+ */
+export function useCardAuthStatus(): PayCardAuthStatus {
+  return useSelector(selectCardAuthStatus);
+}

--- a/features/flow/pay-card-auth/src/index.native.ts
+++ b/features/flow/pay-card-auth/src/index.native.ts
@@ -3,5 +3,7 @@ export type { CardLoginProps, PayCardLoginTrackEvent } from "./components/CardLo
 export { openHostedLoginInSecureBrowser } from "./components/CardLogin/openHostedLogin.native";
 export type { OpenHostedLogin, HostedLoginResult } from "./state/types";
 export type { CardLoginOauthConfig, PayCardAuthCallback } from "./state/types";
+export type { PayCardAuthStatus } from "./state/types";
 export { useIsCardSignedIn } from "./hooks/useIsCardSignedIn";
+export { useCardAuthStatus } from "./hooks/useCardAuthStatus";
 export { useCardLogout } from "./hooks/useCardLogout";

--- a/features/flow/pay-card-auth/src/index.ts
+++ b/features/flow/pay-card-auth/src/index.ts
@@ -2,5 +2,7 @@ export { CardLogin } from "./components/CardLogin";
 export type { CardLoginProps, PayCardLoginTrackEvent } from "./components/CardLogin/types";
 export type { OpenHostedLogin, HostedLoginResult } from "./state/types";
 export type { CardLoginOauthConfig, PayCardAuthCallback } from "./state/types";
+export type { PayCardAuthStatus } from "./state/types";
 export { useIsCardSignedIn } from "./hooks/useIsCardSignedIn";
+export { useCardAuthStatus } from "./hooks/useCardAuthStatus";
 export { useCardLogout } from "./hooks/useCardLogout";

--- a/features/flow/pay-card-auth/src/state/__tests__/slice.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/slice.native.test.ts
@@ -1,5 +1,10 @@
 import { payCardAuthSlice, payCardAuthInitialState, setHasCard, setSignedIn } from "../slice";
-import { selectPayCardAuth, selectHasCard, selectIsSignedIn } from "../selectors";
+import {
+  selectPayCardAuth,
+  selectHasCard,
+  selectCardAuthStatus,
+  selectIsSignedIn,
+} from "../selectors";
 
 const reducer = payCardAuthSlice.reducer;
 const root = (state = payCardAuthInitialState) => ({ payCardAuth: state });
@@ -19,25 +24,28 @@ describe("payCardAuth slice", () => {
     expect(reducer(withCard, setHasCard(false))).toEqual(payCardAuthInitialState);
   });
 
-  it("initializes signed out", () => {
-    expect(payCardAuthInitialState.isSignedIn).toBe(false);
+  it("initializes with an unresolved status", () => {
+    expect(payCardAuthInitialState.status).toBe("unknown");
   });
 
-  it("sets isSignedIn", () => {
+  it("maps a signed-in report onto the status", () => {
     const state = reducer(undefined, setSignedIn(true));
-    expect(state).toEqual({ ...payCardAuthInitialState, isSignedIn: true });
+    expect(state).toEqual({ ...payCardAuthInitialState, status: "signedIn" });
   });
 
-  it("clears isSignedIn", () => {
+  it("maps a signed-out report onto the status", () => {
     const signedIn = reducer(undefined, setSignedIn(true));
-    expect(reducer(signedIn, setSignedIn(false))).toEqual(payCardAuthInitialState);
+    expect(reducer(signedIn, setSignedIn(false))).toEqual({
+      ...payCardAuthInitialState,
+      status: "signedOut",
+    });
   });
 
-  it("keeps the two flags apart", () => {
-    // `hasCard` says the user owns a card. `isSignedIn` says a session is live. Neither implies
-    // the other.
+  it("keeps the card flag and the session status apart", () => {
+    // `hasCard` says the user owns a card. The status says where the session stands. Neither
+    // implies the other.
     const state = reducer(reducer(undefined, setHasCard(true)), setSignedIn(false));
-    expect(state).toEqual({ hasCard: true, isSignedIn: false });
+    expect(state).toEqual({ hasCard: true, status: "signedOut" });
   });
 });
 
@@ -52,8 +60,15 @@ describe("payCardAuth selectors", () => {
     expect(selectHasCard(root(reducer(undefined, setHasCard(true))))).toBe(true);
   });
 
-  it("selectIsSignedIn reflects the flag", () => {
+  it("selectCardAuthStatus reflects the tri-state", () => {
+    expect(selectCardAuthStatus(root())).toBe("unknown");
+    expect(selectCardAuthStatus(root(reducer(undefined, setSignedIn(true))))).toBe("signedIn");
+    expect(selectCardAuthStatus(root(reducer(undefined, setSignedIn(false))))).toBe("signedOut");
+  });
+
+  it("selectIsSignedIn is true only for a live session", () => {
     expect(selectIsSignedIn(root())).toBe(false);
+    expect(selectIsSignedIn(root(reducer(undefined, setSignedIn(false))))).toBe(false);
     expect(selectIsSignedIn(root(reducer(undefined, setSignedIn(true))))).toBe(true);
   });
 });

--- a/features/flow/pay-card-auth/src/state/selectors.ts
+++ b/features/flow/pay-card-auth/src/state/selectors.ts
@@ -1,4 +1,4 @@
-import type { PayCardAuthState } from "./types";
+import type { PayCardAuthState, PayCardAuthStatus } from "./types";
 
 type PayCardAuthStateRoot = {
   payCardAuth: PayCardAuthState;
@@ -12,7 +12,15 @@ export function selectHasCard(state: PayCardAuthStateRoot): boolean {
   return state.payCardAuth.hasCard;
 }
 
+/**
+ * Where the Card session stands. Hosts that must tell "still resolving" from "signed out" read this;
+ * everything that only cares whether a session is live reads {@link selectIsSignedIn}.
+ */
+export function selectCardAuthStatus(state: PayCardAuthStateRoot): PayCardAuthStatus {
+  return state.payCardAuth.status;
+}
+
 /** True while a Card session is live. `CardLogin` hides on it, and `More` shows on it. */
 export function selectIsSignedIn(state: PayCardAuthStateRoot): boolean {
-  return state.payCardAuth.isSignedIn;
+  return state.payCardAuth.status === "signedIn";
 }

--- a/features/flow/pay-card-auth/src/state/slice.ts
+++ b/features/flow/pay-card-auth/src/state/slice.ts
@@ -3,7 +3,7 @@ import type { PayCardAuthState } from "./types";
 
 export const payCardAuthInitialState: PayCardAuthState = {
   hasCard: false,
-  isSignedIn: false,
+  status: "unknown",
 };
 
 export const payCardAuthSlice = createSlice({
@@ -15,10 +15,11 @@ export const payCardAuthSlice = createSlice({
     },
     /**
      * Written by the login machine, and by `More` once a logout is through. It is runtime
-     * state, not a preference, so the slice must stay out of the persisted app state.
+     * state, not a preference, so the slice must stay out of the persisted app state. The boolean
+     * maps onto the tri-state: a machine can only report the two resolved outcomes, never `unknown`.
      */
     setSignedIn: (state, action: PayloadAction<boolean>) => {
-      state.isSignedIn = action.payload;
+      state.status = action.payload ? "signedIn" : "signedOut";
     },
   },
 });

--- a/features/flow/pay-card-auth/src/state/types.ts
+++ b/features/flow/pay-card-auth/src/state/types.ts
@@ -153,13 +153,21 @@ export type CardLoginEvent =
 
 /* --- Redux ----------------------------------------------------------------------------------- */
 
+/**
+ * Where the Card session stands. `unknown` is the boot value: the login machine is still reading the
+ * stored session, so no one can yet say whether the holder is signed in. It lets a host tell "still
+ * resolving" from "signed out", which a bare boolean cannot, and so keeps the login CTA from flashing
+ * before the machine hydrates.
+ */
+export type PayCardAuthStatus = "unknown" | "signedOut" | "signedIn";
+
 export type PayCardAuthState = Readonly<{
   hasCard: boolean;
   /**
-   * True while a Card session is live. The login machine owns the value, and every component outside
-   * it reads this flag instead, because two machines would each hydrate and neither would agree.
+   * Where the Card session stands. The login machine owns the value, and every component outside it
+   * reads this instead, because two machines would each hydrate and neither would agree.
    */
-  isSignedIn: boolean;
+  status: PayCardAuthStatus;
 }>;
 
 export type PayCardLoginIntroState = Readonly<{

--- a/features/flow/pay-card-details/src/__tests__/cardApiStore.tsx
+++ b/features/flow/pay-card-details/src/__tests__/cardApiStore.tsx
@@ -4,7 +4,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { cardManagementApi } from "@domain/api-card-management";
-import { payCardAuthSlice } from "@features/flow-pay-card-auth/state";
+import { payCardAuthSlice, type PayCardAuthState } from "@features/flow-pay-card-auth/state";
 import { cardApi, cardApiExtra } from "@shared/api-services";
 
 export const CARD_API_BASE_URL = "https://card.test";
@@ -45,7 +45,10 @@ export function makeCardApiStore({ signedIn = false }: { signedIn?: boolean } = 
       payCardAuth: payCardAuthSlice.reducer,
     },
     preloadedState: {
-      payCardAuth: { hasCard: signedIn, isSignedIn: signedIn },
+      payCardAuth: {
+        hasCard: signedIn,
+        status: signedIn ? "signedIn" : "signedOut",
+      } satisfies PayCardAuthState,
     },
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware({

--- a/features/flow/pay-card/src/Card.native.test.tsx
+++ b/features/flow/pay-card/src/Card.native.test.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
 import { View } from "react-native";
+import type { PayCardAuthStatus } from "@features/flow-pay-card-auth";
 import type { CardProps } from "./Card.types";
 
-let mockIsSignedIn = false;
+let mockStatus: PayCardAuthStatus = "unknown";
 
 jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogin: () => <View testID="card-login" />,
-  useIsCardSignedIn: () => mockIsSignedIn,
+  useCardAuthStatus: () => mockStatus,
 }));
 
 jest.mock("@features/flow-pay-card-details", () => ({
+  CardArtwork: () => <View testID="card-artwork" />,
   CardDetails: ({ cardVisual }: { cardVisual?: unknown }) => (
     <View testID={cardVisual ? "card-details-with-visual" : "card-details"} />
   ),
@@ -41,48 +43,80 @@ const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => (
 
 describe("Card (native)", () => {
   beforeEach(() => {
-    mockIsSignedIn = false;
+    mockStatus = "unknown";
   });
 
-  it("composes the card details block with the auth login", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
-
-    expect(screen.getByTestId("card-details")).toBeVisible();
-    expect(screen.getByTestId("card-login")).toBeVisible();
-  });
-
-  it("leaves the title to the login block while nobody is signed in", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
-
-    expect(screen.queryByText(title)).toBeNull();
-  });
-
-  it("shows the title once the card holder is signed in", () => {
-    mockIsSignedIn = true;
-
+  it("always shows the host title", () => {
     render(<Card title={title} oauthConfig={oauthConfig} />);
 
     expect(screen.getByText(title)).toBeVisible();
   });
 
-  it("mounts the onboarding widget", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
+  describe("while resolving the session", () => {
+    it("shows only the bare artwork, holding back the widget and card details", () => {
+      render(<Card title={title} oauthConfig={oauthConfig} />);
 
-    expect(screen.getByTestId("card-onboarding-widget")).toBeVisible();
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.queryByTestId("card-onboarding-widget")).toBeNull();
+      expect(screen.queryByTestId("card-details")).toBeNull();
+    });
   });
 
-  it("hands the card visual to the details block once the host provides a formatter and label", () => {
-    render(
-      <Card
-        title={title}
-        oauthConfig={oauthConfig}
-        formatCountervalue={formatCountervalue}
-        balanceLabel="Balance"
-      />,
-    );
+  describe("while signed out", () => {
+    beforeEach(() => {
+      mockStatus = "signedOut";
+    });
 
-    expect(screen.getByTestId("card-details-with-visual")).toBeVisible();
-    expect(screen.queryByTestId("card-details")).toBeNull();
-    expect(screen.getByTestId("card-login")).toBeVisible();
+    it("shows the bare artwork above the login, with no card details", () => {
+      render(<Card title={title} oauthConfig={oauthConfig} />);
+
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.getByTestId("card-login")).toBeVisible();
+      expect(screen.queryByTestId("card-details")).toBeNull();
+    });
+
+    it("never builds the balance overlay, even when the host provides a formatter and label", () => {
+      render(
+        <Card
+          title={title}
+          oauthConfig={oauthConfig}
+          formatCountervalue={formatCountervalue}
+          balanceLabel="Balance"
+        />,
+      );
+
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.queryByTestId("card-details-with-visual")).toBeNull();
+    });
+  });
+
+  describe("once signed in", () => {
+    beforeEach(() => {
+      mockStatus = "signedIn";
+    });
+
+    it("shows the widget and the card details, with no login or bare artwork", () => {
+      render(<Card title={title} oauthConfig={oauthConfig} />);
+
+      expect(screen.getByTestId("card-onboarding-widget")).toBeVisible();
+      expect(screen.getByTestId("card-details")).toBeVisible();
+      expect(screen.queryByTestId("card-login")).toBeNull();
+      expect(screen.queryByTestId("card-artwork")).toBeNull();
+    });
+
+    it("hands the card visual to the details block once the host provides a formatter and label", () => {
+      render(
+        <Card
+          title={title}
+          oauthConfig={oauthConfig}
+          formatCountervalue={formatCountervalue}
+          balanceLabel="Balance"
+        />,
+      );
+
+      expect(screen.getByTestId("card-details-with-visual")).toBeVisible();
+      expect(screen.queryByTestId("card-details")).toBeNull();
+      expect(screen.queryByTestId("card-login")).toBeNull();
+    });
   });
 });

--- a/features/flow/pay-card/src/Card.types.ts
+++ b/features/flow/pay-card/src/Card.types.ts
@@ -25,14 +25,24 @@ export type CardProps = {
   readonly onTrackEvent?: PayCardLoginTrackEvent;
 };
 
+/**
+ * Which of the three mutually exclusive faces the flow shows.
+ *
+ * - `resolving` — the login machine is still reading the stored session. Only the title and the bare
+ *   artwork show, so nothing flashes before the answer lands.
+ * - `signedOut` — nobody is signed in: the bare artwork sits above the login CTA.
+ * - `signedIn` — a live session: the card face, onboarding widget and card actions show, no login.
+ */
+export type CardDisplayState = "resolving" | "signedOut" | "signedIn";
+
 /** Props the presentational view renders, resolved by {@link useCardViewModel}. */
 export type CardViewProps = {
   readonly title: string;
   readonly oauthConfig: CardLoginOauthConfig;
   readonly callback?: PayCardAuthCallback | null;
   readonly onTrackEvent?: PayCardLoginTrackEvent;
-  /** True while a Card session is live. The title only shows to a signed-in card holder. */
-  readonly isSignedIn: boolean;
+  /** Which face to show. The children are mutually exclusive, so the view switches on this. */
+  readonly displayState: CardDisplayState;
   /** Balance overlay for the card face, or `undefined` to show the bare artwork. */
   readonly cardVisual?: CardVisualProps;
 };

--- a/features/flow/pay-card/src/Card.web.test.tsx
+++ b/features/flow/pay-card/src/Card.web.test.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import type { PayCardAuthStatus } from "@features/flow-pay-card-auth";
 import type { CardProps } from "./Card.types";
 
-let mockIsSignedIn = false;
+let mockStatus: PayCardAuthStatus = "unknown";
 
 jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogin: () => <div data-testid="card-login" />,
-  useIsCardSignedIn: () => mockIsSignedIn,
+  useCardAuthStatus: () => mockStatus,
 }));
 
 jest.mock("@features/flow-pay-card-details", () => ({
+  CardArtwork: () => <div data-testid="card-artwork" />,
   CardDetails: ({ cardVisual }: { cardVisual?: unknown }) => (
     <div data-testid={cardVisual ? "card-details-with-visual" : "card-details"} />
   ),
@@ -40,48 +42,82 @@ const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => (
 
 describe("Card (web)", () => {
   beforeEach(() => {
-    mockIsSignedIn = false;
+    mockStatus = "unknown";
   });
 
-  it("renders the host title once the card holder is signed in", () => {
-    mockIsSignedIn = true;
-
+  it("always shows the host title", () => {
     render(<Card title={title} oauthConfig={oauthConfig} />);
 
     expect(screen.getByText(title)).toBeVisible();
   });
 
-  it("shows the host title while nobody is signed in", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
+  describe("while resolving the session", () => {
+    it("shows only the bare artwork, holding back the widget and the card details", () => {
+      render(<Card title={title} oauthConfig={oauthConfig} />);
 
-    expect(screen.getByText(title)).toBeVisible();
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.queryByTestId("card-onboarding-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("card-details")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("card-details-with-visual")).not.toBeInTheDocument();
+    });
   });
 
-  it("composes the card details block with the auth login", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
+  describe("while signed out", () => {
+    beforeEach(() => {
+      mockStatus = "signedOut";
+    });
 
-    expect(screen.getByTestId("card-details")).toBeVisible();
-    expect(screen.getByTestId("card-login")).toBeVisible();
+    it("shows the bare artwork above the login, with no card details or widget", () => {
+      render(<Card title={title} oauthConfig={oauthConfig} />);
+
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.getByTestId("card-login")).toBeVisible();
+      expect(screen.queryByTestId("card-onboarding-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("card-details")).not.toBeInTheDocument();
+    });
+
+    it("never builds the balance overlay, even when the host provides a formatter and label", () => {
+      render(
+        <Card
+          title={title}
+          oauthConfig={oauthConfig}
+          formatCountervalue={formatCountervalue}
+          balanceLabel="Balance"
+        />,
+      );
+
+      expect(screen.getByTestId("card-artwork")).toBeVisible();
+      expect(screen.queryByTestId("card-details-with-visual")).not.toBeInTheDocument();
+    });
   });
 
-  it("mounts the onboarding widget", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
+  describe("once signed in", () => {
+    beforeEach(() => {
+      mockStatus = "signedIn";
+    });
 
-    expect(screen.getByTestId("card-onboarding-widget")).toBeVisible();
-  });
+    it("shows the widget and the card details, with no login or bare artwork", () => {
+      render(<Card title={title} oauthConfig={oauthConfig} />);
 
-  it("hands the card visual to the details block once the host provides a formatter and label", () => {
-    render(
-      <Card
-        title={title}
-        oauthConfig={oauthConfig}
-        formatCountervalue={formatCountervalue}
-        balanceLabel="Balance"
-      />,
-    );
+      expect(screen.getByTestId("card-onboarding-widget")).toBeVisible();
+      expect(screen.getByTestId("card-details")).toBeVisible();
+      expect(screen.queryByTestId("card-login")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("card-artwork")).not.toBeInTheDocument();
+    });
 
-    expect(screen.getByTestId("card-details-with-visual")).toBeVisible();
-    expect(screen.queryByTestId("card-details")).not.toBeInTheDocument();
-    expect(screen.getByTestId("card-login")).toBeVisible();
+    it("hands the card visual to the details block once the host provides a formatter and label", () => {
+      render(
+        <Card
+          title={title}
+          oauthConfig={oauthConfig}
+          formatCountervalue={formatCountervalue}
+          balanceLabel="Balance"
+        />,
+      );
+
+      expect(screen.getByTestId("card-details-with-visual")).toBeVisible();
+      expect(screen.queryByTestId("card-details")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("card-login")).not.toBeInTheDocument();
+    });
   });
 });

--- a/features/flow/pay-card/src/CardView.native.tsx
+++ b/features/flow/pay-card/src/CardView.native.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Subheader, SubheaderRow, SubheaderTitle, Box } from "@ledgerhq/lumen-ui-rnative";
 import { CardLogin } from "@features/flow-pay-card-auth";
-import { CardDetails } from "@features/flow-pay-card-details";
+import { CardArtwork, CardDetails } from "@features/flow-pay-card-details";
 import { CardOnboardingWidget } from "@features/flow-pay-card-widget";
 import type { CardViewProps } from "./Card.types";
 
@@ -10,29 +10,32 @@ export function CardView({
   oauthConfig,
   callback,
   onTrackEvent,
-  isSignedIn,
+  displayState,
   cardVisual,
 }: CardViewProps) {
   return (
     <Box lx={{ flex: 1, gap: "s16" }}>
-      {isSignedIn ? (
-        <Subheader>
-          <SubheaderRow>
-            <SubheaderTitle>{title}</SubheaderTitle>
-          </SubheaderRow>
-        </Subheader>
-      ) : null}
-      <CardOnboardingWidget />
-      {/* TODO: orchestrate the display state here. The card face + details show once the holder is
-          signed in and has a card, while the login shows only while nobody is signed in. Right now
-          each child decides on its own, so they can overlap. */}
-      <CardDetails cardVisual={cardVisual} />
-      <CardLogin
-        key={`${oauthConfig.apiUrl}`}
-        oauthConfig={oauthConfig}
-        callback={callback}
-        onTrackEvent={onTrackEvent}
-      />
+      <Subheader>
+        <SubheaderRow>
+          <SubheaderTitle>{title}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+      {displayState === "signedIn" ? (
+        <>
+          <CardOnboardingWidget />
+          <CardDetails cardVisual={cardVisual} />
+        </>
+      ) : (
+        <>
+          <CardArtwork />
+          <CardLogin
+            key={`${oauthConfig.apiUrl}`}
+            oauthConfig={oauthConfig}
+            callback={callback}
+            onTrackEvent={onTrackEvent}
+          />
+        </>
+      )}
     </Box>
   );
 }

--- a/features/flow/pay-card/src/CardView.web.tsx
+++ b/features/flow/pay-card/src/CardView.web.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { CardLogin } from "@features/flow-pay-card-auth";
-import { CardDetails } from "@features/flow-pay-card-details";
+import { CardArtwork, CardDetails } from "@features/flow-pay-card-details";
 import { CardOnboardingWidget } from "@features/flow-pay-card-widget";
-import { Divider } from "@ledgerhq/lumen-ui-react";
 import type { CardViewProps } from "./Card.types";
 
 export function CardView({
@@ -10,23 +9,29 @@ export function CardView({
   oauthConfig,
   callback,
   onTrackEvent,
+  displayState,
   cardVisual,
 }: CardViewProps) {
   return (
     <div className="flex flex-col gap-16">
       <p className="heading-5-semi-bold text-base">{title}</p>
-      <CardOnboardingWidget />
-      {/* TODO: orchestrate the display state here. These pieces are mutually exclusive: the card
-          face shows once the holder is signed in and has a card, while the login shows only while
-          nobody is signed in. Right now each child decides on its own, so they can overlap. */}
-      <CardDetails cardVisual={cardVisual} />
-      <Divider />
-      <CardLogin
-        key={`${oauthConfig.apiUrl}`}
-        oauthConfig={oauthConfig}
-        callback={callback}
-        onTrackEvent={onTrackEvent}
-      />
+      {displayState === "signedIn" ? (
+        <>
+          <CardOnboardingWidget />
+          <CardDetails cardVisual={cardVisual} />
+        </>
+      ) : (
+        <>
+          <CardArtwork />
+
+          <CardLogin
+            key={`${oauthConfig.apiUrl}`}
+            oauthConfig={oauthConfig}
+            callback={callback}
+            onTrackEvent={onTrackEvent}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/features/flow/pay-card/src/useCardViewModel.ts
+++ b/features/flow/pay-card/src/useCardViewModel.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import { useIsCardSignedIn } from "@features/flow-pay-card-auth";
-import type { CardProps, CardViewProps } from "./Card.types";
+import { useCardAuthStatus } from "@features/flow-pay-card-auth";
+import type { CardDisplayState, CardProps, CardViewProps } from "./Card.types";
 
 /** Mock card balance shown until the real balance API is wired (see LIVE-35427 follow-up). */
 const MOCK_CARD_BALANCE = 100;
@@ -19,12 +19,16 @@ export function useCardViewModel({
   balanceLabel,
   onTrackEvent,
 }: CardProps): CardViewProps {
-  const isSignedIn = useIsCardSignedIn();
+  const status = useCardAuthStatus();
+  const displayState: CardDisplayState = status === "unknown" ? "resolving" : status;
+  const isSignedIn = status === "signedIn";
 
   const cardVisual = useMemo<CardViewProps["cardVisual"]>(() => {
-    if (!formatCountervalue || balanceLabel === undefined) return undefined;
+    // The balance overlay belongs to a signed-in card only. Building it while signed out would drop
+    // the mock balance onto the bare artwork the login CTA sits above.
+    if (!isSignedIn || !formatCountervalue || balanceLabel === undefined) return undefined;
     return { balance: MOCK_CARD_BALANCE, formatCountervalue, balanceLabel };
-  }, [formatCountervalue, balanceLabel]);
+  }, [isSignedIn, formatCountervalue, balanceLabel]);
 
-  return { title, oauthConfig, callback, onTrackEvent, isSignedIn, cardVisual };
+  return { title, oauthConfig, callback, onTrackEvent, displayState, cardVisual };
 }


### PR DESCRIPTION
### 📝 Description

The Pay Card flow used to mount the onboarding widget, card details, and login at the same time, so they could overlap. Auth also only exposed a boolean, which cannot tell “still reading the stored session” from “signed out”, so the login CTA could flash for a holder who is already signed in.

This PR gives `pay-card-auth` a tri-state session status (`unknown` / `signedOut` / `signedIn`) and has the flow resolve one display state. The view then renders a single face: title + artwork while resolving, artwork + login when signed out, widget + details when signed in. `CardLogin` still mounts while resolving so the machine can hydrate. The native subheader is always shown.


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37217](https://ledgerhq.atlassian.net/browse/LIVE-37217)
- **ADR** (if any): N/A

[LIVE-37217]: https://ledgerhq.atlassian.net/browse/LIVE-37217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ