### PR TITLE
test(e2e): fix ambiguous CELO provider row wait (QAA-1356)

### DIFF
--- a/e2e/desktop/tests/page/drawer/delegate.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/delegate.drawer.ts
@@ -18,7 +18,7 @@ export class DelegateDrawer extends Drawer {
     }
   }
 
-  @step("Verify validator group is $0")
+  @step("Verify validator group $0 is visible")
   async validatorGroupIsVisible(validatorGroup: string) {
     await expect(this.provider(validatorGroup)).toBeVisible();
   }

--- a/e2e/mobile/page/trade/stake.page.ts
+++ b/e2e/mobile/page/trade/stake.page.ts
@@ -83,7 +83,7 @@ export default class StakePage {
   @Step("Select the first provider offered for {{{0}}}")
   async selectFirstValidator(currencyId: string): Promise<string> {
     await tapById(this.delegationSummaryValidatorId(currencyId));
-    await waitForElementById(PROVIDER_ROW_REGEX);
+    await waitForElement(getElementById(PROVIDER_ROW_REGEX));
     const rowId = await getIdByRegexp(PROVIDER_ROW_REGEX);
     await tapById(rowId);
     await waitForElementById(this.delegationSummaryValidatorId(currencyId));


### PR DESCRIPTION
### 📝 Description

`voteCELO` has been red on every mobile nightly since #21674 landed. That PR made the spec pick the validator from the rendered list instead of hardcoding a name — the right call — but the wait it introduced is ambiguous.

**Previous behaviour.** `selectFirstValidator` waited on the row regex directly:

```ts
await waitForElementById(PROVIDER_ROW_REGEX); // element(by.id(re)) — no atIndex
```

The list renders one `provider-row-<group>` per validator group, so the matcher hits every row at once. Both platforms fail, differently:

| Platform | Failure |
| --- | --- |
| Android | immediate — `'(view.getTag() should match the pattern: /^provider-row-.+$/ …)' matches 13 views in the hierarchy` |
| iOS | 60s timeout — `TOBEVISIBLE WITH MATCHER(id == "/^provider-row-.+$/") TIMEOUT(1m)` (Detox iOS retries past the ambiguity instead of reporting it) |

This was already visible on #21674's own e2e run ([34236361671](https://github.com/LedgerHQ/ledger-live/actions/runs/34236361671)) and reproduced on the 2026-09-10 nightly ([34420390756](https://github.com/LedgerHQ/ledger-live/actions/runs/34420390756), iOS + Android).

**The fix.** Wait through `getElementById`, which pins `.atIndex(0)`:

```ts
await waitForElement(getElementById(PROVIDER_ROW_REGEX));
```

The next line, `getIdByRegexp`, already went through `getElementById` — only the wait was unscoped. This is the idiom `evmStake.page.ts` uses for the same "first row of a validator list" shape, and `delegateSEI.spec.ts`, which goes through it, passed on **both** iOS and Android in the same nightly that `voteCELO` failed.

**Regression guard.** `voteCELO` itself is the check: it only reaches the amount step once a real group name comes back from the list.

Also carries the `validatorGroupIsVisible` step rewording [requested on #21674](https://github.com/LedgerHQ/ledger-live/pull/21674#discussion_r3969843861) — desktop was green in the nightly (`delegate.spec.ts:338` Vote and `:307` Lock both passed), so nothing else changed there.

**Not in this PR.** The review also suggested making `Delegate.provider` optional so the `"first-available"` sentinel could be dropped from the spec. Trying it turns `provider` into `string | undefined` at **38 call sites** across three packages (11 in `e2e/mobile`, 25 in `e2e/desktop` — 22 in `delegate.spec.ts` alone, spanning ATOM/SOL/ADA/OSMO/MultiversX/MINA — and 2 in `libs/live-e2e-shared`). That is a shared-model refactor that belongs with QAA-1399, not in a nightly fix.

**No changeset**: test-only, no product code touched, and both e2e packages are `private`.

#### ✅ Verification

| Check | Result |
| --- | --- |
| `ledger-live-mobile-e2e-tests` typecheck / `oxlint` / `format:check` | pass |
| `ledger-live-desktop-e2e-tests` nx typecheck / `oxlint` / `format:check` | pass — 0 errors under `tests/` and `live-e2e-shared` |

E2E CI triggered on this branch, filtered to `@celo`:

- **LWM** (iOS & Android) — https://github.com/LedgerHQ/ledger-live/actions/runs/34462404498
- **LWD** — https://github.com/LedgerHQ/ledger-live/actions/runs/34462407615

#### 🔍 QA focus

- **LWM** `voteCELO` — the Allure step `Select the first provider offered for celo` should report a real group name, and `Check CELO validator group in operation details <name>` should assert that same name.
- **LWM** `lockCELO` — untouched, but it shares the page object; it was green on both platforms in the nightly and must stay green.
- **LWD** Celo `Vote` / `Lock` — only the step title changed; both must stay green.

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1356](https://ledgerhq.atlassian.net/browse/QAA-1356) — follow-up to #21674
- **ADR** (if any): n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1356]: https://ledgerhq.atlassian.net/browse/QAA-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ