### PR TITLE
[LWDM] fix(solana): remove hardcoded blind signing warning (LIVE-37118)

### DIFF
--- a/.changeset/solana-remove-blind-signing-warning.md
+++ b/.changeset/solana-remove-blind-signing-warning.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+fix(solana): remove the hardcoded blind signing warning from the transaction summary, the device now warns only when the transaction is actually blind signed

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
@@ -90,11 +90,6 @@ const StepSummary = (props: StepProps) => {
   return (
     <Box flow={4} mx={40}>
       <TrackPage category="Sign Flow" name="Step Summary" />
-      {isSolanaRawTransaction ? (
-        <Alert type="warning" title={t("send.steps.details.solanaRawTransaction.title")}>
-          <Trans i18nKey="send.steps.details.solanaRawTransaction.description" />
-        </Alert>
-      ) : null}
       {utxoLag ? (
         <Alert type="warning">
           <Trans i18nKey="send.steps.details.utxoLag" />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2605,10 +2605,6 @@
         "title": "Device"
       },
       "details": {
-        "solanaRawTransaction": {
-          "title": "Blind signing required",
-          "description": "You cannot verify the transaction details on your Ledger device. If you sign it, you could lose all your assets. Only sign if you trust this website."
-        },
         "utxoLag": "This transaction may take long to verify and sign because the account has a significant number of coins.",
         "subaccountsWarning": "You will need to refill this account with {{ currency }} in order to send the tokens of this account",
         "from": "From",

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -361,7 +361,6 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await modal.waitForModalToAppear();
 
     // Step Recipient
-    await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
@@ -409,7 +408,6 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await modal.waitForModalToAppear();
 
     // Step Recipient
-    await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
@@ -470,7 +468,6 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await modal.waitForModalToAppear();
 
     // Step Recipient
-    await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
@@ -554,7 +551,6 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await modal.waitForModalToAppear();
 
     // Step Recipient
-    await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4842,10 +4842,6 @@
       "toggleCurrency": "Toggle currency"
     },
     "summary": {
-      "solanaRawTransaction": {
-        "title": "Blind signing required",
-        "description": "You cannot verify the transaction details on your Ledger device. If you sign it, you could lose all your assets. Only sign if you trust this website."
-      },
       "subaccountsWarning": "You will need to refill this account with {{ currency }} in order to send the tokens of this account",
       "tag": "Tag (Optional)",
       "validateTag": "Validate tag",

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -321,25 +321,6 @@ function SendSummary({ navigation, route }: Props) {
           </>
         ) : null}
 
-        {isSolanaRawTransaction ? (
-          <NativeUiAlert type="warning">
-            <Flex>
-              <Text
-                color="neutral.c100"
-                flexShrink={1}
-                variant="bodyLineHeight"
-                fontWeight="semiBold"
-              >
-                <Trans i18nKey="send.summary.solanaRawTransaction.title" />{" "}
-              </Text>
-
-              <Text paddingTop={2}>
-                <Trans i18nKey="send.summary.solanaRawTransaction.description" />
-              </Text>
-            </Flex>
-          </NativeUiAlert>
-        ) : null}
-
         {tooManyUtxos ? (
           <NativeUiAlert type="warning">
             <Flex>


### PR DESCRIPTION
### 📝 Description

With Solana Clear signing shipped, LWD and LWM still displayed a legacy "Blind signing required" warning inherited from the WalletConnect Solana launch. The warning was hardcoded on the transaction summary and fired for every Solana `raw` transaction, including clear-signed ones, so it told users they could not verify a transaction that the device was in fact about to display in full.

This PR removes the app-side warning from both apps. The device is now the only thing that warns, and only when the transaction is actually blind signed. No feature flag is involved: the warning was never flag-gated, it branched purely on the transaction shape (`"raw" in transaction && transaction.raw`).

Changes:

- `apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx`: removed the warning `Alert`.
- `apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx`: removed the warning `NativeUiAlert`.
- `apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts`: dropped the four "Blind signing required" visibility assertions in the raw Solana sign steps.
- Deleted the now-dead English i18n keys `send.steps.details.solanaRawTransaction` and `send.summary.solanaRawTransaction`. Other locales are left untouched, they are updated by the Smartling sync.

The `isSolanaRawTransaction` flag is kept in both files: it also hides the Amount and Total rows, and a raw Solana transaction still has no parsed amount to render.

| Before | After |
|-------------------------------|-------------------------------|
| <img width="647" height="647" alt="Screenshot 2026-09-10 at 14 30 59" src="https://github.com/user-attachments/assets/7fd260c0-5e0b-45cb-ac66-09ccf3137c09" /> | <img width="631" height="554" alt="Screenshot 2026-09-10 at 14 41 51" src="https://github.com/user-attachments/assets/a4153f69-eebb-4aec-a7c3-d871a6ad0964" />|
<img height="700" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-10 at 14 59 46" src="https://github.com/user-attachments/assets/67f1ec81-7773-402b-9a71-9b7b665967a7" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37118](https://ledgerhq.atlassian.net/browse/LIVE-37118)
- **ADR** (if any):


🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-37118]: https://ledgerhq.atlassian.net/browse/LIVE-37118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ