### PR TITLE
chore(ui): make the deprecated design system libs private (LIVE-37226)

### DIFF
--- a/.changeset/clumsy-moons-tickle.md
+++ b/.changeset/clumsy-moons-tickle.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/ui-shared": patch
+"@ledgerhq/icons-ui": patch
+"@ledgerhq/react-ui": patch
+"@ledgerhq/native-ui": patch
+---
+
+Mark the deprecated design system packages as private so they stop being published to npm, and drop their npm installation instructions

--- a/libs/ui/packages/icons/README.md
+++ b/libs/ui/packages/icons/README.md
@@ -7,17 +7,7 @@
 
 ### A collection of Ledger-flavoured icons
 
-#### This package contains a collection of React and React Native icon components.
-
-## Installation
-
-**Note:** Do not install this package directly if your project is using `@ledgerhq/react-ui` or `@ledgerhq/native-ui`. Both packages include `icons-ui` as a depedency and the icon components are re-exported and are accessible from there.
-
-### Package
-
-```sh
-npm i @ledgerhq/icons-ui
-```
+#### This internal package contains a collection of React and React Native icon components.
 
 ## Usage
 

--- a/libs/ui/packages/icons/package.json
+++ b/libs/ui/packages/icons/package.json
@@ -2,6 +2,7 @@
   "name": "@ledgerhq/icons-ui",
   "description": "Icons used by the Ledger design system.",
   "version": "0.20.0",
+  "private": true,
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/ui/packages/native/README.md
+++ b/libs/ui/packages/native/README.md
@@ -6,30 +6,7 @@
 [![npm](https://img.shields.io/npm/v/@ledgerhq/native-ui)](https://www.npmjs.com/package/@ledgerhq/native-ui)
 ### Design and interface resources for React Native
 
-#### This package contains [React Native](https://reactnative.dev/) components and styles built on top of our design system and used internally at [Ledger](https://www.ledger.com/).
-
-## Installation
-
-### Package
-
-```sh
-npm i @ledgerhq/native-ui
-```
-
-### Peer dependencies
-
-_This library uses the following packages under the hood and relies on them being installed separately to avoid package duplication._
-
-```sh
-npm i styled-components react-native-reanimated react-native-svg
-```
-
-### Additional setup
-
-Follow the installation instructions for:
-
-- [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/docs/2.2.0/installation)
-- [react-native-svg](https://github.com/react-native-svg/react-native-svg#installation)
+#### This internal package contains [React Native](https://reactnative.dev/) components and styles built on top of our design system and used internally at [Ledger](https://www.ledger.com/).
 
 ## Usage
 

--- a/libs/ui/packages/native/package.json
+++ b/libs/ui/packages/native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/native-ui",
   "version": "0.66.0",
+  "private": true,
   "description": "Ledger Live - Mobile UI",
   "repository": {
     "type": "git",

--- a/libs/ui/packages/react/README.md
+++ b/libs/ui/packages/react/README.md
@@ -6,29 +6,7 @@
 [![npm](https://img.shields.io/npm/v/@ledgerhq/react-ui)](https://www.npmjs.com/package/@ledgerhq/react-ui)
 ### Design and interface resources for React
 
-#### This package contains [React](https://reactjs.org/) components and styles built on top of our design system and used internally at [Ledger](https://www.ledger.com/).
-
-## Installation
-
-### Package
-
-```sh
-npm i @ledgerhq/react-ui
-```
-
-### Peer dependencies
-
-This library uses [styled components](https://styled-components.com/) heavily and relies on it being installed separately (to avoid package duplication).
-
-```sh
-npm i styled-components
-```
-
-And (obviously) if React packages are not already installed:
-
-```sh
-npm i react react-dom
-```
+#### This internal package contains [React](https://reactjs.org/) components and styles built on top of our design system and used internally at [Ledger](https://www.ledger.com/).
 
 ## Usage
 

--- a/libs/ui/packages/react/package.json
+++ b/libs/ui/packages/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/react-ui",
   "version": "0.53.0",
+  "private": true,
   "description": "Ledger Live - Desktop UI",
   "author": "Ledger Wallet Team <team-live@ledger.fr>",
   "repository": {

--- a/libs/ui/packages/shared/package.json
+++ b/libs/ui/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/ui-shared",
   "version": "0.5.0",
+  "private": true,
   "description": "Package with the shared assets and code between the React and React Native versions of the Ledger design system",
   "main": "lib/index.js",
   "typescriptMain": "index.ts",


### PR DESCRIPTION
> [!NOTE]
> Package metadata and READMEs only, no source change.

### 📝 Description

`@ledgerhq/ui-shared`, `@ledgerhq/icons-ui`, `@ledgerhq/react-ui` and `@ledgerhq/native-ui` are deprecated in favour of Lumen, yet still published to npm on every release.

- `"private": true` on the four packages, so `changeset publish` skips them. `privatePackages.version` stays `true`, so they keep being versioned and changelogged.
- Dropped the `## Installation` block from the icons, react and native READMEs.

Safe move: consumers in the repo use `workspace:^` and are unaffected, and external consumers keep resolving the last published version — these packages get no new features, only removals as call sites migrate to Lumen, and their READMEs already document them as deprecated. Follow-up: `npm deprecate` them (LIVE-37227).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37226](https://ledgerhq.atlassian.net/browse/LIVE-37226) (epic [LIVE-37225](https://ledgerhq.atlassian.net/browse/LIVE-37225), initiative [LIVE-37105](https://ledgerhq.atlassian.net/browse/LIVE-37105))
- **ADR** (if any): n/a

[LIVE-37226]: https://ledgerhq.atlassian.net/browse/LIVE-37226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37225]: https://ledgerhq.atlassian.net/browse/LIVE-37225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37105]: https://ledgerhq.atlassian.net/browse/LIVE-37105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ