### PR TITLE
feat(pay-card): keep the OAuth code from the deep link (LIVE-34740)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
@@ -374,6 +374,17 @@ describe("parseDeepLink", () => {
       });
     });
 
+    it("creates paytab route with the authorization code and the attempt state", () => {
+      const parsed = parseDeepLink("ledgerlive://paytab?code=auth-code&state=attempt-state");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "paytab",
+        code: "auth-code",
+        state: "attempt-state",
+      });
+    });
+
     it("creates product tour route", () => {
       const parsed = parseDeepLink("ledgerlive://product-tour");
       const route = createRoute(parsed);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
@@ -360,6 +360,17 @@ describe("parseDeepLink", () => {
 
       expect(route).toEqual({
         type: "paytab",
+        code: undefined,
+      });
+    });
+
+    it("creates paytab route with the Card login authorization code", () => {
+      const parsed = parseDeepLink("ledgerlive://paytab?code=auth-code&app_id=app-value");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "paytab",
+        code: "auth-code",
       });
     });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/payTab.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/payTab.handler.test.ts
@@ -12,7 +12,15 @@ describe("payTab.handler", () => {
 
       payTabHandler({ type: "paytab" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith("/paytab");
+      expect(context.navigate).toHaveBeenCalledWith("/paytab", undefined);
+    });
+
+    it("carries the Card login authorization code as router state", () => {
+      const context = createMockContext({ isPayTabEnabled: true });
+
+      payTabHandler({ type: "paytab", code: "auth-code" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/paytab", { code: "auth-code" });
     });
 
     it("falls back to the default handler when the lwdPayTab flag is disabled", () => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/payTab.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/payTab.handler.test.ts
@@ -23,6 +23,17 @@ describe("payTab.handler", () => {
       expect(context.navigate).toHaveBeenCalledWith("/paytab", { code: "auth-code" });
     });
 
+    it("carries the attempt state alongside the authorization code", () => {
+      const context = createMockContext({ isPayTabEnabled: true });
+
+      payTabHandler({ type: "paytab", code: "auth-code", state: "attempt-state" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/paytab", {
+        code: "auth-code",
+        state: "attempt-state",
+      });
+    });
+
     it("falls back to the default handler when the lwdPayTab flag is disabled", () => {
       const context = createMockContext({ isPayTabEnabled: false });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
@@ -7,5 +7,5 @@ export const payTabHandler: DeeplinkHandler<"paytab"> = (route, context) => {
   }
 
   // The code travels as router state, because an authorization code has no business in a kept URL.
-  context.navigate("/paytab", route.code ? { code: route.code } : undefined);
+  context.navigate("/paytab", route.code ? { code: route.code, state: route.state } : undefined);
 };

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
@@ -1,10 +1,11 @@
 import { DeeplinkHandler } from "../types";
 import { defaultHandler } from "./default.handler";
 
-export const payTabHandler: DeeplinkHandler<"paytab"> = (_route, context) => {
+export const payTabHandler: DeeplinkHandler<"paytab"> = (route, context) => {
   if (!context.isPayTabEnabled) {
     return defaultHandler({ type: "default" }, context);
   }
 
-  context.navigate("/paytab");
+  // The code travels as router state, because an authorization code has no business in a kept URL.
+  context.navigate("/paytab", route.code ? { code: route.code } : undefined);
 };

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
@@ -7,5 +7,8 @@ export const payTabHandler: DeeplinkHandler<"paytab"> = (route, context) => {
   }
 
   // The code travels as router state, because an authorization code has no business in a kept URL.
-  context.navigate("/paytab", route.code ? { code: route.code, state: route.state } : undefined);
+  context.navigate(
+    "/paytab",
+    route.code ? { code: route.code, ...(route.state ? { state: route.state } : {}) } : undefined,
+  );
 };

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -278,6 +278,7 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
       const route: PayTabRoute = {
         type: "paytab",
         code: query.code,
+        state: query.state,
       };
       return route;
     }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -277,6 +277,7 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
     case "paytab": {
       const route: PayTabRoute = {
         type: "paytab",
+        code: query.code,
       };
       return route;
     }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -226,6 +226,11 @@ export interface PayTabRoute {
    * `go.ledger.com`, which sends the browser on to `ledgerlive://paytab?code=…`.
    */
   code?: string;
+  /**
+   * The login attempt this code answers, echoed back by the provider. Lets the flow tell a stray
+   * redirect from an abandoned attempt apart from the one it is currently waiting on.
+   */
+  state?: string;
 }
 
 export interface LedgerSyncRoute {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -221,6 +221,11 @@ export interface PerpsRoute {
 
 export interface PayTabRoute {
   type: "paytab";
+  /**
+   * The OAuth authorization code, when the Card login redirect brought one. The provider redirects to
+   * `go.ledger.com`, which sends the browser on to `ledgerlive://paytab?code=…`.
+   */
+  code?: string;
 }
 
 export interface LedgerSyncRoute {


### PR DESCRIPTION
## Summary

The Pay tab deep link drops every query parameter today. The provider sends the OAuth code on that
link, so the code cannot reach the Pay tab. This pull request keeps the `code` parameter, and the
handler hands it to the Pay tab as router state.

A user sees no change. The desktop Card login reads that code in a later pull request. The
`lwdPayTab` flag also ships disabled.

## Stack

This pull request is part of the LIVE-34740 split. It is parallel to the stack, because no other
layer touches these five files. Merge it before the layer that completes the login.

## Checks

- `pnpm desktop test:jest "useDeeplinking"` — 177 tests pass.
- `pnpm nx run ledger-live-desktop:typecheck` — passes.
