### PR TITLE
refactor(pay-card): build every hosted Card URL in the flow (LIVE-34740)

### DIFF
--- a/.changeset/tame-lions-borrow.md
+++ b/.changeset/tame-lions-borrow.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-card-auth": minor
+---
+
+feat(pay-card): build every hosted Card URL in the flow
+
+Adds `buildHostedUrl` and `buildHostedPageUrl`, and an optional `hostedUiUrl` on `CardLoginOauthConfig`, so a host app can address any hosted Card page without hardcoding its origin.

--- a/features/flow/pay-card-auth/src/index.native.ts
+++ b/features/flow/pay-card-auth/src/index.native.ts
@@ -1,6 +1,8 @@
 export { CardLogin } from "./components/CardLogin/index.native";
 export type { CardLoginProps, PayCardLoginTrackEvent } from "./components/CardLogin/types";
 export { openHostedLoginInSecureBrowser } from "./components/CardLogin/openHostedLogin.native";
+export { buildHostedPageUrl } from "./state/buildHostedPageUrl";
+export { buildHostedUrl } from "./state/buildHostedUrl";
 export type { OpenHostedLogin, HostedLoginResult } from "./state/types";
 export type { CardLoginOauthConfig, PayCardAuthCallback } from "./state/types";
 export type { PayCardAuthStatus } from "./state/types";

--- a/features/flow/pay-card-auth/src/index.native.ts
+++ b/features/flow/pay-card-auth/src/index.native.ts
@@ -3,6 +3,7 @@ export type { CardLoginProps, PayCardLoginTrackEvent } from "./components/CardLo
 export { openHostedLoginInSecureBrowser } from "./components/CardLogin/openHostedLogin.native";
 export { buildHostedPageUrl } from "./state/buildHostedPageUrl";
 export { buildHostedUrl } from "./state/buildHostedUrl";
+export { SIGNUP_PATH } from "./state/buildSignupUrl";
 export type { OpenHostedLogin, HostedLoginResult } from "./state/types";
 export type { CardLoginOauthConfig, PayCardAuthCallback } from "./state/types";
 export type { PayCardAuthStatus } from "./state/types";

--- a/features/flow/pay-card-auth/src/index.ts
+++ b/features/flow/pay-card-auth/src/index.ts
@@ -2,6 +2,7 @@ export { CardLogin } from "./components/CardLogin";
 export type { CardLoginProps, PayCardLoginTrackEvent } from "./components/CardLogin/types";
 export { buildHostedPageUrl } from "./state/buildHostedPageUrl";
 export { buildHostedUrl } from "./state/buildHostedUrl";
+export { SIGNUP_PATH } from "./state/buildSignupUrl";
 export type { OpenHostedLogin, HostedLoginResult } from "./state/types";
 export type { CardLoginOauthConfig, PayCardAuthCallback } from "./state/types";
 export type { PayCardAuthStatus } from "./state/types";

--- a/features/flow/pay-card-auth/src/index.ts
+++ b/features/flow/pay-card-auth/src/index.ts
@@ -1,5 +1,7 @@
 export { CardLogin } from "./components/CardLogin";
 export type { CardLoginProps, PayCardLoginTrackEvent } from "./components/CardLogin/types";
+export { buildHostedPageUrl } from "./state/buildHostedPageUrl";
+export { buildHostedUrl } from "./state/buildHostedUrl";
 export type { OpenHostedLogin, HostedLoginResult } from "./state/types";
 export type { CardLoginOauthConfig, PayCardAuthCallback } from "./state/types";
 export type { PayCardAuthStatus } from "./state/types";

--- a/features/flow/pay-card-auth/src/state/__tests__/buildHostedPageUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildHostedPageUrl.native.test.ts
@@ -1,0 +1,34 @@
+import { buildHostedPageUrl } from "../buildHostedPageUrl";
+
+const SIGNUP_URL = "https://hosted.test/onboarding/signup";
+const AUTHORIZE_URL = "https://card.api.test/v1/auth/oauth2/authorize?client_id=key&prompt=consent";
+
+describe("buildHostedPageUrl", () => {
+  it("keeps the path of the page, and takes the base of the host", () => {
+    expect(buildHostedPageUrl("https://provider.test", SIGNUP_URL)).toBe(
+      "https://provider.test/onboarding/signup",
+    );
+  });
+
+  it("keeps the query of the page", () => {
+    expect(buildHostedPageUrl("https://provider.test", AUTHORIZE_URL)).toBe(
+      "https://provider.test/v1/auth/oauth2/authorize?client_id=key&prompt=consent",
+    );
+  });
+
+  it("takes the base of a host that carries a path of its own", () => {
+    expect(
+      buildHostedPageUrl("https://provider.test/v1/auth/oauth2/authorize", AUTHORIZE_URL),
+    ).toBe("https://provider.test/v1/auth/oauth2/authorize?client_id=key&prompt=consent");
+  });
+
+  it("refuses a base that is not https", () => {
+    expect(() => buildHostedPageUrl("http://provider.test", SIGNUP_URL)).toThrow(/must be https/);
+  });
+
+  it("refuses a page that is not a URL", () => {
+    expect(() => buildHostedPageUrl("https://provider.test", "/onboarding/signup")).toThrow(
+      /Invalid URL/,
+    );
+  });
+});

--- a/features/flow/pay-card-auth/src/state/__tests__/buildHostedPageUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildHostedPageUrl.native.test.ts
@@ -31,4 +31,12 @@ describe("buildHostedPageUrl", () => {
       /Invalid URL/,
     );
   });
+
+  it("keeps a page of another scheme on the trusted base, never on its own", () => {
+    // Only the path and the query of `pageUrl` are read; its own scheme and host never reach the
+    // result, which stays validated https on `baseUrl` regardless of what `pageUrl` was.
+    expect(buildHostedPageUrl("https://provider.test", "javascript:alert(1)")).toBe(
+      "https://provider.test/alert(1)",
+    );
+  });
 });

--- a/features/flow/pay-card-auth/src/state/__tests__/buildHostedUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildHostedUrl.native.test.ts
@@ -1,0 +1,45 @@
+import { buildHostedUrl } from "../buildHostedUrl";
+
+describe("buildHostedUrl", () => {
+  it("addresses the path on the base it was given", () => {
+    expect(buildHostedUrl("https://provider.test", "/onboarding/signup")).toBe(
+      "https://provider.test/onboarding/signup",
+    );
+  });
+
+  it("keeps the query the path carries", () => {
+    expect(buildHostedUrl("https://provider.test", "/kyc?step=2")).toBe(
+      "https://provider.test/kyc?step=2",
+    );
+  });
+
+  it("takes the base of a host that carries a path of its own", () => {
+    expect(buildHostedUrl("https://provider.test/tenant", "/onboarding/signup")).toBe(
+      "https://provider.test/onboarding/signup",
+    );
+  });
+
+  it("refuses a base that is not https", () => {
+    expect(() => buildHostedUrl("http://provider.test", "/onboarding/signup")).toThrow(
+      /must be https/,
+    );
+  });
+
+  it.each([undefined, ""])("refuses the base %p", base => {
+    expect(() => buildHostedUrl(base, "/onboarding/signup")).toThrow(/no base URL/);
+  });
+
+  it.each([
+    "https://attacker.test/onboarding/signup",
+    "//attacker.test/onboarding/signup",
+    "https://provider.test.attacker.test/onboarding/signup",
+  ])("refuses the path %p, which leaves the base origin", path => {
+    expect(() => buildHostedUrl("https://provider.test", path)).toThrow(/must stay on/);
+  });
+
+  it("takes a path that names the base origin in full", () => {
+    expect(buildHostedUrl("https://provider.test", "https://provider.test/kyc")).toBe(
+      "https://provider.test/kyc",
+    );
+  });
+});

--- a/features/flow/pay-card-auth/src/state/__tests__/buildHostedUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildHostedUrl.native.test.ts
@@ -33,6 +33,7 @@ describe("buildHostedUrl", () => {
     "https://attacker.test/onboarding/signup",
     "//attacker.test/onboarding/signup",
     "https://provider.test.attacker.test/onboarding/signup",
+    "http://provider.test/onboarding/signup",
   ])("refuses the path %p, which leaves the base origin", path => {
     expect(() => buildHostedUrl("https://provider.test", path)).toThrow(/must stay on/);
   });

--- a/features/flow/pay-card-auth/src/state/__tests__/buildSignupUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildSignupUrl.native.test.ts
@@ -25,6 +25,10 @@ describe("buildSignupUrl", () => {
     expect(pathname).toBe("/onboarding/signup");
   });
 
+  it("refuses a config that names no hosted UI", () => {
+    expect(() => buildSignupUrl({ ...oauthConfig, hostedUiUrl: undefined })).toThrow(/no base URL/);
+  });
+
   it("refuses a hosted UI that is not https", () => {
     expect(() => buildSignupUrl({ ...oauthConfig, hostedUiUrl: "http://hosted.test" })).toThrow(
       /must be https/,

--- a/features/flow/pay-card-auth/src/state/buildHostedPageUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildHostedPageUrl.ts
@@ -1,0 +1,7 @@
+import { buildHostedUrl } from "./buildHostedUrl";
+
+export function buildHostedPageUrl(baseUrl: string, pageUrl: string): string {
+  const page = new URL(pageUrl);
+
+  return buildHostedUrl(baseUrl, `${page.pathname}${page.search}`);
+}

--- a/features/flow/pay-card-auth/src/state/buildHostedUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildHostedUrl.ts
@@ -1,0 +1,18 @@
+export function buildHostedUrl(baseUrl: string | undefined, path: string): string {
+  if (!baseUrl) {
+    throw new Error("buildHostedUrl: no base URL to address the page on");
+  }
+
+  const base = new URL(baseUrl);
+  const url = new URL(path, base);
+
+  if (url.protocol !== "https:") {
+    throw new Error(`buildHostedUrl: baseUrl must be https, got "${url.protocol}"`);
+  }
+
+  if (url.origin !== base.origin) {
+    throw new Error(`buildHostedUrl: the path must stay on ${base.origin}, got "${url.origin}"`);
+  }
+
+  return url.toString();
+}

--- a/features/flow/pay-card-auth/src/state/buildHostedUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildHostedUrl.ts
@@ -4,11 +4,12 @@ export function buildHostedUrl(baseUrl: string | undefined, path: string): strin
   }
 
   const base = new URL(baseUrl);
-  const url = new URL(path, base);
 
-  if (url.protocol !== "https:") {
-    throw new Error(`buildHostedUrl: baseUrl must be https, got "${url.protocol}"`);
+  if (base.protocol !== "https:") {
+    throw new Error(`buildHostedUrl: baseUrl must be https, got "${base.protocol}"`);
   }
+
+  const url = new URL(path, base);
 
   if (url.origin !== base.origin) {
     throw new Error(`buildHostedUrl: the path must stay on ${base.origin}, got "${url.origin}"`);

--- a/features/flow/pay-card-auth/src/state/buildSignupUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildSignupUrl.ts
@@ -1,13 +1,8 @@
+import { buildHostedUrl } from "./buildHostedUrl";
 import type { CardLoginOauthConfig } from "./types";
 
-const SIGNUP_PATH = "/onboarding/signup";
+export const SIGNUP_PATH = "/onboarding/signup";
 
 export function buildSignupUrl(oauthConfig: CardLoginOauthConfig): string {
-  const url = new URL(SIGNUP_PATH, oauthConfig.hostedUiUrl);
-
-  if (url.protocol !== "https:") {
-    throw new Error(`buildSignupUrl: hostedUiUrl must be https, got "${url.protocol}"`);
-  }
-
-  return url.toString();
+  return buildHostedUrl(oauthConfig.hostedUiUrl, SIGNUP_PATH);
 }

--- a/features/flow/pay-card-auth/src/state/types.ts
+++ b/features/flow/pay-card-auth/src/state/types.ts
@@ -40,7 +40,12 @@ export type CardLoginOauthConfig = Readonly<{
   /** Base of the Card API, which also hosts the authorize page the browser opens. */
   apiUrl: string;
   clientId: string;
-  /** Base of the provider's hosted UI, which carries the signup page the intro opens. */
+  /**
+   * Base of the provider's hosted UI, which carries the signup page the intro opens.
+   *
+   * Optional, because it can be derived elsewhere (e.g. manifest-driven). Leave it out and
+   * `buildSignupUrl` throws.
+   */
   hostedUiUrl?: string;
   /**
    * Sent to the provider on authorize. The token exchange does not repeat it. The provider whitelists

--- a/features/flow/pay-card-auth/src/state/types.ts
+++ b/features/flow/pay-card-auth/src/state/types.ts
@@ -41,7 +41,7 @@ export type CardLoginOauthConfig = Readonly<{
   apiUrl: string;
   clientId: string;
   /** Base of the provider's hosted UI, which carries the signup page the intro opens. */
-  hostedUiUrl: string;
+  hostedUiUrl?: string;
   /**
    * Sent to the provider on authorize. The token exchange does not repeat it. The provider whitelists
    * an `https` URL only, so this one cannot be the app's own link. It redirects to `deepLink`.


### PR DESCRIPTION
## Summary

Every hosted Card URL now comes from one builder in the flow package. `buildHostedUrl` takes a base
URL and a path. It rejects a base that is not `https`, and it rejects a path that leaves the origin
of the base. `buildHostedPageUrl` keeps the path and the query of a page, and puts them on the base
of a manifest. `buildSignupUrl` reuses the builder, and it exports `SIGNUP_PATH`.

`hostedUiUrl` becomes optional on `CardLoginOauthConfig`, because desktop takes the base of every
hosted page from the manifest of the live app.

A user sees no change. Nothing calls the two new builders yet.

## Stack

Layer 1 of the LIVE-34740 split.

## Checks

- `pnpm nx run @features/flow-pay-card-auth:test` — 205 tests pass.
- `pnpm nx run @features/flow-pay-card-auth:typecheck` — passes for web and native.
- `pnpm nx run @features/flow-pay-card-auth:lint` — no error.
