### PR TITLE
chore(hw-bolos): make package private (LIVE-33935)

### DIFF
--- a/libs/ledgerjs/packages/hw-bolos/package.json
+++ b/libs/ledgerjs/packages/hw-bolos/package.json
@@ -16,9 +16,7 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-bolos",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
### 📝 Description

Mark `@ledgerhq/hw-bolos` as private by adding `"private": true` and removing `publishConfig`.

The package has 0 external npm dependents. Its only consumers are `ledger-live-common` and `live-signer-solana`, both private workspace packages. There is no breaking change for the external ecosystem.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33935](https://ledgerhq.atlassian.net/browse/LIVE-33935)
- **ADR** (if any): N/A

[LIVE-33935]: https://ledgerhq.atlassian.net/browse/LIVE-33935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ