### PR TITLE
chore(e2e): give receive tests to coin-integration (QAA-1500)

### DIFF
--- a/.changeset/qaa-1500-receive-team-owner.md
+++ b/.changeset/qaa-1500-receive-team-owner.md
@@ -1,0 +1,23 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Give the receive verify-address tests back to Coin-integration (QAA-1500)
+
+`1d62665e5e9` moved `receive.address.spec.ts` off Wallet XP but carved XRP and
+Tezos out to `Team.BST` — on desktop through two `teamOwner` overrides, on mobile
+through `BST_VERIFY_ADDRESS_CURRENCIES`. Every test split from B2CQA-249 and
+B2CQA-651 belongs to Coin-integration, so both carve-outs go, and with them the
+now-dead `teamOwner?` field on `ReceiveTestCase`.
+
+Ownership feeds Allure's `owner`/`parentSuite`/`feature` and the `team` CI
+dropdown, which `e2e/tooling/filter/teamSpecs.mjs` resolves by grepping
+`Team.<MEMBER>` per spec *file* — so a single `Team.BST` line pulled the whole
+file into `team=bst`. `--list-teams` now reports `bst` at 9 desktop spec files
+instead of 10 and 120 mobile instead of 130, with `coin-integration` unchanged.
+
+Mobile also linked only the B2CQA-249-family key for eight of the ten currencies
+while desktop linked both families. The missing B2CQA-651-family keys (2687, 2688,
+2689, 2690, 2691, 2693, 2694, 2696) are added so both suites report the same Xray
+tests.

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -16,7 +16,6 @@ import { buildTags } from "tests/utils/tagsUtils";
 type ReceiveTestCase = {
   account: Account;
   xrayTicket: string;
-  teamOwner?: Team;
 };
 
 const nativeAccounts: ReceiveTestCase[] = [
@@ -25,10 +24,10 @@ const nativeAccounts: ReceiveTestCase[] = [
   { account: Account.SOL_1, xrayTicket: "B2CQA-2563, B2CQA-2689" },
   { account: Account.TRX_1, xrayTicket: "B2CQA-2565, B2CQA-2690, B2CQA-2699" },
   { account: Account.DOT_1, xrayTicket: "B2CQA-2562, B2CQA-2691" },
-  { account: Account.XRP_1, xrayTicket: "B2CQA-2566, B2CQA-2692", teamOwner: Team.BST },
+  { account: Account.XRP_1, xrayTicket: "B2CQA-2566, B2CQA-2692" },
   { account: Account.BCH_1, xrayTicket: "B2CQA-2558, B2CQA-2693" },
   { account: Account.ATOM_1, xrayTicket: "B2CQA-2560, B2CQA-2694" },
-  { account: Account.XTZ_1, xrayTicket: "B2CQA-2564, B2CQA-2695", teamOwner: Team.BST },
+  { account: Account.XTZ_1, xrayTicket: "B2CQA-2564, B2CQA-2695" },
   { account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
 ];
 
@@ -53,7 +52,7 @@ async function verifySendCurrencyTokensWarning(app: Application, account: Accoun
 for (const receive of nativeAccounts) {
   test.describe("Receive", () => {
     test.use({
-      teamOwner: receive.teamOwner ?? Team.COIN_INTEGRATION,
+      teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: receive.account.currency.speculosApp,
       cliCommands: [liveDataCommand(receive.account)],

--- a/e2e/mobile/specs/verifyAddress/verifyAddress.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddress.ts
@@ -2,8 +2,6 @@ import { AccountType } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
 
-const BST_VERIFY_ADDRESS_CURRENCIES = new Set(["ripple", "tezos"]);
-
 export function runVerifyAddressTest(account: AccountType, tmsLinks: string[], tags: string[]) {
   describe("Receive", () => {
     beforeAll(async () => {
@@ -14,9 +12,7 @@ export function runVerifyAddressTest(account: AccountType, tmsLinks: string[], t
       await app.mainNavigation.waitForWallet40Ready();
     });
 
-    setTeamOwner(
-      BST_VERIFY_ADDRESS_CURRENCIES.has(account.currency.id) ? Team.BST : Team.COIN_INTEGRATION,
-    );
+    setTeamOwner(Team.COIN_INTEGRATION);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`[${account.currency.testLabel}] - Verify address`, async () => {

--- a/e2e/mobile/specs/verifyAddress/verifyAddressATOM.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressATOM.spec.ts
@@ -3,6 +3,6 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.ATOM_1,
-  ["B2CQA-2560"],
+  ["B2CQA-2560", "B2CQA-2694"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@cosmos", "@family-cosmos"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressBCH.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressBCH.spec.ts
@@ -3,6 +3,6 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.BCH_1,
-  ["B2CQA-2558"],
+  ["B2CQA-2558", "B2CQA-2693"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin_cash", "@family-bitcoin"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressBSC.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressBSC.spec.ts
@@ -2,6 +2,6 @@ import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 runVerifyAddressTest(
   Account.BSC_1,
-  ["B2CQA-2686"],
+  ["B2CQA-2686", "B2CQA-2696"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bsc", "@family-evm"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressBTC.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressBTC.spec.ts
@@ -3,6 +3,6 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.BTC_NATIVE_SEGWIT_1,
-  ["B2CQA-2559"],
+  ["B2CQA-2559", "B2CQA-2687"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressDOT.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressDOT.spec.ts
@@ -3,6 +3,6 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.DOT_1,
-  ["B2CQA-2562"],
+  ["B2CQA-2562", "B2CQA-2691"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@polkadot", "@family-polkadot"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressETH.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressETH.spec.ts
@@ -3,7 +3,7 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.ETH_1,
-  ["B2CQA-2561"],
+  ["B2CQA-2561", "B2CQA-2688"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/verifyAddress/verifyAddressSOL.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressSOL.spec.ts
@@ -3,6 +3,6 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.SOL_1,
-  ["B2CQA-2563"],
+  ["B2CQA-2563", "B2CQA-2689"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@solana", "@family-solana"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressTRX.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressTRX.spec.ts
@@ -3,6 +3,6 @@ import { runVerifyAddressTest } from "@e2e/specs/verifyAddress/verifyAddress";
 
 runVerifyAddressTest(
   Account.TRX_1,
-  ["B2CQA-2565"],
+  ["B2CQA-2565", "B2CQA-2690"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@tron", "@family-tron"],
 );


### PR DESCRIPTION
### 📝 Description

**Problem.** `1d62665e5e9` ("chore(e2e): move add-account/receive teamOwner to CI and BST") moved `receive.address.spec.ts` off Wallet XP, but carved **XRP and Tezos** out to `Team.BST` — on desktop through two `teamOwner` overrides, on mobile through `BST_VERIFY_ADDRESS_CURRENCIES`. Every test split from B2CQA-249 and B2CQA-651 belongs to Coin-integration, so those two currencies were reporting to the wrong team in Allure and answering to the wrong CI `team` filter.

**Fix.** Both carve-outs are removed, and with them the now-dead `teamOwner?` field on `ReceiveTestCase`. All twelve desktop receive tests and all ten mobile `verifyAddress*` specs are `Team.COIN_INTEGRATION`.

Ownership feeds Allure's `owner`/`parentSuite`/`feature` and the `team` dropdown on the E2E workflows, which `e2e/tooling/filter/teamSpecs.mjs` resolves by grepping `Team.<MEMBER>` **per spec file** — so a single `Team.BST` line pulled the whole file into `team=bst`. Verified against the computed index (`resolve.mjs --list-teams`), which is derived from source rather than stored:

| runner | `bst` before | `bst` after | `coin-integration` |
| --- | --- | --- | --- |
| desktop (playwright) | 10 spec files | 9 | 8, unchanged |
| mobile (detox) | 130 spec files | 120 | 131, unchanged |

`coin-integration` is unchanged because selection is per file and these specs were already indexed under it too.

**Xray.** While double-checking the linked tickets: mobile linked only the B2CQA-249-family key for eight of the ten currencies, while desktop linked both families. The missing B2CQA-651-family keys are added so the two suites report the same tests — BTC/2687, ETH/2688, SOL/2689, TRX/2690, DOT/2691, BCH/2693, ATOM/2694, BSC/2696. The warning-box keys (2697/2698/2699) already belong to the dedicated `verifyAddressWarning*` specs and are untouched.

The matching Jira labels were corrected outside this PR: `bst_test` → `coin_integration_test` on B2CQA-2564 and B2CQA-2566, and the ten previously unlabelled children of B2CQA-651 (2687–2696) now carry `LWD_TEST` / `LWM_TEST` / `Receive` / `coin_integration_test`.

No product code is touched — this is test ownership metadata and TMS links only.

### ✅ Checks

- `ledger-live-desktop-e2e-tests`: lint, typecheck, format:check — pass
- `ledger-live-mobile-e2e-tests`: lint, typecheck, format:check — pass
- `playwright test --list` still collects all 12 receive tests, XRP and Tezos included
- E2E CI dispatched on this branch scoped to `team=coin-integration` (LWD + LWM) — run links in a comment below

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1500](https://ledgerhq.atlassian.net/browse/QAA-1500)
- **ADR** (if any): n/a
- Related: **QAA-1499** — `add.account.spec.ts` still carries eight `Team.BST` rows from the same commit (XRP, ADA, ALGO, XTZ, GRAM, APT, ZEC, ALEO). Deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1500]: https://ledgerhq.atlassian.net/browse/QAA-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ