### PR TITLE
test(e2e): retag add.account to coin-integration (QAA-1499)

### DIFF
--- a/e2e/desktop/tests/specs/add.account.spec.ts
+++ b/e2e/desktop/tests/specs/add.account.spec.ts
@@ -10,7 +10,6 @@ type AddAccountTestCase = {
   readonly currency: Currency;
   readonly xrayTicket: string;
   readonly portfolioAssetName?: string;
-  readonly teamOwner?: Team;
 };
 
 const currencies: AddAccountTestCase[] = [
@@ -20,42 +19,34 @@ const currencies: AddAccountTestCase[] = [
   },
   { currency: Currency.ETH, xrayTicket: "B2CQA-2503, B2CQA-929, B2CQA-2645, B2CQA-2673" },
   { currency: Currency.ETC, xrayTicket: "B2CQA-2502, B2CQA-2646, B2CQA-2674" },
-  { currency: Currency.XRP, xrayTicket: "B2CQA-2505, B2CQA-2647, B2CQA-2675", teamOwner: Team.BST },
+  { currency: Currency.XRP, xrayTicket: "B2CQA-2505, B2CQA-2647, B2CQA-2675" },
   {
     currency: Currency.DOT,
     xrayTicket: "B2CQA-2504, B2CQA-2648, B2CQA-2676",
     portfolioAssetName: Currency.DOT.name,
   },
   { currency: Currency.TRX, xrayTicket: "B2CQA-2508, B2CQA-2649, B2CQA-2677" },
-  { currency: Currency.ADA, xrayTicket: "B2CQA-2500, B2CQA-2650, B2CQA-2678", teamOwner: Team.BST },
+  { currency: Currency.ADA, xrayTicket: "B2CQA-2500, B2CQA-2650, B2CQA-2678" },
   { currency: Currency.XLM, xrayTicket: "B2CQA-2506, B2CQA-2651, B2CQA-2679" },
   { currency: Currency.BCH, xrayTicket: "B2CQA-2498, B2CQA-2652, B2CQA-2680" },
-  {
-    currency: Currency.ALGO,
-    xrayTicket: "B2CQA-2497, B2CQA-2653, B2CQA-2681",
-    teamOwner: Team.BST,
-  },
+  { currency: Currency.ALGO, xrayTicket: "B2CQA-2497, B2CQA-2653, B2CQA-2681" },
   { currency: Currency.ATOM, xrayTicket: "B2CQA-2501, B2CQA-2654, B2CQA-2682" },
-  { currency: Currency.XTZ, xrayTicket: "B2CQA-2507, B2CQA-2655, B2CQA-2683", teamOwner: Team.BST },
+  { currency: Currency.XTZ, xrayTicket: "B2CQA-2507, B2CQA-2655, B2CQA-2683" },
   { currency: Currency.SOL, xrayTicket: "B2CQA-2642, B2CQA-2656, B2CQA-2684" },
-  {
-    currency: Currency.GRAM,
-    xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685",
-    teamOwner: Team.BST,
-  },
-  { currency: Currency.APT, xrayTicket: "B2CQA-3644, B2CQA-3645, B2CQA-3646", teamOwner: Team.BST },
+  { currency: Currency.GRAM, xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685" },
+  { currency: Currency.APT, xrayTicket: "B2CQA-3644, B2CQA-3645, B2CQA-3646" },
   {
     currency: Currency.BASE,
     xrayTicket: "B2CQA-4226, B2CQA-4227, B2CQA-4228",
     portfolioAssetName: Currency.ETH.name,
   },
-  { currency: Currency.ZEC, xrayTicket: "B2CQA-4296, B2CQA-4297, B2CQA-4298", teamOwner: Team.BST },
+  { currency: Currency.ZEC, xrayTicket: "B2CQA-4296, B2CQA-4297, B2CQA-4298" },
 ];
 
 for (const currency of currencies) {
   test.describe("Add account", () => {
     test.use({
-      teamOwner: currency.teamOwner ?? Team.COIN_INTEGRATION,
+      teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: currency.currency.speculosApp,
     });


### PR DESCRIPTION
### 📝 Description

`add.account.spec.ts` carried no `Team.WALLET_XP` — the currency table already defaulted to
`Team.COIN_INTEGRATION`. The team that was actually stale is `Team.BST`, applied as a per-entry override on
7 currencies: XRP, ADA, ALGO, XTZ, GRAM/TON, APT and ZEC.

This drops those 7 overrides so all 17 table-driven tests resolve to Coin-integration, removes the
now-unused `teamOwner` field from `AddAccountTestCase`, and simplifies
`currency.teamOwner ?? Team.COIN_INTEGRATION` to `Team.COIN_INTEGRATION`.

The standalone Aleo `test.describe` deliberately keeps `Team.BST`: its Xray keys
(B2CQA-4450 / B2CQA-4451 / B2CQA-4452) are not split from B2CQA-102 or B2CQA-786, so it sits outside the
ticket's scope. Because team selection is per spec **file**, `add.account.spec.ts` consequently still resolves
under `team=bst` as well as `team=coin-integration` — expected, not a regression.

Ownership only feeds Allure (`allure.owner` / `parentSuite` / `feature`) and the CI `team` dropdown, which
derives it by grepping `Team.*` out of the spec source. There is no behavioural change to any test.

The matching Jira work was done on the tickets themselves. Team ownership on a B2CQA test is carried by a
**label**, not the `Team` field — that field offers no coin-integration option and stays "Ledger Live". 13 tickets
updated: `bst_test` → `coin_integration_test` on B2CQA-2647, -2650, -2653, -2655, -2657, -3646, -4298, and
`coin_integration_test` added to B2CQA-102, -2498, -2500, -2507, -2643, -3644.

**Verification**

- `nx run ledger-live-desktop-e2e-tests:typecheck`, `:lint` and `:format:check` (oxfmt) all clean
- `resolve.mjs --team coin-integration` → 8 specs including this one; `--team bst` → 10, still including this one
  via the Aleo block. No team selects 0 specs.
- `playwright test --list add.account.spec.ts` → all 18 tests still enumerate

**QA focus areas**

- Allure `owner` / `parentSuite` / `feature` on the add-account tests should read `Coin-integration` for every
  currency except ALEO, which stays `BST`.
- The `team=coin-integration` and `team=bst` selections in the desktop e2e workflow dropdown should both still
  pick up `add.account.spec.ts`.

No changeset: e2e-only change to a test package, consistent with recent e2e-only commits on `develop`.

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1499](https://ledgerhq.atlassian.net/browse/QAA-1499)
- **ADR** (if any): n/a

Known gaps deliberately left out of this PR (all flagged in a comment on QAA-1499): **B2CQA-330** is the third
parent family this spec covers and none of its 17 children carry a team label; the mobile add-account specs keep
the identical 7-currency `BST_ADD_ACCOUNT_CURRENCIES` carve-out while these tickets are tagged Platform LWD+LWM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1499]: https://ledgerhq.atlassian.net/browse/QAA-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ