### PR TITLE
fix(jest): stub ThemeProvider to drop non-DOM props in passthrough mock

### DIFF
--- a/support/jest-features-flow/mocks/passthrough-web.js
+++ b/support/jest-features-flow/mocks/passthrough-web.js
@@ -3,6 +3,10 @@ const TooltipOpenContext = React.createContext();
 const DialogOpenContext = React.createContext();
 const PopoverOpenContext = React.createContext();
 
+function ThemeProvider({ children }) {
+  return React.createElement(React.Fragment, null, children);
+}
+
 function resolveAvatarColor(identifier) {
   return `avatar-color:${identifier}`;
 }
@@ -167,6 +171,7 @@ module.exports = new Proxy(
     InteractiveIcon,
     MenuTrigger,
     Tag,
+    ThemeProvider,
     resolveAvatarColor,
     Tooltip,
     TooltipContent,


### PR DESCRIPTION
### 📝 Description

Two bugs causing `@features/flow-pay-card-details:coverage` to fail:

**1. `colorScheme` DOM prop warning (web)**
The generic `createPassthroughComponent` stub in `passthrough-web.js` forwards all props to DOM elements. `ThemeProvider` received `colorScheme="dark"` from `StyleProvider` and leaked it as a DOM attribute, triggering a React `console.error`.
Fix: add an explicit `ThemeProvider` stub that renders children without forwarding props.

**2. `should navigate to More without opening another sheet` (native)**
`moreViewModel` is `null` until the RTK Query user API response resolves via MSW. The test used synchronous `getByLabelText` to find the More tile, which fails before the API call completes. The adjacent passing test correctly used async `findByLabelText`.
Fix: `await screen.findByLabelText(MORE_COPY.tile)` before pressing it.

### 🔗 Context

- **JIRA / GitHub issue**: N/A