### PR TITLE
fix(pay-card): skip flaky More navigation test pending async fix

### DIFF
--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
@@ -50,7 +50,9 @@ describe("CardDetails (native)", () => {
     expect(await screen.findByLabelText(MORE_COPY.tile)).toBeVisible();
   });
 
-  it("should navigate to More without opening another sheet", async () => {
+  // TODO: the More tile only renders after the RTK Query user fetch resolves; use findByLabelText
+  // Tracked in: https://github.com/LedgerHQ/ledger-live/pull/21814
+  it.skip("should navigate to More without opening another sheet", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));


### PR DESCRIPTION
### 📝 Description

Unblocks develop. The test `should navigate to More without opening another sheet` was breaking CI because it uses sync `getByLabelText` to find the More tile, which only renders after the RTK Query user fetch resolves via MSW. The element doesn't exist yet when the query runs.

Skipped with a reference to #21814 which carries the proper fix (`findByLabelText` + `ThemeProvider` stub cleanup).

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A