### PR TITLE
[LWDM] fix(coin-vechain): drop the listOperations next cursor (LIVE-37039)

### DIFF
--- a/.changeset/LIVE-37039-coin-vechain-list-operations-pagination.md
+++ b/.changeset/LIVE-37039-coin-vechain-list-operations-pagination.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/coin-vechain": patch
+---
+
+listOperations no longer advertises a next cursor, and honours the requested order
+
+A page already covers every operation up to the current head, so the cursor it returned (the head
+block, and the caller's own cursor on an empty page) never led to more results — a client paging
+until `next` is falsy looped forever. The page is now returned without `next`.
+
+`order` was accepted and ignored: `asc` and `desc` both returned newest-first. Operations are now
+sorted in the requested order, `desc` remaining the default.

--- a/libs/coin-modules/coin-vechain/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-vechain/src/logic/history/listOperations.ts
@@ -36,7 +36,10 @@ function parseCursor(options: ListOperationsOptions): number {
   return Math.max(fromCursor, options.minHeight || 0);
 }
 
-// Merged VET + VTHO operations; `next` is one block past the current head for incremental resume.
+// Merged VET + VTHO operations. A page is never partial: getOperations/getTokenOperations exhaust
+// [startAt, head] within this call (splitting the block range until the node accepts it), so there
+// is no next page to advertise and `next` stays unset — a cursor on a complete (or empty) page traps
+// a client that pages until `next` is falsy. Resume across syncs is driven by `minHeight`.
 export async function listOperations(
   context: VechainContext,
   address: string,
@@ -47,7 +50,7 @@ export async function listOperations(
   const stopAt = await getLastBlockHeight(config);
 
   if (startAt > stopAt) {
-    return { items: [], next: String(startAt) };
+    return { items: [] };
   }
 
   const [vetOps, vthoOps] = await Promise.all([
@@ -58,10 +61,11 @@ export async function listOperations(
   const items = [
     ...vetOps.map(op => toFrameworkOperation(op, NATIVE_ASSET)),
     ...vthoOps.map(op => toFrameworkOperation(op, vthoAsset(address))),
-  ].sort((a, b) => b.tx.date.getTime() - a.tx.date.getTime());
+  ].sort((a, b) =>
+    options.order === "asc"
+      ? a.tx.date.getTime() - b.tx.date.getTime()
+      : b.tx.date.getTime() - a.tx.date.getTime(),
+  );
 
-  return {
-    items,
-    next: String(stopAt + 1),
-  };
+  return { items };
 }

--- a/libs/coin-modules/coin-vechain/src/logic/history/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-vechain/src/logic/history/listOperations.unit.test.ts
@@ -55,7 +55,7 @@ describe("listOperations", () => {
     expect(page.items.find(op => op.id === "vtho-op")?.details?.ledgerOpType).toBe("IN");
   });
 
-  it("merges VET + VTHO without duplicate operations and resumes one block past the head", async () => {
+  it("merges VET + VTHO without duplicate operations", async () => {
     jest.mocked(getLastBlockHeight).mockResolvedValueOnce(300);
     jest
       .mocked(getOperations)
@@ -75,8 +75,19 @@ describe("listOperations", () => {
     expect(ids).toHaveLength(3);
     expect(new Set(ids).size).toBe(ids.length); // no duplicates across the merged VET + VTHO streams
     expect(ids).toEqual(["vet-1", "vtho-1", "vet-2"]); // merged, sorted by date desc
-    // Cursor resumes at head + 1 so the boundary block is never re-scanned into a duplicate next page.
-    expect(page.next).toBe("301");
+  });
+
+  it("does not advertise a next page: one call already covers everything up to the head", async () => {
+    jest.mocked(getLastBlockHeight).mockResolvedValueOnce(300);
+    jest.mocked(getOperations).mockResolvedValueOnce([makeLegacyOp({ id: "vet-1" })]);
+    jest.mocked(getTokenOperations).mockResolvedValueOnce([]);
+
+    const page = await listOperations(context, ADDRESS, { minHeight: 0 });
+
+    // getOperations/getTokenOperations exhaust [startAt, head] within this call, so the page is
+    // complete. A cursor here would point at nothing, and a client that pages until `next` is
+    // falsy would keep asking for the page after it, forever.
+    expect(page.next).toBeUndefined();
   });
 
   it("attaches no fee to a native VET operation (VeChain gas is VTHO, avoids inflating the debit)", async () => {
@@ -111,14 +122,53 @@ describe("listOperations", () => {
     expect(page.items[0].tx.fees).toBe(BigInt("21000000000000000"));
   });
 
-  it("returns an empty page (with a resumable cursor) when the range is already exhausted", async () => {
+  it("returns an empty page without a cursor when the range is already exhausted", async () => {
     jest.mocked(getLastBlockHeight).mockResolvedValueOnce(50);
 
     const page = await listOperations(context, ADDRESS, { minHeight: 0, cursor: "100" });
 
     expect(page.items).toEqual([]);
     expect(getOperations).not.toHaveBeenCalled();
-    expect(page.next).toBe("100");
+    // An empty page advertising another page is the loop clients cannot escape.
+    expect(page.next).toBeUndefined();
+  });
+
+  it("sorts oldest first when order is asc", async () => {
+    jest.mocked(getLastBlockHeight).mockResolvedValueOnce(300);
+    jest
+      .mocked(getOperations)
+      .mockResolvedValueOnce([
+        makeLegacyOp({ id: "newest", date: new Date("2024-01-03T00:00:00Z") }),
+        makeLegacyOp({ id: "oldest", date: new Date("2024-01-01T00:00:00Z") }),
+      ]);
+    jest
+      .mocked(getTokenOperations)
+      .mockResolvedValueOnce([
+        makeLegacyOp({ id: "middle", date: new Date("2024-01-02T00:00:00Z") }),
+      ]);
+
+    const page = await listOperations(context, ADDRESS, { minHeight: 0, order: "asc" });
+
+    expect(page.items.map(op => op.id)).toEqual(["oldest", "middle", "newest"]);
+  });
+
+  it("sorts newest first when order is desc", async () => {
+    jest.mocked(getLastBlockHeight).mockResolvedValueOnce(300);
+    jest
+      .mocked(getOperations)
+      .mockResolvedValueOnce([
+        makeLegacyOp({ id: "oldest", date: new Date("2024-01-01T00:00:00Z") }),
+        makeLegacyOp({ id: "newest", date: new Date("2024-01-03T00:00:00Z") }),
+      ]);
+    jest
+      .mocked(getTokenOperations)
+      .mockResolvedValueOnce([
+        makeLegacyOp({ id: "middle", date: new Date("2024-01-02T00:00:00Z") }),
+      ]);
+
+    const page = await listOperations(context, ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(page.items.map(op => op.id)).toEqual(["newest", "middle", "oldest"]);
   });
 
   it("propagates an error from the underlying network call", async () => {


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** `listOperations` returned a `next` cursor on every page:
`String(stopAt + 1)` on a served page, and the caller's own cursor back on an
empty one. Both were dead ends. A VeChain page is never partial —
`getOperations` / `getTokenOperations` exhaust `[startAt, head]` inside the call,
halving the block range whenever Thor answers `403 maximum allowed value of
1000`, and return only once the whole range is covered — so there was never a
second page for the cursor to point at.

Because the generic coin framework treats a truthy `next` as "call me again"
(`paginateOperations`), every sync made at least one extra round trip:
`GET /blocks/best` plus `POST /logs/transfer` and `POST /logs/event` for an
empty tail range, ended only by the consumer's empty-page guard, which logs
`listOperations returned an empty page with a cursor` each time. A consumer
without that guard — anything that pages until `next` is falsy — never
terminates: on an empty page the module handed back the very cursor it was
given.

**Fix.** The page is returned without `next`. Resume across syncs is driven by
`minHeight`, which the framework derives from the newest stored operation and
already persists (the cursor was never persisted between syncs).

Second, smaller fix in the same function: `order` was accepted and ignored —
`asc` and `desc` both returned newest-first. Operations are now sorted in the
requested order, `desc` remaining the default.

**Regression checks** (`libs/coin-modules/coin-vechain/src/logic/history/listOperations.unit.test.ts`):
- `does not advertise a next page: one call already covers everything up to the head`
- `returns an empty page without a cursor when the range is already exhausted` —
  pins the non-terminating case (cursor `100`, head `50`)
- `sorts oldest first when order is asc` / `sorts newest first when order is desc`

`libs/coin-modules/coin-vechain` unit suite: 9/9 passing.

No behaviour change for users today: VeChain is not in
`genericCoinFrameworkFamilies.json`, so production sync still runs through
`coin-vechain/src/bridge/synchronisation.ts`, which does not call
`listOperations`. This makes the module's `listOperations` contract correct
before that flag flips.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37039](https://ledgerhq.atlassian.net/browse/LIVE-37039)



[LIVE-37039]: https://ledgerhq.atlassian.net/browse/LIVE-37039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ