### PR TITLE
test(pay-card): wait for user fetch before More tile press

### DIFF
--- a/.changeset/pay-card-wait-for-more-tile.md
+++ b/.changeset/pay-card-wait-for-more-tile.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-details": patch
+---
+
+Wait for the Card user fetch before pressing the More tile in native CardDetails tests

--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
@@ -50,13 +50,11 @@ describe("CardDetails (native)", () => {
     expect(await screen.findByLabelText(MORE_COPY.tile)).toBeVisible();
   });
 
-  // TODO: the More tile only renders after the RTK Query user fetch resolves; use findByLabelText
-  // Tracked in: https://github.com/LedgerHQ/ledger-live/pull/21814
-  it.skip("should navigate to More without opening another sheet", async () => {
+  it("should navigate to More without opening another sheet", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));
-    await user.press(screen.getByLabelText(MORE_COPY.tile));
+    await user.press(await screen.findByLabelText(MORE_COPY.tile));
 
     expect(screen.getByText(MORE_COPY.rows.managePin)).toBeVisible();
     expect(screen.getByTestId("card-details-more-content")).toBeVisible();


### PR DESCRIPTION
## Summary
- Re-enable the native CardDetails More-navigation test that was skipped as flaky.
- Wait for the Card user query with `findByLabelText` before pressing the More tile, so the tile exists when the fetch resolves.

## Test plan
- [ ] `npx nx run @features/flow-pay-card-details:coverage --maxWorkers=2`
- [ ] Confirm `should navigate to More without opening another sheet` is no longer skipped and passes.