### PR TITLE
feat(analytics): add base of new analytics package (LIVE-37157)

### DIFF
--- a/.changeset/shared-analytics-packages-scaffold.md
+++ b/.changeset/shared-analytics-packages-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@shared/analytics": minor
+---
+
+Add first draft of `@shared/analytics` package.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,7 @@ apps/ledger-live-desktop/scripts/                        @ledgerhq/platform
 /shared/                                                 @ledgerhq/platform
 
 # Platform — shared (explicit overrides)
+/shared/analytics/                                       @ledgerhq/platform
 /shared/feature-flags                                    @ledgerhq/platform
 /shared/schema-primitives                                @ledgerhq/platform
 /shared/qr-code                                          @ledgerhq/platform

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17553,6 +17553,43 @@ importers:
         specifier: 19.1.4
         version: 19.1.4(react@19.1.4)
 
+  shared/analytics:
+    dependencies:
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+    devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
+      '@support/jest-shared':
+        specifier: workspace:*
+        version: link:../../support/jest-shared
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.5.0(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.67.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.82.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   shared/api-services:
     dependencies:
       '@reduxjs/toolkit':
@@ -23157,7 +23194,6 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28630,7 +28666,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23194,6 +23194,7 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28666,7 +28667,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:

--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -6,7 +6,9 @@
 
 Shared `track` for Ledger Wallet apps. Each app registers its own analytics client (e.g. Segment), consent check, and extra props.
 
-## Example Setup
+## Getting started
+
+### Example setup
 
 ```ts
 import {
@@ -19,17 +21,15 @@ import {
   track,
   type LoggableEvent,
 } from "@shared/analytics";
+// register analytics functions
+setEnabledFn(() => true);
+setExtraPropsFn(() => myExtraPropsSelector(store.getState()));
+setMandatoryExtraPropsFn(() => myMandatoryPropsSelector(store.getState()));
+setPropsFilter((props) => myFilter(props));
 
-setEnabledFn(() => analyticsEnabledSelector(store.getState()));
-setExtraPropsFn(() => analyticsExtraPropsSelector(store.getState()));
-setMandatoryExtraPropsFn(() =>
-  analyticsMandatoryPropsSelector(store.getState())
-);
-setPropsFilter((props) => yourFilter(props));
+// register tracking client and logger
 setAnalytics({
-  track: (event, props) => {
-    void segment.track(event, props);
-  },
+  track: (event, props) => segment.track(event, props),
   log: console.log,
 });
 
@@ -37,23 +37,52 @@ setAnalytics({
 track("Your Event", { foo: "bar" });
 
 // subscribe to the event bus, e.g. for a dev console
-const myDebugging: LoggableEvent[] = [];
-const sub = analyticsEvents$.subscribe((event) => myEvents.push(event));
-const unsubscribe = sub.unsubscribe;
+const myDebug: LoggableEvent[] = [];
+const sub = analyticsEvents$.subscribe((event) => myDebug.push(event));
+const unsubscribe = () => sub.unsubscribe();
 ```
 
-Tracking is off until enabled explicitly. Pass `{ mandatory: true }` to skip that check.
+### Enabling and mandatory
+
+Tracking is off until enabled explicitly with `setEnabledFn`.
+
+In the example above it is switched on by default but more often you will store user consent in some dynamic state. In this case, pass a selector for that state, e.g.
+
+```ts
+setEnabledFn(myAnalyticsEnabledSelector(store.getState()));
+```
+
+For events that do not require consent use the mandatory option, e.g.
 
 ```ts
 track("Mandatory Event", { foo: "bar" }, { mandatory: true });
 ```
 
-`track` is generally fire-and-forget. Delivery status is published on `analyticsEvents$`. When you need to wait until an event is enqueued await the call.
+### Async and await
+
+`track` can be fire-and-forget – async enrichment and delivery will run inside the package. The final delivery status is published on `analyticsEvents$`.
+
+When you need to wait until an event is enqueued, await the call, e.g.
 
 ```ts
-await track("Your Event", { foo: "bar" });
+await track("My Crucial Event", { foo: "bar" });
 ```
 
-Extra props and the registered analytics client may be sync or async.
+The registered analytics client may be sync or async.
 
-Extra props override event props if they have the same key.
+### Filtering and enriching
+
+Use `setPropsFilter` if you need to check your payload for sensitive data before tracking and use `setExtraPropsFn` and `setMandatoryExtraPropsFn` to add props to every payload, e.g.
+
+```ts
+setPropsFilter(scrubSensitive);
+setExtraPropsFn(() => ({ appVersion: "1.2.3" }));
+
+await track("track", { theme: "light", sensitive: "from-enricher" });
+
+analyticsEvents$.subscribe((event) => {
+  console.log(event.eventProps);
+});
+
+// { appVersion: "1.2.3", theme: "light" },
+```

--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -42,12 +42,18 @@ const sub = analyticsEvents$.subscribe((event) => myEvents.push(event));
 const unsubscribe = sub.unsubscribe;
 ```
 
-`track` returns `void` and is fire-and-forget. Enrichment and delivery run asynchronously inside the package.
-
 Tracking is off until enabled explicitly. Pass `{ mandatory: true }` to skip that check.
 
 ```ts
 track("Mandatory Event", { foo: "bar" }, { mandatory: true });
 ```
 
-Extra props and the registered analytics client may be sync or async. Extra props from the function overwrite the same keys on the caller’s payload.
+`track` is generally fire-and-forget. Delivery status is published on `analyticsEvents$`. When you need to wait until an event is enqueued await the call.
+
+```ts
+await track("Your Event", { foo: "bar" });
+```
+
+Extra props and the registered analytics client may be sync or async.
+
+Extra props override event props if they have the same key.

--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -1,0 +1,53 @@
+# @shared/analytics
+
+> [!CAUTION]
+>
+> **Status: WIP** — New package for LIVE-37157. Delete this note once the work is complete.
+
+Shared `track` for Ledger Wallet apps. Each app registers its own analytics client (e.g. Segment), consent check, and extra props.
+
+## Example Setup
+
+```ts
+import {
+  analyticsEvents$,
+  setAnalytics,
+  setEnabledFn,
+  setExtraPropsFn,
+  setMandatoryExtraPropsFn,
+  setPropsFilter,
+  track,
+  type LoggableEvent,
+} from "@shared/analytics";
+
+setEnabledFn(() => analyticsEnabledSelector(store.getState()));
+setExtraPropsFn(() => analyticsExtraPropsSelector(store.getState()));
+setMandatoryExtraPropsFn(() =>
+  analyticsMandatoryPropsSelector(store.getState())
+);
+setPropsFilter((props) => yourFilter(props));
+setAnalytics({
+  track: (event, props) => {
+    void segment.track(event, props);
+  },
+  log: console.log,
+});
+
+// track events
+track("Your Event", { foo: "bar" });
+
+// subscribe to the event bus, e.g. for a dev console
+const myDebugging: LoggableEvent[] = [];
+const sub = analyticsEvents$.subscribe((event) => myEvents.push(event));
+const unsubscribe = sub.unsubscribe;
+```
+
+`track` returns `void` and is fire-and-forget. Enrichment and delivery run asynchronously inside the package.
+
+Tracking is off until enabled explicitly. Pass `{ mandatory: true }` to skip that check.
+
+```ts
+track("Mandatory Event", { foo: "bar" }, { mandatory: true });
+```
+
+Extra props and the registered analytics client may be sync or async. Extra props from the function overwrite the same keys on the caller’s payload.

--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -49,7 +49,7 @@ Tracking is off until enabled explicitly with `setEnabledFn`.
 In the example above it is switched on by default but more often you will store user consent in some dynamic state. In this case, pass a selector for that state, e.g.
 
 ```ts
-setEnabledFn(myAnalyticsEnabledSelector(store.getState()));
+setEnabledFn(() => myAnalyticsEnabledSelector(store.getState()));
 ```
 
 For events that do not require consent use the mandatory option, e.g.

--- a/shared/analytics/jest.config.js
+++ b/shared/analytics/jest.config.js
@@ -1,0 +1,2 @@
+const { createSharedJestConfig } = require("@support/jest-shared");
+module.exports = createSharedJestConfig();

--- a/shared/analytics/package.json
+++ b/shared/analytics/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@shared/analytics",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Client agnostic analytics package",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "lint": "oxlint -c ../../libs/oxc-live-libs/.oxlintrc.json ./src",
+    "lint:fix": "pnpm exec oxfmt -c ../../libs/oxc-live-libs/.oxfmtrc.json ./src && oxlint -c ../../libs/oxc-live-libs/.oxlintrc.json ./src --fix --quiet",
+    "format": "pnpm exec oxfmt -c ../../libs/oxc-live-libs/.oxfmtrc.json ./src",
+    "format:check": "pnpm exec oxfmt -c ../../libs/oxc-live-libs/.oxfmtrc.json ./src --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/analytics"
+  },
+  "dependencies": {
+    "rxjs": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "@support/jest-shared": "workspace:*"
+  }
+}

--- a/shared/analytics/project.json
+++ b/shared/analytics/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@shared/analytics",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/analytics/src/analyticsEvents.ts
+++ b/shared/analytics/src/analyticsEvents.ts
@@ -1,0 +1,16 @@
+/**
+ * @module analytics/analyticsEvents
+ * @description
+ * This module exports the analytics events stream.
+ *
+ * @example
+ * ```ts
+ * import { analyticsEvents$ } from "@shared/analytics";
+ *
+ * analyticsEvents$.subscribe(event => {
+ *   console.log(event);
+ * });
+ * ```
+ */
+
+export { analyticsEvents$ } from "./internals/eventLog";

--- a/shared/analytics/src/index.ts
+++ b/shared/analytics/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./analyticsEvents";
+export * from "./registry";
+export * from "./track";
+export type * from "./types";

--- a/shared/analytics/src/internals/deliver.test.ts
+++ b/shared/analytics/src/internals/deliver.test.ts
@@ -1,0 +1,199 @@
+import { setAnalytics } from "../registry";
+import type { Analytics, DeliveryStatus, LoggableEvent } from "../types";
+import { deliver } from "./deliver";
+import { analyticsEvents$ } from "./eventLog";
+
+const events: LoggableEvent[] = [];
+let sub: ReturnType<typeof analyticsEvents$.subscribe>;
+
+beforeAll(() => {
+  sub = analyticsEvents$.subscribe(event => events.push(event));
+});
+
+afterAll(() => {
+  sub.unsubscribe();
+});
+
+const createAnalyticsClient = ({
+  track = jest.fn(),
+  log = jest.fn(),
+}: Partial<Analytics> = {}): jest.Mocked<Analytics> =>
+  ({
+    track: jest.fn(track),
+    log: jest.fn(log),
+  }) as unknown as jest.Mocked<Analytics>;
+
+beforeEach(() => {
+  events.length = 0;
+  setAnalytics(undefined);
+});
+
+describe("deliver", () => {
+  it("sends the event name and props to the analytics client", async () => {
+    const analytics = createAnalyticsClient();
+    setAnalytics(analytics);
+
+    await deliver({
+      type: "track",
+      eventName: "Tracked",
+      eventProps: { foo: "bar" },
+      eventPropsWithoutExtra: { foo: "bar" },
+    });
+
+    expect(analytics.track).toHaveBeenCalledWith("Tracked", { foo: "bar" });
+  });
+
+  it("logs before sending", async () => {
+    const analytics = createAnalyticsClient();
+    setAnalytics(analytics);
+
+    await deliver({
+      type: "track",
+      eventName: "Logged",
+      eventProps: { foo: "bar" },
+      eventPropsWithoutExtra: { foo: "bar" },
+    });
+
+    expect(analytics.log).toHaveBeenCalledWith("track", "Logged", {
+      foo: "bar",
+    });
+  });
+
+  it("still tracks when logging throws", async () => {
+    const analytics = createAnalyticsClient({
+      log: () => {
+        throw new Error("logger is down");
+      },
+    });
+    setAnalytics(analytics);
+
+    await expect(
+      deliver({
+        type: "track",
+        eventName: "Tracked",
+        eventProps: { foo: "bar" },
+        eventPropsWithoutExtra: { foo: "bar" },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(analytics.track).toHaveBeenCalledWith("Tracked", {
+      foo: "bar",
+    });
+    expect(events[0].deliveryStatus).toBe("enqueued");
+  });
+
+  it("publishes enriched payloads", async () => {
+    setAnalytics(createAnalyticsClient());
+
+    await deliver({
+      type: "track",
+      eventName: "Both Payloads",
+      eventProps: { foo: "bar", appVersion: "1.2.3" },
+      eventPropsWithoutExtra: { foo: "bar" },
+    });
+
+    expect(events[0]).toEqual({
+      date: expect.any(Date),
+      deliveryStatus: "enqueued",
+      eventName: "Both Payloads",
+      eventProps: { foo: "bar", appVersion: "1.2.3" },
+      eventPropsWithoutExtra: { foo: "bar" },
+    });
+  });
+
+  describe("delivery status", () => {
+    it("defaults to enqueued for a synchronous analytics client", async () => {
+      setAnalytics(createAnalyticsClient());
+
+      await deliver({
+        type: "track",
+        eventName: "Enqueued",
+        eventProps: {},
+        eventPropsWithoutExtra: {},
+      });
+
+      expect(events[0].deliveryStatus).toBe("enqueued");
+    });
+
+    it("lets the analytics client override the default status", async () => {
+      setAnalytics(
+        createAnalyticsClient({
+          track: async () => "skipped_no_token" as DeliveryStatus,
+        }),
+      );
+
+      await deliver({
+        type: "track",
+        eventName: "Overridden",
+        eventProps: {},
+        eventPropsWithoutExtra: {},
+      });
+
+      expect(events[0].deliveryStatus).toBe("skipped_no_token");
+    });
+
+    it("defaults to enqueued for an analytics client resolving nothing", async () => {
+      setAnalytics(createAnalyticsClient({ track: async () => {} }));
+
+      await deliver({
+        type: "track",
+        eventName: "Async Void",
+        eventProps: {},
+        eventPropsWithoutExtra: {},
+      });
+
+      expect(events[0].deliveryStatus).toBe("enqueued");
+    });
+
+    it("reports failed_tracking when the analytics client throws", async () => {
+      setAnalytics(
+        createAnalyticsClient({
+          track: () => {
+            throw new Error("segment is down");
+          },
+        }),
+      );
+
+      await expect(
+        deliver({
+          type: "track",
+          eventName: "Throwing",
+          eventProps: {},
+          eventPropsWithoutExtra: {},
+        }),
+      ).resolves.toBeUndefined();
+      expect(events[0].deliveryStatus).toBe("failed_tracking");
+    });
+
+    it("reports failed_tracking without rejecting when the analytics client rejects", async () => {
+      setAnalytics(
+        createAnalyticsClient({
+          track: async () => Promise.reject(new Error("segment is down")),
+        }),
+      );
+
+      await expect(
+        deliver({
+          type: "track",
+          eventName: "Rejecting",
+          eventProps: {},
+          eventPropsWithoutExtra: {},
+        }),
+      ).resolves.toBeUndefined();
+      expect(events[0].deliveryStatus).toBe("failed_tracking");
+    });
+
+    it("reports skipped_no_client when no analytics client is registered", async () => {
+      setAnalytics(undefined);
+
+      await deliver({
+        type: "track",
+        eventName: "No Client",
+        eventProps: {},
+        eventPropsWithoutExtra: {},
+      });
+
+      expect(events[0].deliveryStatus).toBe("skipped_no_client");
+    });
+  });
+});

--- a/shared/analytics/src/internals/deliver.ts
+++ b/shared/analytics/src/internals/deliver.ts
@@ -1,0 +1,42 @@
+import { getAnalytics } from "../registry";
+import type { DeliveryStatus, EventType, Props } from "../types";
+import { publishEvent } from "./eventLog";
+
+type Delivery = {
+  type: EventType;
+  eventName: string;
+  eventProps: Props;
+  eventPropsWithoutExtra: Props;
+};
+
+export async function deliver({
+  type: kind,
+  eventName,
+  eventProps,
+  eventPropsWithoutExtra,
+}: Delivery): Promise<void> {
+  const publish = (deliveryStatus: DeliveryStatus) =>
+    publishEvent({
+      eventName,
+      eventProps,
+      eventPropsWithoutExtra,
+      deliveryStatus,
+    });
+
+  const analytics = getAnalytics();
+  if (!analytics) {
+    publish("skipped_no_client");
+    return;
+  }
+
+  try {
+    analytics.log?.(kind, eventName, eventProps);
+  } catch {}
+
+  try {
+    const status = await analytics.track(eventName, eventProps);
+    publish(status ?? "enqueued");
+  } catch {
+    publish("failed_tracking");
+  }
+}

--- a/shared/analytics/src/internals/eventLog.test.ts
+++ b/shared/analytics/src/internals/eventLog.test.ts
@@ -1,0 +1,62 @@
+import type { LoggableEvent } from "../types";
+import { analyticsEvents$, publishEvent } from "./eventLog";
+
+const events: LoggableEvent[] = [];
+let sub: ReturnType<typeof analyticsEvents$.subscribe>;
+
+beforeAll(() => {
+  sub = analyticsEvents$.subscribe(event => events.push(event));
+});
+
+afterAll(() => {
+  sub.unsubscribe();
+});
+
+beforeEach(() => {
+  events.length = 0;
+});
+
+describe("publishEvent", () => {
+  it("publishes a dated event to analyticsEvents$", () => {
+    publishEvent({
+      eventName: "Published",
+      eventProps: { foo: "bar", appVersion: "1.2.3" },
+      eventPropsWithoutExtra: { foo: "bar" },
+      deliveryStatus: "enqueued",
+    });
+
+    expect(events[0]).toEqual({
+      date: expect.any(Date),
+      eventName: "Published",
+      eventProps: { foo: "bar", appVersion: "1.2.3" },
+      eventPropsWithoutExtra: { foo: "bar" },
+      deliveryStatus: "enqueued",
+    });
+  });
+
+  it("defaults absent payloads to empty objects", () => {
+    publishEvent({
+      eventName: "Defaults",
+      deliveryStatus: "failed_filter",
+    });
+
+    expect(events[0]).toEqual({
+      date: expect.any(Date),
+      eventName: "Defaults",
+      eventProps: {},
+      eventPropsWithoutExtra: {},
+      deliveryStatus: "failed_filter",
+    });
+  });
+
+  it("forwards the delivery status", () => {
+    publishEvent({
+      eventName: "Status",
+      eventProps: { foo: "bar" },
+      eventPropsWithoutExtra: { foo: "bar" },
+      deliveryStatus: "failed_enrichment",
+    });
+
+    expect(events[0].deliveryStatus).toBe("failed_enrichment");
+  });
+});

--- a/shared/analytics/src/internals/eventLog.ts
+++ b/shared/analytics/src/internals/eventLog.ts
@@ -1,0 +1,26 @@
+import { ReplaySubject } from "rxjs";
+import type { DeliveryStatus, LoggableEvent, Props } from "../types";
+
+const eventLog = new ReplaySubject<LoggableEvent>(30);
+
+export const analyticsEvents$ = eventLog.asObservable();
+
+export function publishEvent({
+  eventName,
+  eventProps = {},
+  eventPropsWithoutExtra = {},
+  deliveryStatus,
+}: {
+  eventName: string;
+  eventProps?: Props;
+  eventPropsWithoutExtra?: Props;
+  deliveryStatus: DeliveryStatus;
+}): void {
+  eventLog.next({
+    eventName,
+    eventProps,
+    eventPropsWithoutExtra,
+    date: new Date(),
+    deliveryStatus,
+  });
+}

--- a/shared/analytics/src/internals/normalizeProps.test.ts
+++ b/shared/analytics/src/internals/normalizeProps.test.ts
@@ -1,0 +1,49 @@
+import { normalizeProps } from "./normalizeProps";
+
+describe("normalizeProps", () => {
+  it("returns an empty object for null", () => {
+    expect(normalizeProps(null)).toEqual({});
+  });
+
+  it("returns an empty object for undefined", () => {
+    expect(normalizeProps(undefined)).toEqual({});
+  });
+
+  it("wraps an Error as name and message only", () => {
+    const error = new Error("something went wrong");
+    error.name = "TypeError";
+
+    const result = normalizeProps(error);
+
+    expect(result).toEqual({
+      error: { name: "TypeError", message: "something went wrong" },
+    });
+    expect(result.error).not.toBeInstanceOf(Error);
+    expect(JSON.stringify(result)).not.toContain("stack");
+  });
+
+  it("omits extra enumerable fields from a custom Error", () => {
+    class CustomError extends Error {
+      constructor(
+        message: string,
+        readonly token: string,
+      ) {
+        super(message);
+        this.name = "CustomError";
+      }
+    }
+
+    expect(normalizeProps(new CustomError("failed", "secret-token"))).toEqual({
+      error: { name: "CustomError", message: "failed" },
+    });
+  });
+
+  it("returns a shallow copy of an object", () => {
+    const props = { foo: "bar" };
+
+    const result = normalizeProps(props);
+
+    expect(result).toEqual({ foo: "bar" });
+    expect(result).not.toBe(props);
+  });
+});

--- a/shared/analytics/src/internals/normalizeProps.ts
+++ b/shared/analytics/src/internals/normalizeProps.ts
@@ -1,0 +1,13 @@
+import type { Props } from "../types";
+
+export function normalizeProps(props?: Error | Props | null): Props {
+  if (props == null) {
+    return {};
+  }
+
+  if (props instanceof Error) {
+    return { error: { name: props.name, message: props.message } };
+  }
+
+  return { ...props };
+}

--- a/shared/analytics/src/internals/trackEvent.test.ts
+++ b/shared/analytics/src/internals/trackEvent.test.ts
@@ -229,5 +229,27 @@ describe("trackEvent", () => {
         }),
       ]);
     });
+
+    it("reports failed_filter when the property filter throws after enrichment succeeds", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setExtraPropsFn(() => ({ appVersion: "1.2.3" }));
+      setPropsFilter(props => {
+        if ("appVersion" in props) {
+          throw new Error("filter failed on enriched payload");
+        }
+        return scrubSensitive(props);
+      });
+
+      await trackEvent("track", "Enriched Filter Failure", { theme: "light" });
+
+      expect(analyticsClient.track).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        expect.objectContaining({
+          eventName: "Enriched Filter Failure",
+          deliveryStatus: "failed_filter",
+        }),
+      ]);
+    });
   });
 });

--- a/shared/analytics/src/internals/trackEvent.test.ts
+++ b/shared/analytics/src/internals/trackEvent.test.ts
@@ -1,0 +1,233 @@
+import {
+  setAnalytics,
+  setExtraPropsFn,
+  setMandatoryExtraPropsFn,
+  setPropsFilter,
+} from "../registry";
+import type { Analytics, LoggableEvent, Props } from "../types";
+import { analyticsEvents$ } from "./eventLog";
+import { trackEvent } from "./trackEvent";
+
+const events: LoggableEvent[] = [];
+let sub: ReturnType<typeof analyticsEvents$.subscribe>;
+
+beforeAll(() => {
+  sub = analyticsEvents$.subscribe(event => events.push(event));
+});
+
+afterAll(() => {
+  sub.unsubscribe();
+});
+
+const createAnalyticsClient = ({
+  track = jest.fn(),
+  log = jest.fn(),
+}: Partial<Analytics> = {}): jest.Mocked<Analytics> =>
+  ({
+    track: jest.fn(track),
+    log: jest.fn(log),
+  }) as unknown as jest.Mocked<Analytics>;
+
+const scrubSensitive = (props: Props): Props => {
+  const filtered = { ...props };
+  delete filtered.sensitive;
+  return filtered;
+};
+
+beforeEach(() => {
+  events.length = 0;
+  setAnalytics(undefined);
+  setExtraPropsFn(undefined);
+  setMandatoryExtraPropsFn(undefined);
+  setPropsFilter(undefined);
+});
+
+describe("trackEvent", () => {
+  describe("enrichment", () => {
+    it("sends with sync extras", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setExtraPropsFn(() => ({ appVersion: "1.2.3" }));
+
+      await trackEvent("track", "Sync Event", {});
+
+      expect(analyticsClient.track).toHaveBeenCalledWith("Sync Event", {
+        appVersion: "1.2.3",
+      });
+    });
+
+    it("sends after async extras resolve", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      let resolveExtras: (value: Props) => void = () => {};
+      setExtraPropsFn(
+        () =>
+          new Promise<Props>(resolve => {
+            resolveExtras = resolve;
+          }),
+      );
+
+      const pending = trackEvent("track", "Async Event", {});
+
+      expect(analyticsClient.track).not.toHaveBeenCalled();
+      resolveExtras({ appVersion: "1.2.3" });
+      await pending;
+      expect(analyticsClient.track).toHaveBeenCalledWith("Async Event", {
+        appVersion: "1.2.3",
+      });
+    });
+
+    it("calls the extra props function with no arguments", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      const extraProps = jest.fn(() => ({}));
+      setExtraPropsFn(extraProps);
+
+      await trackEvent("track", "Stateful", {});
+
+      expect(extraProps).toHaveBeenCalledWith();
+    });
+
+    it("lets extra props win over caller props", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setExtraPropsFn(() => ({ platform: "desktop" }));
+
+      await trackEvent("track", "Collision", { platform: "caller-supplied" });
+
+      expect(analyticsClient.track).toHaveBeenCalledWith("Collision", {
+        platform: "desktop",
+      });
+    });
+
+    it("uses mandatory extra props for mandatory events", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setMandatoryExtraPropsFn(() => ({ mandatory: "props" }));
+
+      await trackEvent("track", "Mandatory Event", { flow: "onboarding" }, { mandatory: true });
+
+      expect(analyticsClient.track).toHaveBeenCalledWith("Mandatory Event", {
+        flow: "onboarding",
+        mandatory: "props",
+      });
+    });
+
+    it("reports failed_enrichment without rejecting when async extras reject", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setExtraPropsFn(() => Promise.reject(new Error("permission read failed")));
+
+      await expect(trackEvent("track", "Unenrichable", { foo: "bar" })).resolves.toBeUndefined();
+
+      expect(analyticsClient.track).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        expect.objectContaining({
+          eventName: "Unenrichable",
+          eventProps: { foo: "bar" },
+          eventPropsWithoutExtra: { foo: "bar" },
+          deliveryStatus: "failed_enrichment",
+        }),
+      ]);
+    });
+
+    it("reports failed_enrichment when sync extras throw", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setExtraPropsFn(() => {
+        throw new Error("permission read failed");
+      });
+
+      await trackEvent("track", "Unenrichable", { foo: "bar" });
+
+      expect(analyticsClient.track).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        expect.objectContaining({
+          eventName: "Unenrichable",
+          eventProps: { foo: "bar" },
+          eventPropsWithoutExtra: { foo: "bar" },
+          deliveryStatus: "failed_enrichment",
+        }),
+      ]);
+    });
+  });
+
+  describe("property filter", () => {
+    it("filters caller props before sending", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setPropsFilter(scrubSensitive);
+
+      await trackEvent("track", "Tracking Event", { sensitive: "data to filter", theme: "light" });
+
+      expect(analyticsClient.track).toHaveBeenCalledWith("Tracking Event", {
+        theme: "light",
+      });
+    });
+
+    it("filters enriched props before sending", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setExtraPropsFn(() => ({ sensitive: "from-enricher", appVersion: "1.2.3" }));
+      setPropsFilter(scrubSensitive);
+
+      await trackEvent("track", "Enriched Event", { theme: "light" });
+
+      expect(analyticsClient.track).toHaveBeenCalledWith("Enriched Event", {
+        theme: "light",
+        appVersion: "1.2.3",
+      });
+    });
+
+    it("publishes filtered payloads to analyticsEvents$ on success", async () => {
+      setAnalytics(createAnalyticsClient());
+      setExtraPropsFn(() => ({ sensitive: "from-enricher", appVersion: "1.2.3" }));
+      setPropsFilter(scrubSensitive);
+
+      await trackEvent("track", "Subject Event", { theme: "light" });
+
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          eventName: "Subject Event",
+          eventProps: { theme: "light", appVersion: "1.2.3" },
+          eventPropsWithoutExtra: { theme: "light" },
+        }),
+      );
+    });
+
+    it("publishes filtered payloads to analyticsEvents$ when async extras reject", async () => {
+      setAnalytics(createAnalyticsClient());
+      setExtraPropsFn(() => Promise.reject(new Error("permission read failed")));
+      setPropsFilter(scrubSensitive);
+
+      await trackEvent("track", "Unenrichable", { sensitive: "data to filter", theme: "light" });
+
+      expect(events).toEqual([
+        expect.objectContaining({
+          eventName: "Unenrichable",
+          eventProps: { theme: "light" },
+          eventPropsWithoutExtra: { theme: "light" },
+          deliveryStatus: "failed_enrichment",
+        }),
+      ]);
+    });
+
+    it("reports failed_filter when the property filter throws", async () => {
+      const analyticsClient = createAnalyticsClient();
+      setAnalytics(analyticsClient);
+      setPropsFilter(() => {
+        throw new Error("filter failed");
+      });
+
+      await trackEvent("track", "Filtered Event", { theme: "light" });
+
+      expect(analyticsClient.track).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        expect.objectContaining({
+          eventName: "Filtered Event",
+          deliveryStatus: "failed_filter",
+        }),
+      ]);
+    });
+  });
+});

--- a/shared/analytics/src/internals/trackEvent.ts
+++ b/shared/analytics/src/internals/trackEvent.ts
@@ -1,0 +1,41 @@
+import { applyPropsFilter, resolveExtraProps } from "../registry";
+import type { EventType, Props, TrackOptions } from "../types";
+import { deliver } from "./deliver";
+import { publishEvent } from "./eventLog";
+
+export async function trackEvent(
+  kind: EventType,
+  eventName: string,
+  props: Props,
+  { mandatory = false }: TrackOptions = {},
+) {
+  let filteredProps: Props;
+
+  try {
+    filteredProps = applyPropsFilter(props);
+  } catch {
+    publishEvent({ eventName, deliveryStatus: "failed_filter" });
+    return;
+  }
+
+  let filteredExtras: Props = {};
+
+  try {
+    filteredExtras = applyPropsFilter({ ...props, ...(await resolveExtraProps(mandatory)) });
+  } catch {
+    publishEvent({
+      eventName,
+      eventProps: filteredProps,
+      eventPropsWithoutExtra: filteredProps,
+      deliveryStatus: "failed_enrichment",
+    });
+    return;
+  }
+
+  await deliver({
+    type: kind,
+    eventName,
+    eventProps: filteredExtras,
+    eventPropsWithoutExtra: filteredProps,
+  });
+}

--- a/shared/analytics/src/internals/trackEvent.ts
+++ b/shared/analytics/src/internals/trackEvent.ts
@@ -18,10 +18,10 @@ export async function trackEvent(
     return;
   }
 
-  let filteredExtras: Props = {};
+  let extraProps: Props;
 
   try {
-    filteredExtras = applyPropsFilter({ ...props, ...(await resolveExtraProps(mandatory)) });
+    extraProps = (await resolveExtraProps(mandatory)) ?? {};
   } catch {
     publishEvent({
       eventName,
@@ -29,6 +29,15 @@ export async function trackEvent(
       eventPropsWithoutExtra: filteredProps,
       deliveryStatus: "failed_enrichment",
     });
+    return;
+  }
+
+  let filteredExtras: Props;
+
+  try {
+    filteredExtras = applyPropsFilter({ ...props, ...extraProps });
+  } catch {
+    publishEvent({ eventName, deliveryStatus: "failed_filter" });
     return;
   }
 

--- a/shared/analytics/src/registry.test.ts
+++ b/shared/analytics/src/registry.test.ts
@@ -1,0 +1,103 @@
+import {
+  applyPropsFilter,
+  getAnalytics,
+  isEnabled,
+  resolveExtraProps,
+  setAnalytics,
+  setEnabledFn,
+  setExtraPropsFn,
+  setMandatoryExtraPropsFn,
+  setPropsFilter,
+} from "./registry";
+
+beforeEach(() => {
+  setAnalytics(undefined);
+  setEnabledFn(undefined);
+  setExtraPropsFn(undefined);
+  setMandatoryExtraPropsFn(undefined);
+  setPropsFilter(undefined);
+});
+
+describe("registry", () => {
+  describe("getAnalytics", () => {
+    it("returns the injected analytics", () => {
+      const myAnalytics = { track: jest.fn() };
+      setAnalytics(myAnalytics);
+
+      expect(getAnalytics()).toBe(myAnalytics);
+    });
+
+    it("returns undefined after the analytics client is cleared", () => {
+      setAnalytics({ track: jest.fn() });
+      setAnalytics(undefined);
+
+      expect(getAnalytics()).toBeUndefined();
+    });
+  });
+
+  describe("isEnabled", () => {
+    it("is false by default", () => {
+      expect(isEnabled()).toEqual(false);
+    });
+
+    it("is true when the enabled function returns true", () => {
+      setEnabledFn(() => true);
+
+      expect(isEnabled()).toEqual(true);
+    });
+
+    it("is false when the enabled function returns false", () => {
+      setEnabledFn(() => false);
+
+      expect(isEnabled()).toEqual(false);
+    });
+
+    it("is false after the enabled function is cleared", () => {
+      setEnabledFn(() => true);
+      setEnabledFn(undefined);
+
+      expect(isEnabled()).toEqual(false);
+    });
+  });
+
+  describe("resolveExtraProps", () => {
+    it("uses the extra props function for non-mandatory events", () => {
+      setExtraPropsFn(() => ({ extra: "props" }));
+      setMandatoryExtraPropsFn(() => ({ mandatory: "props" }));
+
+      expect(resolveExtraProps(false)).toEqual({ extra: "props" });
+    });
+
+    it("uses the mandatory extra props function for mandatory events", () => {
+      setExtraPropsFn(() => ({ extra: "props" }));
+      setMandatoryExtraPropsFn(() => ({ mandatory: "props" }));
+
+      expect(resolveExtraProps(true)).toEqual({ mandatory: "props" });
+    });
+
+    it("returns undefined when no function is registered", () => {
+      expect(resolveExtraProps(false)).toBeUndefined();
+      expect(resolveExtraProps(true)).toBeUndefined();
+    });
+  });
+
+  describe("applyPropsFilter", () => {
+    it("returns props unchanged when no filter is registered", () => {
+      expect(applyPropsFilter({ harmless: "unfiltered" })).toStrictEqual({
+        harmless: "unfiltered",
+      });
+    });
+
+    it("runs props through the registered filter", () => {
+      setPropsFilter(props => {
+        const filtered = { ...props };
+        delete filtered.sensitive;
+        return filtered;
+      });
+
+      expect(applyPropsFilter({ sensitive: "filtered", harmless: "unfiltered" })).toEqual({
+        harmless: "unfiltered",
+      });
+    });
+  });
+});

--- a/shared/analytics/src/registry.ts
+++ b/shared/analytics/src/registry.ts
@@ -1,0 +1,77 @@
+/**
+ * @module analytics/registry
+ * @description
+ * This module exports the analytics registry.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   setAnalytics,
+ *   setEnabledFn,
+ *   setExtraPropsFn,
+ *   setMandatoryExtraPropsFn,
+ *   setPropsFilter,
+ * } from "@shared/analytics";
+ *
+ * setAnalytics({ track: async (_event, _props) => {} });
+ * setEnabledFn(() => true);
+ * setExtraPropsFn(() => ({ extra: "props" }));
+ * setMandatoryExtraPropsFn(() => ({ mandatory: "props" }));
+ * setPropsFilter(props => {
+ *   const filtered = { ...props };
+ *   delete filtered.sensitive;
+ *   return filtered;
+ * });
+ * ```
+ */
+
+import type {
+  Analytics,
+  EnabledFn,
+  ExtraPropsFn,
+  MandatoryExtraPropsFn,
+  Props,
+  PropsFilter,
+} from "./types";
+
+let _analytics: Analytics | undefined;
+let _enabledFn: EnabledFn | undefined;
+let _extraPropsFn: ExtraPropsFn | undefined;
+let _mandatoryExtraPropsFn: MandatoryExtraPropsFn | undefined;
+let _propsFilter: PropsFilter | undefined;
+
+export function setAnalytics(analytics?: Analytics): void {
+  _analytics = analytics;
+}
+
+export function getAnalytics(): Analytics | undefined {
+  return _analytics;
+}
+
+export function setEnabledFn(enabledFn?: EnabledFn): void {
+  _enabledFn = enabledFn;
+}
+
+export function isEnabled(): boolean {
+  return _enabledFn?.() ?? false;
+}
+
+export function setExtraPropsFn(extraPropsFn?: ExtraPropsFn): void {
+  _extraPropsFn = extraPropsFn;
+}
+
+export function setMandatoryExtraPropsFn(mandatoryExtraPropsFn?: MandatoryExtraPropsFn): void {
+  _mandatoryExtraPropsFn = mandatoryExtraPropsFn;
+}
+
+export function resolveExtraProps(mandatory: boolean): Props | Promise<Props> | undefined {
+  return mandatory ? _mandatoryExtraPropsFn?.() : _extraPropsFn?.();
+}
+
+export function setPropsFilter(propsFilter?: PropsFilter): void {
+  _propsFilter = propsFilter;
+}
+
+export function applyPropsFilter(props: Props): Props {
+  return _propsFilter ? _propsFilter(props) : props;
+}

--- a/shared/analytics/src/track.test.ts
+++ b/shared/analytics/src/track.test.ts
@@ -51,4 +51,39 @@ describe("track", () => {
       { mandatory: true },
     );
   });
+
+  it("returns a promise that settles when trackEvent resolves", async () => {
+    register();
+    let resolveTrackEvent: (() => void) | undefined;
+    jest.mocked(trackEvent).mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTrackEvent = resolve;
+        }),
+    );
+
+    let settled = false;
+    const pending = track("Analytics Event", { event: "props" });
+    expect(pending).toBeInstanceOf(Promise);
+
+    void pending?.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveTrackEvent?.();
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it("returns undefined when tracking is disabled and not mandatory", () => {
+    register();
+    setEnabledFn(() => false);
+
+    const result = track("Analytics Consent", { flow: "onboarding" });
+
+    expect(result).toBeUndefined();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
 });

--- a/shared/analytics/src/track.test.ts
+++ b/shared/analytics/src/track.test.ts
@@ -1,0 +1,54 @@
+jest.mock("./internals/trackEvent", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import { setEnabledFn } from "./registry";
+import { trackEvent } from "./internals/trackEvent";
+import { track } from "./track";
+
+const register = () => {
+  setEnabledFn(() => true);
+};
+
+beforeEach(() => {
+  jest.mocked(trackEvent).mockReset();
+  setEnabledFn(() => true);
+});
+
+describe("track", () => {
+  it("delegates to trackEvent when tracking is enabled", () => {
+    register();
+
+    track("Analytics Event", { event: "props" });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "track",
+      "Analytics Event",
+      { event: "props" },
+      { mandatory: false },
+    );
+  });
+
+  it("does not delegate when tracking is disabled", () => {
+    register();
+    setEnabledFn(() => false);
+
+    track("Analytics Consent", { flow: "onboarding" });
+
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("delegates mandatory events even when tracking is disabled", () => {
+    register();
+    setEnabledFn(() => false);
+
+    track("Analytics Consent", { flow: "onboarding" }, { mandatory: true });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "track",
+      "Analytics Consent",
+      { flow: "onboarding" },
+      { mandatory: true },
+    );
+  });
+});

--- a/shared/analytics/src/track.ts
+++ b/shared/analytics/src/track.ts
@@ -1,0 +1,28 @@
+/**
+ * @module analytics/track
+ * @description
+ * This module exports the track function.
+ *
+ * @example
+ * ```ts
+ * import { track } from "@shared/analytics";
+ *
+ * track("myEvent", { prop: "value" });
+ * track("myEvent", { prop: "value" }, { mandatory: true });
+ * ```
+ */
+
+import { normalizeProps } from "./internals/normalizeProps";
+import { isEnabled } from "./registry";
+import { trackEvent } from "./internals/trackEvent";
+import type { Props, TrackOptions } from "./types";
+
+export function track(
+  event: string,
+  props?: Error | Props | null,
+  { mandatory = false }: TrackOptions = {},
+): void {
+  if (isEnabled() || mandatory) {
+    void trackEvent("track", event, normalizeProps(props), { mandatory });
+  }
+}

--- a/shared/analytics/src/track.ts
+++ b/shared/analytics/src/track.ts
@@ -22,7 +22,7 @@ export function track(
   props?: Error | Props | null,
   { mandatory = false }: TrackOptions = {},
 ): void | Promise<void> {
-  if (isEnabled() || mandatory) {
+  if (mandatory || isEnabled()) {
     return trackEvent("track", event, normalizeProps(props), { mandatory });
   }
 }

--- a/shared/analytics/src/track.ts
+++ b/shared/analytics/src/track.ts
@@ -21,8 +21,8 @@ export function track(
   event: string,
   props?: Error | Props | null,
   { mandatory = false }: TrackOptions = {},
-): void {
+): void | Promise<void> {
   if (isEnabled() || mandatory) {
-    void trackEvent("track", event, normalizeProps(props), { mandatory });
+    return trackEvent("track", event, normalizeProps(props), { mandatory });
   }
 }

--- a/shared/analytics/src/types.ts
+++ b/shared/analytics/src/types.ts
@@ -1,0 +1,37 @@
+export type Props = Record<string, unknown>;
+
+export type EventType = "track" | "page";
+
+export type DeliveryStatus =
+  | "enqueued"
+  | "failed_tracking"
+  | "failed_enrichment"
+  | "failed_filter"
+  | "skipped_no_client"
+  | "skipped_no_store"
+  | "skipped_no_token";
+
+export type LoggableEvent = {
+  eventName: string;
+  eventProps?: Props;
+  eventPropsWithoutExtra?: Props;
+  date: Date;
+  deliveryStatus?: DeliveryStatus;
+};
+
+export interface Analytics {
+  track(event: string, props: Props): void | Promise<void | DeliveryStatus>;
+  log?(type: EventType, event: string, props: Props): void;
+}
+
+export type EnabledFn = () => boolean;
+
+export type ExtraPropsFn = () => Props | Promise<Props>;
+
+export type MandatoryExtraPropsFn = () => Props;
+
+export type PropsFilter = (props: Props) => Props;
+
+export type TrackOptions = {
+  mandatory?: boolean;
+};

--- a/shared/analytics/tsconfig.json
+++ b/shared/analytics/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/shared/analytics/tsconfig.test.json
+++ b/shared/analytics/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
### 📝 Description

Add a base for a new `@shared/analytics` package.

This includes:
- package and project config (ts, test, etc.)
- README describing package
- code for setup functions (for apps to inject their analytics client, store, logging, etc.)
- code for track function (providing a slice through the primary use cases)
- code for `analyticsEvents$` (the RxJs event bus to be used by in app analytics consoles)

Out of scope (for future tickets):
- `trackPage`, `screenRefs`, `closeAndFlush` and `flush`
- `@shared/analytics-react` bringing the `Track` and `TrackPage` components
- Replacing the custom analytics used in Desktop, Mobile and Wallet CLI apps

### 🔗 Context

- **JIRA / GitHub issue**:
    -  [LIVE-37157](https://ledgerhq.atlassian.net/browse/LIVE-37157) **Create first base for @shared/analytics** 
    - [LIVE-37163](https://ledgerhq.atlassian.net/browse/LIVE-37163) **Add trackSubject to @shared/analytics** (bundled with this PR as separation would be wasteful)

This ticket is split from a large design piece in [LIVE-34837](https://ledgerhq.atlassian.net/browse/LIVE-34837). See the linked items for the split of more granular tickets.

[LIVE-37157]: https://ledgerhq.atlassian.net/browse/LIVE-37157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37163]: https://ledgerhq.atlassian.net/browse/LIVE-37163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34837]: https://ledgerhq.atlassian.net/browse/LIVE-34837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ