### PR TITLE
[LWM] fix(pay-tab): scroll the whole Pay tab content

### DIFF
--- a/.changeset/pay-tab-scroll-clipped-content.md
+++ b/.changeset/pay-tab-scroll-clipped-content.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"@features/flow-pay-card": minor
+"@features/flow-pay-card-auth": minor
+---
+
+Scroll the whole Pay tab: the content no longer gets clipped and clears the tab bar

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -13,9 +13,11 @@ import {
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Wallet40Background } from "LLM/components/Wallet40Background";
 import { TrackScreen } from "~/analytics";
+import { ScrollView } from "react-native";
 
 type PayTabViewProps = {
   readonly top: number;
+  readonly bottom: number;
   readonly cardTitle: string;
   readonly oauthConfig: CardProps["oauthConfig"];
   readonly callback: CardProps["callback"];
@@ -32,6 +34,7 @@ type PayTabViewProps = {
 export function PayTabView({
   top,
   cardTitle,
+  bottom,
   oauthConfig,
   callback,
   featureTour,
@@ -46,21 +49,26 @@ export function PayTabView({
   return (
     <Box lx={{ flex: 1 }} testID="paytab-screen">
       <Wallet40Background type="pay" />
-      <Box lx={{ flex: 1, gap: "s24", paddingHorizontal: "s16" }} style={{ paddingTop: top }}>
-        <TrackScreen category="Pay" balance_filter={balance.filter} />
-        <Balance {...balance} actionTiles={actionTiles} />
-        {isContactsEnabled && <Contacts {...contacts} />}
-        <ContactAddressPicker {...contactAddressPicker} />
-        <Card
-          title={cardTitle}
-          oauthConfig={oauthConfig}
-          callback={callback}
-          onTrackEvent={balance.onTrackEvent}
-        />
-        <FeatureTour {...featureTour} />
-        <DepositOptions {...depositOptions} />
-        <BankTransferIntro {...bankTransferIntro} />
-      </Box>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ flexGrow: 1, paddingTop: top, paddingBottom: bottom }}
+      >
+        <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
+          <TrackScreen category="Pay" balance_filter={balance.filter} />
+          <Balance {...balance} actionTiles={actionTiles} />
+          {isContactsEnabled && <Contacts {...contacts} />}
+          <ContactAddressPicker {...contactAddressPicker} />
+          <Card
+            title={cardTitle}
+            oauthConfig={oauthConfig}
+            callback={callback}
+            onTrackEvent={balance.onTrackEvent}
+          />
+          <FeatureTour {...featureTour} />
+          <DepositOptions {...depositOptions} />
+          <BankTransferIntro {...bankTransferIntro} />
+        </Box>
+      </ScrollView>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useRoute, type RouteProp } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import useEnv from "@features/platform-env";
 import { useContactsFeature } from "@features/platform-contacts";
 import { useTranslation } from "@shared/i18n";
@@ -18,7 +19,8 @@ import { track } from "~/analytics";
 import { PAY_TAB_DEEP_LINK } from "~/navigation/deeplinks/payTabDeepLink";
 
 export function usePayTabViewModel() {
-  const { top } = useNavigationBarHeights();
+  const { top, bottom } = useNavigationBarHeights();
+  const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const { params } = useRoute<RouteProp<PayTabNavigatorParamList, ScreenName.PayTab>>();
 
@@ -66,6 +68,7 @@ export function usePayTabViewModel() {
 
   return {
     top,
+    bottom: bottom + insets.bottom,
     cardTitle: t("payTab.card.title"),
     oauthConfig,
     callback,

--- a/features/flow/pay-card-auth/src/components/CardLogin/CardLoginView.native.tsx
+++ b/features/flow/pay-card-auth/src/components/CardLogin/CardLoginView.native.tsx
@@ -26,7 +26,6 @@ export function CardLoginView({
         lx={{
           flexDirection: "column",
           gap: "s4",
-          paddingTop: "s16",
         }}
       >
         <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s16" }}>

--- a/features/flow/pay-card/src/Card.native.test.tsx
+++ b/features/flow/pay-card/src/Card.native.test.tsx
@@ -46,12 +46,6 @@ describe("Card (native)", () => {
     mockStatus = "unknown";
   });
 
-  it("always shows the host title", () => {
-    render(<Card title={title} oauthConfig={oauthConfig} />);
-
-    expect(screen.getByText(title)).toBeVisible();
-  });
-
   describe("while resolving the session", () => {
     it("shows only the bare artwork, holding back the widget and card details", () => {
       render(<Card title={title} oauthConfig={oauthConfig} />);

--- a/features/flow/pay-card/src/CardView.native.tsx
+++ b/features/flow/pay-card/src/CardView.native.tsx
@@ -15,25 +15,25 @@ export function CardView({
 }: CardViewProps) {
   return (
     <Box lx={{ flex: 1, gap: "s16" }}>
-      <Subheader>
-        <SubheaderRow>
-          <SubheaderTitle>{title}</SubheaderTitle>
-        </SubheaderRow>
-      </Subheader>
       {displayState === "signedIn" ? (
         <>
+          <Subheader>
+            <SubheaderRow>
+              <SubheaderTitle>{title}</SubheaderTitle>
+            </SubheaderRow>
+          </Subheader>
           <CardOnboardingWidget />
           <CardDetails cardVisual={cardVisual} />
         </>
       ) : (
         <>
-          <CardArtwork />
           <CardLogin
             key={`${oauthConfig.apiUrl}`}
             oauthConfig={oauthConfig}
             callback={callback}
             onTrackEvent={onTrackEvent}
           />
+          <CardArtwork />
         </>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- Make the Pay tab a real `ScrollView` so content below the first screen is reachable.
- Pad the scroll content by the tab bar height plus the home-indicator inset so the last block clears the floating pill.
- Reorder the native card: signed-out shows login then artwork; the "Crypto card" title only appears when signed in.

## Test plan
- [ ] On iPhone with a home indicator, open Pay and scroll to the bottom of the card section. The last content should sit above the tab bar.
- [ ] On a short signed-out layout, confirm login sits above the artwork and there is no "Crypto card" title.
- [ ] On a signed-in layout, confirm the title, widget, and card details still render.
- [ ] `npx nx run-many -t test --projects @features/flow-pay-card,@features/flow-pay-card-auth`
- [ ] PayTab Jest suites in `apps/ledger-live-mobile/src/mvvm/features/PayTab`