### PR TITLE
[LWDM] feat(architecture): add @shared/platform-linking package

### DIFF
--- a/.changeset/shared-platform-linking.md
+++ b/.changeset/shared-platform-linking.md
@@ -1,0 +1,7 @@
+---
+"@shared/platform-linking": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add @shared/platform-linking package for cross-platform external link handling with URL safety, localization and analytics

--- a/apps/ledger-live-desktop/.eslintrc.guardrails.js
+++ b/apps/ledger-live-desktop/.eslintrc.guardrails.js
@@ -53,7 +53,11 @@ module.exports = {
   overrides: [
     {
       files: ["src/**/*.ts", "src/**/*.tsx"],
-      excludedFiles: ["src/renderer/linking.ts", "src/main/openURL.ts"],
+      excludedFiles: [
+        "src/renderer/linking.ts",
+        "src/main/openURL.ts",
+        "src/renderer/components/LinkingProviderWrapper.tsx",
+      ],
       rules: {
         "no-restricted-syntax": ["error", ...shellOpenExternalRestrictions],
       },

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -187,6 +187,7 @@
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*",
     "@shared/i18n": "workspace:*",
+    "@shared/platform-linking": "workspace:*",
     "@shared/ui-info-state": "workspace:*",
     "@tanstack/react-query": "5.28.9",
     "@tanstack/react-query-devtools": "5.28.14",

--- a/apps/ledger-live-desktop/src/renderer/App.tsx
+++ b/apps/ledger-live-desktop/src/renderer/App.tsx
@@ -36,6 +36,7 @@ import { I18nextProvider } from "react-i18next";
 import { I18nProvider } from "@shared/i18n";
 import i18n from "~/renderer/i18n/init";
 import { setZcashShieldedEnabled } from "@ledgerhq/live-common/families/zcash/setup";
+import { LinkingProviderWrapper } from "~/renderer/components/LinkingProviderWrapper";
 
 const reloadApp = (event: KeyboardEvent) => {
   if ((event.ctrlKey || event.metaKey) && event.key === "r") {
@@ -129,7 +130,9 @@ const App = ({ store, initialCountervalues }: Props) => {
       <I18nextProvider i18n={i18n}>
         <I18nProvider i18n={i18n}>
           <Provider store={store}>
-            <InnerApp initialCountervalues={initialCountervalues} />
+            <LinkingProviderWrapper>
+              <InnerApp initialCountervalues={initialCountervalues} />
+            </LinkingProviderWrapper>
           </Provider>
         </I18nProvider>
       </I18nextProvider>

--- a/apps/ledger-live-desktop/src/renderer/components/LinkingProviderWrapper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LinkingProviderWrapper.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo, type ReactNode } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { shell } from "electron";
+import {
+  LinkingProvider,
+  LEDGER_URL_LANGUAGES,
+  DEFAULT_LANGUAGE,
+  type LinkingConfig,
+} from "@shared/platform-linking";
+import { track } from "~/renderer/analytics/segment";
+import { languageSelector } from "~/renderer/reducers/settings";
+
+export function LinkingProviderWrapper({
+  children,
+}: Readonly<{ children: ReactNode }>): React.JSX.Element {
+  const currentLanguage = useSelector(languageSelector);
+
+  const config = useMemo<LinkingConfig>(
+    () => ({
+      openExternal: url => {
+        shell.openExternal(url);
+      },
+      onLinkOpened: url => track("OpenURL", { url }),
+      localization: {
+        currentLanguage,
+        defaultLanguage: DEFAULT_LANGUAGE,
+        languages: LEDGER_URL_LANGUAGES,
+      },
+    }),
+    [currentLanguage],
+  );
+
+  return <LinkingProvider config={config}>{children}</LinkingProvider>;
+}

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -224,6 +224,7 @@
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*",
     "@shared/i18n": "workspace:*",
+    "@shared/platform-linking": "workspace:*",
     "@shared/password-verifier": "workspace:*",
     "@shared/ui-info-state": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*",

--- a/apps/ledger-live-mobile/src/components/LinkingProviderWrapper.tsx
+++ b/apps/ledger-live-mobile/src/components/LinkingProviderWrapper.tsx
@@ -1,0 +1,36 @@
+import React, { useMemo, type ReactNode } from "react";
+import { Linking } from "react-native";
+import { useSelector } from "~/context/hooks";
+import {
+  LinkingProvider,
+  LEDGER_URL_LANGUAGES,
+  DEFAULT_LANGUAGE,
+  type LinkingConfig,
+} from "@shared/platform-linking";
+import { track } from "~/analytics/segment";
+import { languageSelector } from "~/reducers/settings";
+
+export function LinkingProviderWrapper({
+  children,
+}: Readonly<{ children: ReactNode }>): React.JSX.Element {
+  const currentLanguage = useSelector(languageSelector);
+
+  const config = useMemo<LinkingConfig>(
+    () => ({
+      openExternal: url => {
+        Linking.openURL(url);
+      },
+      onLinkOpened: url => {
+        track("OpenURL", { url });
+      },
+      localization: {
+        currentLanguage,
+        defaultLanguage: DEFAULT_LANGUAGE,
+        languages: LEDGER_URL_LANGUAGES,
+      },
+    }),
+    [currentLanguage],
+  );
+
+  return <LinkingProvider config={config}>{children}</LinkingProvider>;
+}

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -102,6 +102,7 @@ import {
   setSolanaTxcEnabled,
 } from "@ledgerhq/live-common/families/solana/setup";
 import { setCosmosLdmkEnabled } from "@ledgerhq/live-common/families/cosmos/setup";
+import { LinkingProviderWrapper } from "~/components/LinkingProviderWrapper";
 import { setXrpLdmkEnabled } from "@ledgerhq/live-common/families/xrp/setup";
 import { resolveSuiTransport, setSuiTransport } from "@ledgerhq/live-common/families/sui/setup";
 import useCheckAccountWithFunds from "./logic/postOnboarding/useCheckAccountWithFunds";
@@ -379,36 +380,38 @@ export default class Root extends Component {
                   {/* Two providers, one instance: `I18nextProvider` serves the app's own
                     react-i18next call sites, `I18nProvider` serves the DDD packages through
                     `@shared/i18n`. */}
-                  <I18nextProvider i18n={i18n}>
-                    <I18nProvider i18n={i18n}>
-                      <LocaleProvider>
-                        <PlatformAppProviderWrapper>
-                          <SafeAreaProvider>
-                            <ModalSystemPrimer />
-                            <StylesProvider>
-                              <StyledStatusBar />
-                              <NavBarColorHandler />
-                              <AuthPass>
-                                <GestureHandlerRootView style={styles.root}>
-                                  <WaitForAppReady currencyInitialized={currencyInitialized}>
-                                    <AppProviders initialCountervalues={initialCountervalues}>
-                                      <AppGeoBlocker>
-                                        <AppVersionBlocker>
-                                          <BridgeSyncProvider>
-                                            <App />
-                                          </BridgeSyncProvider>
-                                        </AppVersionBlocker>
-                                      </AppGeoBlocker>
-                                    </AppProviders>
-                                  </WaitForAppReady>
-                                </GestureHandlerRootView>
-                              </AuthPass>
-                            </StylesProvider>
-                          </SafeAreaProvider>
-                        </PlatformAppProviderWrapper>
-                      </LocaleProvider>
-                    </I18nProvider>
-                  </I18nextProvider>
+                  <LinkingProviderWrapper>
+                    <I18nextProvider i18n={i18n}>
+                      <I18nProvider i18n={i18n}>
+                        <LocaleProvider>
+                          <PlatformAppProviderWrapper>
+                            <SafeAreaProvider>
+                              <ModalSystemPrimer />
+                              <StylesProvider>
+                                <StyledStatusBar />
+                                <NavBarColorHandler />
+                                <AuthPass>
+                                  <GestureHandlerRootView style={styles.root}>
+                                    <WaitForAppReady currencyInitialized={currencyInitialized}>
+                                      <AppProviders initialCountervalues={initialCountervalues}>
+                                        <AppGeoBlocker>
+                                          <AppVersionBlocker>
+                                            <BridgeSyncProvider>
+                                              <App />
+                                            </BridgeSyncProvider>
+                                          </AppVersionBlocker>
+                                        </AppGeoBlocker>
+                                      </AppProviders>
+                                    </WaitForAppReady>
+                                  </GestureHandlerRootView>
+                                </AuthPass>
+                              </StylesProvider>
+                            </SafeAreaProvider>
+                          </PlatformAppProviderWrapper>
+                        </LocaleProvider>
+                      </I18nProvider>
+                    </I18nextProvider>
+                  </LinkingProviderWrapper>
                 </QueuedBottomSheetsProvider>
               </BrazeContentCardsProvider>
             </RebootProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1212,6 +1212,9 @@ importers:
       '@shared/i18n':
         specifier: workspace:*
         version: link:../../shared/i18n
+      '@shared/platform-linking':
+        specifier: workspace:*
+        version: link:../../shared/platform-linking
       '@shared/ui-info-state':
         specifier: workspace:*
         version: link:../../shared/ui-info-state
@@ -2090,6 +2093,9 @@ importers:
       '@shared/password-verifier':
         specifier: workspace:*
         version: link:../../shared/password-verifier
+      '@shared/platform-linking':
+        specifier: workspace:*
+        version: link:../../shared/platform-linking
       '@shared/ui-info-state':
         specifier: workspace:*
         version: link:../../shared/ui-info-state
@@ -17893,6 +17899,51 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  shared/platform-linking:
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.5.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
+      '@support/jest-shared':
+        specifier: workspace:*
+        version: link:../../support/jest-shared
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.0.0(@types/react@19.0.14)
+      jest:
+        specifier: 'catalog:'
+        version: 30.5.0
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.5.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.67.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   shared/schema-primitives:
     dependencies:
       zod:
@@ -23157,7 +23208,6 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28630,7 +28680,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:

--- a/shared/platform-linking/README.md
+++ b/shared/platform-linking/README.md
@@ -1,0 +1,79 @@
+# @shared/platform-linking
+
+> [!CAUTION]
+> **Status: UNSTABLE** — New package; API may change as features adopt it.
+
+Cross-platform external link opening with URL safety validation, localization, and optional tracking.
+
+## Problem
+
+Both apps (LLD/LLM) duplicate the same concerns when opening external links:
+
+- URL safety validation (`isUrlSafe`)
+- URL localization (`useLocalizedUrl`)
+- Analytics tracking (`track("OpenURL", ...)`)
+- Platform-specific open call (Electron `shell.openExternal` / RN `Linking.openURL`)
+
+This package abstracts those into a single provider that each app wires once.
+
+## Usage
+
+### App setup (wire once at root)
+
+```tsx
+// apps/ledger-live-desktop
+import { LinkingProvider } from "@shared/platform-linking";
+import { shell } from "electron";
+import { track } from "~/renderer/analytics/segment";
+
+<LinkingProvider
+  config={{
+    openExternal: (url) => shell.openExternal(url),
+    onLinkOpened: (url) => track("OpenURL", { url }),
+    localization: {
+      currentLanguage: language,
+      defaultLanguage: "en",
+      languages: { en: "", fr: "fr", es: "es" },
+    },
+  }}
+>
+  <App />
+</LinkingProvider>
+```
+
+### Feature usage
+
+```tsx
+import { useOpenLink, useLocalizedUrl } from "@shared/platform-linking";
+
+function MyComponent() {
+  const openLink = useOpenLink();
+  const supportUrl = useLocalizedUrl(FEATURE_URLS.support);
+
+  return <Link onPress={() => openLink(supportUrl)}>Help</Link>;
+}
+```
+
+### Feature-colocated URLs
+
+Each feature owns its URLs:
+
+```ts
+// features/flow/<feature>/src/urls.ts
+export const FEATURE_URLS = {
+  support: "https://support.ledger.com/article/...",
+} as const satisfies Record<string, `https://${string}`>;
+```
+
+## Exports
+
+| Export            | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `LinkingProvider`  | React context provider — wire once per app                    |
+| `useOpenLink`      | Hook returning a fire-and-forget function that validates, tracks, and opens a URL |
+| `useLocalizedUrl`  | Hook returning a localized version of a URL                   |
+| `assertSafeUrl`    | Throws if a URL uses a disallowed protocol (https/mailto only) |
+| `localizeUrl`      | Pure function to localize Ledger URLs by language             |
+| `LinkingConfig`    | Config type for the provider                                  |
+| `LocalizationConfig` | Localization subset of the config                          |
+| `OpenExternal`     | Type for the platform-specific open function                  |

--- a/shared/platform-linking/jest.config.js
+++ b/shared/platform-linking/jest.config.js
@@ -1,0 +1,20 @@
+const { createSharedJestConfig } = require("@support/jest-shared");
+module.exports = createSharedJestConfig({
+  testEnvironment: "jsdom",
+  testMatch: ["**/*.test.ts", "**/*.test.tsx"],
+  globals: {
+    IS_REACT_ACT_ENVIRONMENT: true,
+  },
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+          parser: { syntax: "typescript", tsx: true },
+          transform: { react: { runtime: "automatic" } },
+        },
+      },
+    ],
+  },
+});

--- a/shared/platform-linking/package.json
+++ b/shared/platform-linking/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@shared/platform-linking",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cross-platform external link opening with URL safety, localization, and tracking",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/platform-linking"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "typescript": "catalog:",
+    "@support/jest-shared": "workspace:*"
+  }
+}

--- a/shared/platform-linking/project.json
+++ b/shared/platform-linking/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@shared/platform-linking",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/platform-linking/src/LinkingProvider.test.tsx
+++ b/shared/platform-linking/src/LinkingProvider.test.tsx
@@ -1,0 +1,177 @@
+import React, { type ReactNode } from "react";
+import ReactDOM from "react-dom/client";
+import { act } from "react";
+import { LinkingProvider, useOpenLink, useLocalizedUrl } from "./LinkingProvider";
+import type { LinkingConfig } from "./types";
+
+function TestHarness<T>({ hook, onResult }: { hook: () => T; onResult: (value: T) => void }): null {
+  onResult(hook());
+  return null;
+}
+
+function renderHookWithProvider<T>(hook: () => T, config: LinkingConfig): T {
+  let result: T;
+  const container = document.createElement("div");
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(
+      <LinkingProvider config={config}>
+        <TestHarness
+          hook={hook}
+          onResult={v => {
+            result = v;
+          }}
+        />
+      </LinkingProvider>,
+    );
+  });
+  return result!;
+}
+
+describe("useOpenLink", () => {
+  it("throws when used outside provider", () => {
+    const container = document.createElement("div");
+    const root = ReactDOM.createRoot(container);
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      act(() => {
+        root.render(<TestHarness hook={() => useOpenLink()} onResult={() => {}} />);
+      });
+    }).toThrow("useOpenLink must be used within");
+
+    spy.mockRestore();
+  });
+
+  it("calls openExternal with the URL", () => {
+    const openExternal = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal });
+
+    openLink("https://support.ledger.com");
+    expect(openExternal).toHaveBeenCalledWith("https://support.ledger.com");
+  });
+
+  it("calls onLinkOpened callback when provided", () => {
+    const openExternal = jest.fn();
+    const onLinkOpened = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), {
+      openExternal,
+      onLinkOpened,
+    });
+
+    openLink("https://support.ledger.com");
+    expect(onLinkOpened).toHaveBeenCalledWith("https://support.ledger.com");
+    expect(openExternal).toHaveBeenCalledWith("https://support.ledger.com");
+  });
+
+  it("works without onLinkOpened", () => {
+    const openExternal = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal });
+
+    openLink("https://support.ledger.com");
+    expect(openExternal).toHaveBeenCalledWith("https://support.ledger.com");
+  });
+
+  it("blocks unsafe URLs before calling openExternal", () => {
+    const openExternal = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal });
+
+    expect(() => openLink("javascript:alert(1)")).toThrow("Blocked unsafe protocol");
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("blocks http URLs", () => {
+    const openExternal = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal });
+
+    expect(() => openLink("http://ledger.com")).toThrow("Blocked unsafe protocol");
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("allows mailto URLs", () => {
+    const openExternal = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal });
+
+    openLink("mailto:support@ledger.com");
+    expect(openExternal).toHaveBeenCalledWith("mailto:support@ledger.com");
+  });
+
+  it("does not localize — caller is responsible via useLocalizedUrl", () => {
+    const openExternal = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), {
+      openExternal,
+      localization: {
+        currentLanguage: "fr",
+        defaultLanguage: "en",
+        languages: { en: "", fr: "fr" },
+      },
+    });
+
+    openLink("https://www.ledger.com/academy");
+    expect(openExternal).toHaveBeenCalledWith("https://www.ledger.com/academy");
+  });
+
+  it("swallows rejected promises from openExternal", async () => {
+    const openExternal = jest.fn().mockRejectedValue(new Error("platform error"));
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal });
+
+    openLink("https://support.ledger.com");
+    await new Promise(r => setTimeout(r, 0));
+    expect(openExternal).toHaveBeenCalled();
+  });
+
+  it("does not call onLinkOpened when URL is unsafe", () => {
+    const openExternal = jest.fn();
+    const onLinkOpened = jest.fn();
+    const openLink = renderHookWithProvider(() => useOpenLink(), { openExternal, onLinkOpened });
+
+    expect(() => openLink("javascript:void(0)")).toThrow();
+    expect(onLinkOpened).not.toHaveBeenCalled();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("useLocalizedUrl", () => {
+  it("returns the URL unchanged without localization config", () => {
+    const url = renderHookWithProvider(() => useLocalizedUrl("https://www.ledger.com/academy"), {
+      openExternal: jest.fn(),
+    });
+    expect(url).toBe("https://www.ledger.com/academy");
+  });
+
+  it("returns a localized URL with localization config", () => {
+    const url = renderHookWithProvider(() => useLocalizedUrl("https://www.ledger.com/academy"), {
+      openExternal: jest.fn(),
+      localization: {
+        currentLanguage: "fr",
+        defaultLanguage: "en",
+        languages: { en: "", fr: "fr" },
+      },
+    });
+    expect(url).toBe("https://www.ledger.com/fr/academy");
+  });
+
+  it("returns the URL unchanged for the default language", () => {
+    const url = renderHookWithProvider(() => useLocalizedUrl("https://www.ledger.com/academy"), {
+      openExternal: jest.fn(),
+      localization: {
+        currentLanguage: "en",
+        defaultLanguage: "en",
+        languages: { en: "", fr: "fr" },
+      },
+    });
+    expect(url).toBe("https://www.ledger.com/academy");
+  });
+
+  it("returns non-Ledger URLs unchanged even with localization", () => {
+    const url = renderHookWithProvider(() => useLocalizedUrl("https://github.com/LedgerHQ"), {
+      openExternal: jest.fn(),
+      localization: {
+        currentLanguage: "fr",
+        defaultLanguage: "en",
+        languages: { en: "", fr: "fr" },
+      },
+    });
+    expect(url).toBe("https://github.com/LedgerHQ");
+  });
+});

--- a/shared/platform-linking/src/LinkingProvider.tsx
+++ b/shared/platform-linking/src/LinkingProvider.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
+import type { LinkingConfig } from "./types";
+import { assertSafeUrl } from "./assertSafeUrl";
+import { localizeUrl } from "./localizeUrl";
+
+const LinkingContext = createContext<LinkingConfig | null>(null);
+
+export function LinkingProvider({
+  children,
+  config,
+}: Readonly<{
+  children: ReactNode;
+  config: LinkingConfig;
+}>): React.JSX.Element {
+  return <LinkingContext.Provider value={config}>{children}</LinkingContext.Provider>;
+}
+
+export function useOpenLink(): (url: string) => void {
+  const config = useContext(LinkingContext);
+  if (!config) {
+    throw new Error("useOpenLink must be used within a <LinkingProvider>");
+  }
+  const { openExternal, onLinkOpened } = config;
+
+  return useCallback(
+    (url: string) => {
+      assertSafeUrl(url);
+      onLinkOpened?.(url);
+      Promise.resolve(openExternal(url)).catch(() => {});
+    },
+    [openExternal, onLinkOpened],
+  );
+}
+
+export function useLocalizedUrl(url: string): string {
+  const config = useContext(LinkingContext);
+  return useMemo(
+    () => (config?.localization ? localizeUrl(url, config.localization) : url),
+    [url, config?.localization],
+  );
+}

--- a/shared/platform-linking/src/assertSafeUrl.test.ts
+++ b/shared/platform-linking/src/assertSafeUrl.test.ts
@@ -1,0 +1,31 @@
+import { assertSafeUrl } from "./assertSafeUrl";
+
+describe("assertSafeUrl", () => {
+  it("allows https URLs", () => {
+    expect(() => assertSafeUrl("https://support.ledger.com")).not.toThrow();
+  });
+
+  it("allows mailto URLs", () => {
+    expect(() => assertSafeUrl("mailto:support@ledger.com")).not.toThrow();
+  });
+
+  it("blocks http URLs", () => {
+    expect(() => assertSafeUrl("http://example.com")).toThrow("Blocked unsafe protocol");
+  });
+
+  it("blocks javascript protocol", () => {
+    expect(() => assertSafeUrl("javascript:alert(1)")).toThrow("Blocked unsafe protocol");
+  });
+
+  it("blocks file protocol", () => {
+    expect(() => assertSafeUrl("file:///etc/passwd")).toThrow("Blocked unsafe protocol");
+  });
+
+  it("throws on invalid URLs", () => {
+    expect(() => assertSafeUrl("not-a-url")).toThrow("Invalid URL");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => assertSafeUrl("")).toThrow("Invalid URL");
+  });
+});

--- a/shared/platform-linking/src/assertSafeUrl.ts
+++ b/shared/platform-linking/src/assertSafeUrl.ts
@@ -1,0 +1,13 @@
+const ALLOWED_PROTOCOLS = new Set(["https:", "mailto:"]);
+
+export function assertSafeUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`Blocked unsafe protocol "${parsed.protocol}" in URL: ${url}`);
+  }
+}

--- a/shared/platform-linking/src/index.ts
+++ b/shared/platform-linking/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./assertSafeUrl";
+export * from "./localizeUrl";
+export * from "./LinkingProvider";

--- a/shared/platform-linking/src/localizeUrl.test.ts
+++ b/shared/platform-linking/src/localizeUrl.test.ts
@@ -1,0 +1,87 @@
+import { localizeUrl } from "./localizeUrl";
+import type { LocalizationConfig } from "./types";
+
+const baseConfig: LocalizationConfig = {
+  currentLanguage: "en",
+  defaultLanguage: "en",
+  languages: {
+    en: "",
+    fr: "fr",
+    es: "es",
+    zh: "zh-hans",
+  },
+};
+
+describe("localizeUrl", () => {
+  it("returns the URL unchanged for the default language", () => {
+    expect(localizeUrl("https://www.ledger.com/academy", baseConfig)).toBe(
+      "https://www.ledger.com/academy",
+    );
+  });
+
+  it("localizes ledger.com for French", () => {
+    const config = { ...baseConfig, currentLanguage: "fr" };
+    expect(localizeUrl("https://www.ledger.com/academy", config)).toBe(
+      "https://www.ledger.com/fr/academy",
+    );
+  });
+
+  it("localizes shop.ledger.com for Spanish", () => {
+    const config = { ...baseConfig, currentLanguage: "es" };
+    expect(localizeUrl("https://shop.ledger.com/pages/privacy-policy", config)).toBe(
+      "https://shop.ledger.com/es/pages/privacy-policy",
+    );
+  });
+
+  it("localizes support.ledger.com with zh-cn override", () => {
+    const config = { ...baseConfig, currentLanguage: "zh" };
+    expect(localizeUrl("https://support.ledger.com/article/123", config)).toBe(
+      "https://support.ledger.com/zh-cn/article/123",
+    );
+  });
+
+  it("returns non-matching URLs unchanged", () => {
+    const config = { ...baseConfig, currentLanguage: "fr" };
+    expect(localizeUrl("https://github.com/LedgerHQ", config)).toBe("https://github.com/LedgerHQ");
+  });
+
+  it("handles unknown language by returning the URL unchanged", () => {
+    const config = { ...baseConfig, currentLanguage: "xx" };
+    expect(localizeUrl("https://www.ledger.com/academy", config)).toBe(
+      "https://www.ledger.com/academy",
+    );
+  });
+
+  it("does not localize lookalike hosts", () => {
+    const config = { ...baseConfig, currentLanguage: "fr" };
+    expect(localizeUrl("https://www.ledger.com.evil/phishing", config)).toBe(
+      "https://www.ledger.com.evil/phishing",
+    );
+  });
+
+  it("does not localize subdomains of lookalike hosts", () => {
+    const config = { ...baseConfig, currentLanguage: "fr" };
+    expect(localizeUrl("https://shop.ledger.com.attacker.io/fake", config)).toBe(
+      "https://shop.ledger.com.attacker.io/fake",
+    );
+  });
+
+  it("localizes an exact domain match with no path", () => {
+    const config = { ...baseConfig, currentLanguage: "fr" };
+    expect(localizeUrl("https://www.ledger.com", config)).toBe("https://www.ledger.com/fr");
+  });
+
+  it("localizes a domain with query params", () => {
+    const config = { ...baseConfig, currentLanguage: "fr" };
+    expect(localizeUrl("https://www.ledger.com?ref=app", config)).toBe(
+      "https://www.ledger.com/fr?ref=app",
+    );
+  });
+
+  it("localizes support.ledger.com base without article suffix", () => {
+    const config = { ...baseConfig, currentLanguage: "es" };
+    expect(localizeUrl("https://support.ledger.com/faq", config)).toBe(
+      "https://support.ledger.com/es/faq",
+    );
+  });
+});

--- a/shared/platform-linking/src/localizeUrl.ts
+++ b/shared/platform-linking/src/localizeUrl.ts
@@ -1,0 +1,68 @@
+import type { LocalizationConfig } from "./types";
+
+export const LEDGER_URL_LANGUAGES: Record<string, string> = {
+  en: "",
+  fr: "fr",
+  es: "es",
+  de: "de",
+  ru: "ru",
+  zh: "zh-hans",
+  tr: "tr",
+  pt: "pt-br",
+  ja: "ja",
+  ko: "ko",
+  th: "th",
+};
+
+export const DEFAULT_LANGUAGE = "en";
+
+const BASE_LEDGER_SUPPORT = "https://support.ledger.com";
+const LEDGER = "https://www.ledger.com";
+const SHOP = "https://shop.ledger.com";
+const SALESFORCE_SUPPORT = `${BASE_LEDGER_SUPPORT}/article`;
+
+function buildLocalizedBase(
+  baseUrl: string,
+  langMap: Record<string, string>,
+  currentLanguage: string,
+  defaultLanguage: string,
+  suffix = "",
+): string {
+  const languagePart = currentLanguage === defaultLanguage ? "" : langMap[currentLanguage] || "";
+  const suffixPart = suffix ? `/${suffix}` : "";
+  const langSegment = languagePart ? `/${languagePart}` : "";
+  return `${baseUrl}${langSegment}${suffixPart}`;
+}
+
+export function localizeUrl(url: string, config: LocalizationConfig): string {
+  const { currentLanguage, defaultLanguage, languages } = config;
+
+  const salesforceLang: Record<string, string> = { ...languages, zh: "zh-cn" };
+
+  const patterns: Record<string, string> = {
+    [LEDGER]: buildLocalizedBase(LEDGER, languages, currentLanguage, defaultLanguage),
+    [SHOP]: buildLocalizedBase(SHOP, languages, currentLanguage, defaultLanguage),
+    [BASE_LEDGER_SUPPORT]: buildLocalizedBase(
+      BASE_LEDGER_SUPPORT,
+      salesforceLang,
+      currentLanguage,
+      defaultLanguage,
+    ),
+    [SALESFORCE_SUPPORT]: buildLocalizedBase(
+      BASE_LEDGER_SUPPORT,
+      salesforceLang,
+      currentLanguage,
+      defaultLanguage,
+      "article",
+    ),
+  };
+
+  const matchingPattern = Object.keys(patterns).find(
+    p =>
+      url.startsWith(p) &&
+      (url.length === p.length || url[p.length] === "/" || url[p.length] === "?"),
+  );
+  if (!matchingPattern) return url;
+
+  return url.replace(matchingPattern, patterns[matchingPattern]);
+}

--- a/shared/platform-linking/src/types.ts
+++ b/shared/platform-linking/src/types.ts
@@ -1,0 +1,13 @@
+export type OpenExternal = (url: string) => void | Promise<void>;
+
+export type LocalizationConfig = {
+  currentLanguage: string;
+  defaultLanguage: string;
+  languages: Record<string, string>;
+};
+
+export type LinkingConfig = {
+  openExternal: OpenExternal;
+  onLinkOpened?: (url: string) => void;
+  localization?: LocalizationConfig;
+};

--- a/shared/platform-linking/tsconfig.json
+++ b/shared/platform-linking/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "types": ["jest"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### 📝 Description

**Problem**: External link handling (URL safety, localization, analytics tracking) is duplicated across apps with platform-specific code scattered in `linking.ts` files. Feature packages have no clean way to open external URLs without importing app-level code.

**Solution**: New `@shared/platform-linking` package providing:

- `LinkingProvider` — React context accepting platform-specific config (`openExternal`, analytics, localization)
- `useOpenLink()` — hook that validates URL safety (`https:` / `mailto:` only), fires analytics, and delegates to platform opener
- `useLocalizedUrl()` — hook that localizes Ledger URLs based on user language
- `assertSafeUrl()` — standalone URL protocol validation
- `localizeUrl()` — standalone URL localization for Ledger domains

**Usage:**
```ts
import { useOpenLink, useLocalizedUrl } from "@shared/platform-linking";

const openLink = useOpenLink();
const privacyUrl = useLocalizedUrl("https://shop.ledger.com/pages/privacy-policy");
const onOpen = useCallback(() => openLink(privacyUrl), [openLink, privacyUrl]);
```

App integration (wiring `LinkingProvider` in LLD/LLM) and feature consumption will follow in a separate PR.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37270](https://ledgerhq.atlassian.net/browse/LIVE-37270)

[LIVE-37270]: https://ledgerhq.atlassian.net/browse/LIVE-37270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ