### PR TITLE
fix(pay-tab): align tiles in quick actions details

### DIFF
--- a/.changeset/spotty-gorillas-yell.md
+++ b/.changeset/spotty-gorillas-yell.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-details": minor
+---
+
+fix row display for quick actions

--- a/features/flow/pay-card-details/src/components/CardDetails/Scenes/OverviewScene.native.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/Scenes/OverviewScene.native.tsx
@@ -16,14 +16,18 @@ function OverviewActions({
 }: OverviewActionsProps) {
   return (
     <Box lx={{ flexDirection: "row", gap: "s8" }}>
-      <FreezeAction
-        status={freezeViewModel.status}
-        isActionDisabled={freezeViewModel.isActionDisabled}
-        onOpenConfirm={onFreezePress}
-      />
-      {moreViewModel ? (
-        <MoreAction moreLabel={moreViewModel.moreLabel} onMorePress={onMorePress} />
-      ) : null}
+      <Box lx={{ flex: 1 }}>
+        <FreezeAction
+          status={freezeViewModel.status}
+          isActionDisabled={freezeViewModel.isActionDisabled}
+          onOpenConfirm={onFreezePress}
+        />
+      </Box>
+      <Box lx={{ flex: 1 }}>
+        {moreViewModel ? (
+          <MoreAction moreLabel={moreViewModel.moreLabel} onMorePress={onMorePress} />
+        ) : null}
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
Fix alignment of Tiles in card details 


<img width="385" height="415" alt="Screenshot 2026-09-11 at 08 37 17" src="https://github.com/user-attachments/assets/f7dcbcd7-de08-4a8d-a31a-5e118db82f51" />
