### PR TITLE
[LWD] fix(mock-server): keep the device screen pressable (LIVE-37249)

### DIFF
--- a/.changeset/mock-device-screen-under-modal.md
+++ b/.changeset/mock-device-screen-under-modal.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Keep the mock server device screen reachable while a device-interaction modal is open, instead of the press dismissing the modal

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceScreen/DeviceScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceScreen/DeviceScreenView.tsx
@@ -1,11 +1,20 @@
 import React from "react";
 import type { DeviceScreenState } from "@ledgerhq/live-dmk-desktop";
 import { ChevronDown, ChevronUp, Devices } from "@ledgerhq/lumen-ui-react/symbols";
+import { cn } from "LLD/utils/cn";
 import { DeviceOsInfo } from "./components/DeviceOsInfo";
 import { DeviceScreenButtons } from "./components/DeviceScreenButtons";
 import { DeviceScreenImage } from "./components/DeviceScreenImage";
 import type { DeviceScreenViewModel } from "./types";
 import type { DeviceScreenModel } from "./utils/deviceModel";
+
+/**
+ * Device-interaction modals paint an overlay over the sidebar, disable pointer
+ * events on the body and dismiss on any pointer-down reaching the document.
+ * The panel opts out of all three so the device stays drivable under a modal.
+ */
+const reachableUnderModalOverlay = "pointer-events-auto relative z-[200]";
+const keepModalsOpen = (event: React.PointerEvent<HTMLDivElement>) => event.stopPropagation();
 
 export interface DeviceScreenViewProps {
   readonly viewModel: DeviceScreenViewModel;
@@ -26,11 +35,9 @@ export function DeviceScreenView({ viewModel }: DeviceScreenViewProps) {
   const Chevron = collapsed ? ChevronUp : ChevronDown;
 
   return (
-    // Painted above the modal layer (z-index 100): device flows put a full-window
-    // backdrop over the sidebar, and the screen has to stay clickable through it —
-    // confirming a receive address is gated on pressing the device.
     <div
-      className="relative z-[200] flex flex-col rounded-md bg-canvas-muted"
+      className={cn(reachableUnderModalOverlay, "flex flex-col rounded-md bg-canvas-muted")}
+      onPointerDown={keepModalsOpen}
       data-testid="device-screen"
     >
       <button

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceScreen/__integrations__/DeviceScreen.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceScreen/__integrations__/DeviceScreen.integration.test.tsx
@@ -92,6 +92,28 @@ describe("DeviceScreen", () => {
     expect(pressButton).toHaveBeenCalledWith("left", "release");
   });
 
+  it("stays interactive while a modal disables pointer events on the body", () => {
+    render(<DeviceScreen />);
+
+    expect(screen.getByTestId("device-screen")).toHaveClass("pointer-events-auto");
+  });
+
+  it("keeps a press from reaching the document listeners modals dismiss on", () => {
+    const onDocumentPointerDown = jest.fn();
+    document.addEventListener("pointerdown", onDocumentPointerDown);
+
+    render(<DeviceScreen />);
+    const left = screen.getByTestId("device-screen-button-left");
+    // jsdom does not implement pointer capture.
+    left.setPointerCapture = jest.fn();
+
+    fireEvent.pointerDown(left, { pointerId: 1 });
+
+    expect(onDocumentPointerDown).not.toHaveBeenCalled();
+
+    document.removeEventListener("pointerdown", onDocumentPointerDown);
+  });
+
   it("collapses to its header, stops polling, and persists the choice", async () => {
     const { user } = render(<DeviceScreen />);
 


### PR DESCRIPTION
### 📝 Description

The mock server device screen panel sits in the sidebar, under the overlay of any device-interaction modal. While such a modal was open the panel could not be pressed, and pressing it dismissed the modal and cancelled the flow — so the device could not be driven exactly when the modal was waiting on it.

Two causes, both from the modal being a Radix modal `Dialog`:

- it sets `pointer-events: none` on the `body`, so presses never reached the panel;
- it dismisses on any `pointerdown` reaching the `document`, and the panel is outside the dialog content.

The panel now opts out of both: `pointer-events-auto` restores hit-testing on its subtree, and `stopPropagation` on its `onPointerDown` keeps the press from reaching the document listener. Nothing Radix-specific, so it holds for any overlay that dismisses on document pointer-down.

Two regression tests cover it, each verified to fail without the fix:

```
✓ stays interactive while a modal disables pointer events on the body
✓ keeps a press from reaching the document listeners modals dismiss on
```

Testing-only impact: it takes a mock server device and the screen panel that comes with it, so no real user can reach this.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37249](https://ledgerhq.atlassian.net/browse/LIVE-37249)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-37249]: https://ledgerhq.atlassian.net/browse/LIVE-37249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ