### PR TITLE
fix(nx): include dep sources in coverage cache key

### DIFF
--- a/nx.workspace.json
+++ b/nx.workspace.json
@@ -456,6 +456,7 @@
     },
     "coverage": {
       "dependsOn": ["^build", "build"],
+      "inputs": ["default", "^default"],
       "outputs": [
         "{projectRoot}/coverage/lcov.info",
         "{projectRoot}/coverage/sonar-executionTests-report.xml"


### PR DESCRIPTION
Without `"^default"` in inputs, the `coverage` target's cache key only hashes files inside the project itself. Changes to shared jest config packages with `build: nx:noop` (e.g. `@support/jest-features-flow` mock files) produce no build output and therefore don't bust the coverage cache of dependents — stale results can be served even after mock changes.

Aligns `coverage` with `test`, `lint`, and `typecheck`, which already carry `"^default"`.