### PR TITLE
test(pay-card): trigger coverage re-run to validate nx cache fix

### DIFF
--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
@@ -21,6 +21,7 @@ function renderCardDetails() {
   };
 }
 
+// Triggers coverage re-run to validate nx cache key includes dep sources (see nx.workspace.json).
 describe("CardDetails (native)", () => {
   it("should show the preview actions when the card details screen renders", () => {
     renderCardDetails();


### PR DESCRIPTION
Adds a trivial comment to `CardDetails.native.test.tsx` to force a fresh coverage run. Validates that dep source changes now bust the coverage cache after the fix in #21843.