### PR TITLE
test(pay-card): reactivate More navigation test

### DIFF
--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
@@ -50,7 +50,7 @@ describe("CardDetails (native)", () => {
     expect(await screen.findByLabelText(MORE_COPY.tile)).toBeVisible();
   });
 
-  it.skip("should navigate to More without opening another sheet", async () => {
+  it("should navigate to More without opening another sheet", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));


### PR DESCRIPTION
Reverts the `it.skip` added in c900de7265c. The test already uses `findByLabelText` (async with retry) so it no longer races against the RTK Query user fetch. Depends on the nx cache fix (#21843) being merged so dep source changes bust coverage cache.