### PR TITLE
fix(jest): render onPress-bearing Lumen natives as Pressable in mock

### DIFF
--- a/.changeset/jest-passthrough-native-pressable.md
+++ b/.changeset/jest-passthrough-native-pressable.md
@@ -1,0 +1,6 @@
+---
+"@support/jest-features-flow": patch
+"@support/jest-shared": patch
+---
+
+Fix unstable Proxy component references and enable userEvent.press on Lumen natives

--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
@@ -41,9 +41,7 @@ describe("CardDetails (native)", () => {
     expect(screen.queryByText(CARD_COPY.freeze)).toBeNull();
   });
 
-  // TODO: userEvent.press does not fire onPress on custom Lumen host elements.
-  // Fix tracked in: https://github.com/LedgerHQ/ledger-live/pull/21814
-  it.skip("should open the details sheet when Details is pressed", async () => {
+  it("should open the details sheet when Details is pressed", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));
@@ -52,7 +50,7 @@ describe("CardDetails (native)", () => {
     expect(await screen.findByLabelText(MORE_COPY.tile)).toBeVisible();
   });
 
-  it.skip("should navigate to More without opening another sheet", async () => {
+  it("should navigate to More without opening another sheet", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));
@@ -62,8 +60,7 @@ describe("CardDetails (native)", () => {
     expect(screen.getByTestId("card-details-more-content")).toBeVisible();
   });
 
-  // TODO: same as above — userEvent.press on custom Lumen host elements.
-  it.skip("should navigate to freeze confirmation without opening another sheet", async () => {
+  it("should navigate to freeze confirmation without opening another sheet", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));
@@ -73,8 +70,7 @@ describe("CardDetails (native)", () => {
     expect(screen.getByTestId("card-details-freeze-content")).toBeVisible();
   });
 
-  // TODO: same as above — userEvent.press on custom Lumen host elements.
-  it.skip("should return to the overview when the freeze confirmation is cancelled", async () => {
+  it("should return to the overview when the freeze confirmation is cancelled", async () => {
     const { user } = renderCardDetails();
 
     await user.press(screen.getByLabelText(CARD_COPY.details));

--- a/support/jest-features-flow/mocks/passthrough-native.js
+++ b/support/jest-features-flow/mocks/passthrough-native.js
@@ -41,6 +41,17 @@ function Tag({ label, children, ...props }) {
 // component (e.g. Text -> "Text"), so React Native Testing Library text queries still work.
 // Hooks (`use*`) return a mutable ref stub. Redirected here via moduleNameMapper — no
 // per-component mocks, no peer installs.
+const componentCache = new Map();
+
+function makeComponent(prop) {
+  return ({ children, onPress, ...props }) => {
+    if (onPress !== undefined) {
+      return React.createElement("Pressable", { onPress, ...props }, wrapTextChildren(children));
+    }
+    return React.createElement(prop, props, wrapTextChildren(children));
+  };
+}
+
 module.exports = new Proxy(
   { __esModule: true, Banner, Tag },
   {
@@ -51,10 +62,17 @@ module.exports = new Proxy(
         return () => ({ current: null });
       }
       if (prop === "Text") {
-        return ({ children, ...props }) => React.createElement("Text", props, children);
+        if (!componentCache.has("Text")) {
+          componentCache.set("Text", ({ children, ...props }) =>
+            React.createElement("Text", props, children),
+          );
+        }
+        return componentCache.get("Text");
       }
-      return ({ children, ...props }) =>
-        React.createElement(prop, props, wrapTextChildren(children));
+      if (!componentCache.has(prop)) {
+        componentCache.set(prop, makeComponent(prop));
+      }
+      return componentCache.get(prop);
     },
   },
 );

--- a/support/jest-shared/mocks/passthrough-native.js
+++ b/support/jest-shared/mocks/passthrough-native.js
@@ -27,6 +27,17 @@ function Banner({ children, description, primaryAction, secondaryAction, ...prop
   );
 }
 
+const componentCache = new Map();
+
+function makeComponent(prop) {
+  return ({ children, onPress, ...props }) => {
+    if (onPress !== undefined) {
+      return React.createElement("Pressable", { onPress, ...props }, wrapTextChildren(children));
+    }
+    return React.createElement(prop, props, wrapTextChildren(children));
+  };
+}
+
 // Generic Lumen (native) stub: every named export becomes a host element named after the
 // component (e.g. Text -> "Text"), so React Native Testing Library text queries still work.
 // Hooks (`use*`) return a mutable ref stub. Redirected here via moduleNameMapper — no
@@ -41,10 +52,17 @@ module.exports = new Proxy(
         return () => ({ current: null });
       }
       if (prop === "Text") {
-        return ({ children, ...props }) => React.createElement("Text", props, children);
+        if (!componentCache.has("Text")) {
+          componentCache.set("Text", ({ children, ...props }) =>
+            React.createElement("Text", props, children),
+          );
+        }
+        return componentCache.get("Text");
       }
-      return ({ children, ...props }) =>
-        React.createElement(prop, props, wrapTextChildren(children));
+      if (!componentCache.has(prop)) {
+        componentCache.set(prop, makeComponent(prop));
+      }
+      return componentCache.get(prop);
     },
   },
 );


### PR DESCRIPTION
RNTL's `userEvent.press` dispatches through React Native's gesture responder system. Custom host elements (strings like `"Button"`) have no responder, so `onPress` is never triggered.

Two issues fixed in `passthrough-native.js`:

1. **Pressable rendering**: when `onPress` is present, render as `<Pressable>` (mirrors the web passthrough pattern `onClick` → `<button>`).
2. **Stable component references**: the Proxy getter was returning a new function on every access. React treats a new function as a new component type → unmount/remount → stale RNTL test instances → `isElementMounted` returns false → `userEvent.press` silently no-ops. A module-level cache now returns the same function reference per component name.

Re-enables the 4 `CardDetails` native tests that were skipped in #21847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)