### PR TITLE
[LWDM] feat(aleo): unbound flow modal

### DIFF
--- a/.changeset/aleo-unbond-flow-modal.md
+++ b/.changeset/aleo-unbond-flow-modal.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+---
+
+feat(aleo): add the unbond staking flow

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.test.tsx
@@ -1,5 +1,8 @@
+import BigNumber from "bignumber.js";
 import React from "react";
 import { render, screen, userEvent } from "tests/testSetup";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { Operation, OperationType } from "@ledgerhq/types-live";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { ALEO_MAIN_ACCOUNT } from "../__mocks__/account.mock";
 import { AleoCustomModal } from "../constants";
@@ -7,18 +10,46 @@ import ManageModal from "./ManageModal";
 
 jest.mock("@ledgerhq/crypto-icons", () => ({ CryptoIcon: jest.fn() }));
 
-function setup() {
+const pendingOperation = (type: OperationType): Operation =>
+  ({
+    id: `pending-${type}`,
+    hash: "",
+    type,
+    value: new BigNumber(1),
+    fee: new BigNumber(1),
+    senders: [],
+    recipients: [],
+    accountId: ALEO_MAIN_ACCOUNT.id,
+    date: new Date(),
+    blockHash: null,
+    blockHeight: null,
+    extra: {},
+  }) as unknown as Operation;
+
+const account = ({
+  bonded = 0,
+  pendingOperations = [],
+}: { bonded?: number; pendingOperations?: Operation[] } = {}): AleoAccount => ({
+  ...ALEO_MAIN_ACCOUNT,
+  pendingOperations,
+  aleoResources: {
+    ...ALEO_MAIN_ACCOUNT.aleoResources!,
+    bondedBalance: new BigNumber(bonded),
+  },
+});
+
+function setup(acc: AleoAccount = account()) {
   const modalsDiv = document.createElement("div");
   modalsDiv.id = "modals";
   document.body.appendChild(modalsDiv);
 
-  return render(<ManageModal account={ALEO_MAIN_ACCOUNT} />, {
+  return render(<ManageModal account={acc} />, {
     initialState: {
       settings: AFTER_ONBOARDING_STATE,
       modals: {
         [AleoCustomModal.MANAGE]: {
           isOpened: true,
-          data: { account: ALEO_MAIN_ACCOUNT, parentAccount: null },
+          data: { account: acc, parentAccount: null },
         },
       },
     },
@@ -31,33 +62,71 @@ afterEach(() => {
 
 describe("Aleo ManageModal", () => {
   it("hands over to the bond flow when the bond row is clicked", async () => {
-    const { store } = setup();
+    const acc = account();
+    const { store } = setup(acc);
 
     await userEvent.click(await screen.findByTestId("aleo-bond-button"));
 
     expect(store.getState().modals[AleoCustomModal.BOND_PUBLIC]).toEqual({
       isOpened: true,
-      data: { account: ALEO_MAIN_ACCOUNT },
+      data: { account: acc },
     });
     expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
   });
 
-  it.each(["aleo-unbond-button", "aleo-claim-button"])("leaves %s disabled", async testId => {
-    setup();
+  describe("unbond row", () => {
+    it("hands over to the unbond flow when there is a bonded position", async () => {
+      const acc = account({ bonded: 20_000_000_000 });
+      const { store } = setup(acc);
 
-    expect(await screen.findByTestId(testId)).toBeDisabled();
+      await userEvent.click(await screen.findByTestId("aleo-unbond-button"));
+
+      expect(store.getState().modals[AleoCustomModal.UNBOND]).toEqual({
+        isOpened: true,
+        data: { account: acc },
+      });
+      expect(store.getState().modals[AleoCustomModal.MANAGE]?.isOpened).toBeFalsy();
+    });
+
+    it("stays disabled with nothing bonded", async () => {
+      setup(account({ bonded: 0 }));
+
+      expect(await screen.findByTestId("aleo-unbond-button")).toBeDisabled();
+    });
+
+    // `unbond_public` rewrites the single on-chain `unbonding` slot, and the synced staking
+    // figures carry no optimistic adjustment — so a second unbond has to be closed off on the
+    // pending pool rather than on the balances, which still show the pre-broadcast position.
+    it("stays disabled while an unbond is pending, bonded balance notwithstanding", async () => {
+      setup(account({ bonded: 20_000_000_000, pendingOperations: [pendingOperation("UNBOND")] }));
+
+      expect(await screen.findByTestId("aleo-unbond-button")).toBeDisabled();
+    });
+
+    it("is unaffected by an unrelated pending operation", async () => {
+      setup(account({ bonded: 20_000_000_000, pendingOperations: [pendingOperation("OUT")] }));
+
+      expect(await screen.findByTestId("aleo-unbond-button")).toBeEnabled();
+    });
   });
 
-  it("opens no flow from the unbond or claim rows", async () => {
-    const { store } = setup();
+  describe("claim row", () => {
+    it("is still disabled: the flow is not built yet", async () => {
+      setup(account({ bonded: 20_000_000_000 }));
 
-    await userEvent.click(await screen.findByTestId("aleo-unbond-button"));
-    await userEvent.click(await screen.findByTestId("aleo-claim-button"));
+      expect(await screen.findByTestId("aleo-claim-button")).toBeDisabled();
+    });
 
-    const openedModals = Object.entries(store.getState().modals)
-      .filter(([, state]) => state?.isOpened)
-      .map(([name]) => name);
+    it("opens no flow when clicked", async () => {
+      const { store } = setup(account({ bonded: 20_000_000_000 }));
 
-    expect(openedModals).toEqual([AleoCustomModal.MANAGE]);
+      await userEvent.click(await screen.findByTestId("aleo-claim-button"));
+
+      const openedModals = Object.entries(store.getState().modals)
+        .filter(([, state]) => state?.isOpened)
+        .map(([name]) => name);
+
+      expect(openedModals).toEqual([AleoCustomModal.MANAGE]);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ManageModal/ManageModal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import BigNumber from "bignumber.js";
 import { useDispatch } from "LLD/hooks/redux";
 import { Trans, useTranslation } from "react-i18next";
 import { openModal } from "~/renderer/actions/modals";
@@ -9,6 +10,7 @@ import IconCoins from "~/renderer/icons/Coins";
 import UnbondIcon from "~/renderer/icons/Undelegate";
 import ClaimRewardIcon from "~/renderer/icons/ClaimReward";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { hasPendingOperationType } from "@ledgerhq/live-common/families/aleo/utils";
 import type { Account } from "@ledgerhq/types-live";
 import { ModalData } from "~/renderer/modals/types";
 import * as S from "./ManageModal.styles";
@@ -22,6 +24,10 @@ export type Data = {
 const ManageModal = ({ account, parentAccount, source, ...rest }: Data) => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+
+  const hasPendingUnbond = hasPendingOperationType(account, "UNBOND");
+  const canUnbond =
+    (account.aleoResources?.bondedBalance ?? new BigNumber(0)).gt(0) && !hasPendingUnbond;
 
   const onSelectAction = useCallback(
     (onClose: () => void, name: keyof ModalData) => {
@@ -58,12 +64,16 @@ const ManageModal = ({ account, parentAccount, source, ...rest }: Data) => {
                   </S.Description>
                 </S.InfoWrapper>
               </S.ManageButton>
-              {/* Listed so the modal shows the whole staking lifecycle; the flows are not built yet. */}
               <ToolTip
-                content={t("aleo.manage.comingSoonTooltip")}
+                content={t("aleo.manage.unbondPendingTooltip")}
+                enabled={hasPendingUnbond}
                 containerStyle={{ width: "100%" }}
               >
-                <S.ManageButton data-testid="aleo-unbond-button" disabled>
+                <S.ManageButton
+                  data-testid="aleo-unbond-button"
+                  disabled={!canUnbond}
+                  onClick={() => canUnbond && onSelectAction(onClose, "MODAL_ALEO_UNBOND")}
+                >
                   <S.IconWrapper>
                     <UnbondIcon size={16} />
                   </S.IconWrapper>

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/Body.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { StepId, StepProps, St } from "./types";
+import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
+import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
+import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
+import { createStakingFlowBody, StakingFlowData } from "../shared/createStakingFlowBody";
+
+export type Data = StakingFlowData;
+
+const steps: Array<St> = [
+  {
+    id: "amount",
+    label: <Trans i18nKey="aleo.unbond.flow.steps.amount.title" />,
+    component: StepAmount,
+    noScroll: true,
+    footer: StepAmountFooter,
+  },
+  {
+    id: "connectDevice",
+    label: <Trans i18nKey="aleo.unbond.flow.steps.connectDevice.title" />,
+    component: GenericStepConnectDevice,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("amount"),
+  },
+  {
+    id: "confirmation",
+    label: <Trans i18nKey="aleo.unbond.flow.steps.confirmation.title" />,
+    component: StepConfirmation,
+    footer: StepConfirmationFooter,
+  },
+];
+
+export default createStakingFlowBody<StepId>({
+  steps,
+  initialStepId: "amount",
+  title: "aleo.unbond.flow.title",
+  trackCloseEvent: "CloseModalUnbond",
+  mode: "unbond_public",
+  // `recipient` carries the on-chain `staker`, which is always the account itself.
+  // prepareTransaction re-pins it, so this is only a sensible starting value.
+  initialRecipient: account => account.freshAddress,
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/index.tsx
@@ -1,0 +1,9 @@
+import Body from "./Body";
+import { StepId } from "./types";
+import { createStakingFlowModal } from "../shared/createStakingFlowModal";
+
+export default createStakingFlowModal<"MODAL_ALEO_UNBOND", StepId>({
+  name: "MODAL_ALEO_UNBOND",
+  initialStepId: "amount",
+  Body,
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/steps/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/steps/StepAmount.test.tsx
@@ -1,0 +1,148 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
+import { render, screen, userEvent } from "tests/testSetup";
+import i18n from "~/renderer/i18n/init";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { ALEO_BONDED_ACCOUNT, ALEO_MAIN_ACCOUNT } from "../../__mocks__/account.mock";
+import { makeAleoTransaction } from "../../__mocks__/transaction.mock";
+import { makeUnbondStepProps } from "../../__mocks__/stepProps.mock";
+import type { StepProps } from "../types";
+import StepAmount, { StepAmountFooter } from "./StepAmount";
+
+jest.mock("~/renderer/modals/Send/fields/AmountField", () => ({
+  __esModule: true,
+  default: () => <div data-testid="amount-field" />,
+}));
+jest.mock("~/renderer/modals/Send/AccountFooter", () => ({
+  __esModule: true,
+  default: () => <div data-testid="account-footer" />,
+}));
+jest.mock("~/renderer/components/ErrorBanner", () => ({
+  __esModule: true,
+  default: ({ error }: { error: Error }) => <div data-testid="error-banner">{error.name}</div>,
+}));
+
+const withStatusErrors = (errors: Record<string, Error>): Partial<StepProps> => ({
+  status: {
+    errors,
+    warnings: {},
+    estimatedFees: new BigNumber(0),
+    amount: new BigNumber(0),
+    totalSpent: new BigNumber(0),
+  },
+});
+
+const continueButton = () => screen.getByRole("button", { name: "Continue" });
+
+function setup(Component: React.ComponentType<StepProps>, overrides: Partial<StepProps> = {}) {
+  const props = makeUnbondStepProps({
+    t: i18n.t.bind(i18n),
+    account: ALEO_BONDED_ACCOUNT,
+    transaction: makeAleoTransaction({
+      mode: "unbond_public",
+      recipient: ALEO_BONDED_ACCOUNT.freshAddress,
+    }),
+    ...overrides,
+  });
+  const utils = render(<Component {...props} />, {
+    initialState: { settings: AFTER_ONBOARDING_STATE },
+  });
+
+  return { ...utils, props };
+}
+
+describe("Aleo unbond StepAmount", () => {
+  it("renders the amount field with the minimum-stake hint", () => {
+    setup(StepAmount);
+
+    expect(screen.getByTestId("amount-field")).toBeInTheDocument();
+    expect(screen.getByTestId("unbond-info-banner")).toHaveTextContent(
+      /less than 10,000 ALEO bonded/,
+    );
+  });
+
+  // The banner caps the input at the bonded position, not at the spendable balance the
+  // rest of the send flow shows — reading the wrong one would offer an unbondable amount.
+  it("offers the bonded balance as the unbondable maximum", () => {
+    setup(StepAmount);
+
+    expect(screen.getByTestId("unbond-unbondable-banner")).toHaveTextContent(/^20,000 ALEO$/);
+  });
+
+  it("falls back to zero when the account carries no bonded position", () => {
+    setup(StepAmount, { account: ALEO_MAIN_ACCOUNT });
+
+    expect(screen.getByTestId("unbond-unbondable-banner")).toHaveTextContent(/^0 ALEO$/);
+  });
+
+  it("surfaces a step error above the fields", () => {
+    setup(StepAmount, { error: new NotEnoughBalance() });
+
+    expect(screen.getByTestId("error-banner")).toHaveTextContent("NotEnoughBalance");
+  });
+
+  // AmountField renders an amount error inline, so banning the fee banner alongside it
+  // keeps the same shortfall from being reported twice.
+  it("hides the fee error while the amount itself is also invalid", () => {
+    setup(StepAmount, withStatusErrors({ amount: new NotEnoughBalance(), fees: new Error("fee") }));
+
+    expect(screen.queryByTestId("error-banner")).not.toBeInTheDocument();
+  });
+
+  it("shows the fee error on its own once the amount is valid", () => {
+    setup(StepAmount, withStatusErrors({ fees: new NotEnoughBalance() }));
+
+    expect(screen.getByTestId("error-banner")).toHaveTextContent("NotEnoughBalance");
+  });
+
+  it("renders nothing without a status", () => {
+    const { container } = setup(StepAmount, {
+      status: undefined as unknown as StepProps["status"],
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("holds back the fields without an account to unbond from", () => {
+    setup(StepAmount, { account: null });
+
+    expect(screen.queryByTestId("amount-field")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unbond-info-banner")).not.toBeInTheDocument();
+  });
+
+  it("holds back the fields until the transaction exists", () => {
+    setup(StepAmount, { transaction: null });
+
+    expect(screen.queryByTestId("amount-field")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unbond-unbondable-banner")).not.toBeInTheDocument();
+  });
+});
+
+describe("Aleo unbond StepAmountFooter", () => {
+  it("moves on to the device step", async () => {
+    const { props } = setup(StepAmountFooter);
+
+    await userEvent.click(continueButton());
+
+    expect(props.transitionTo).toHaveBeenCalledWith("connectDevice");
+  });
+
+  it("blocks Continue while the bridge is still preparing", () => {
+    setup(StepAmountFooter, { bridgePending: true });
+
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it.each(["amount", "fees", "recipient"])("blocks Continue on a %s error", key => {
+    setup(StepAmountFooter, withStatusErrors({ [key]: new NotEnoughBalance() }));
+
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it("renders nothing without an account", () => {
+    const { container } = setup(StepAmountFooter, { account: null });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/steps/StepAmount.tsx
@@ -1,0 +1,113 @@
+import BigNumber from "bignumber.js";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { MIN_DELEGATOR_STAKE_MICROCREDITS } from "@ledgerhq/live-common/families/aleo/constants";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import React, { Fragment, PureComponent } from "react";
+import { Trans } from "react-i18next";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Alert from "~/renderer/components/Alert";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import AccountFooter from "~/renderer/modals/Send/AccountFooter";
+import AmountField from "~/renderer/modals/Send/fields/AmountField";
+import UnbondableBanner from "../../shared/UnbondableBanner";
+import { StepProps } from "../types";
+
+const StepAmount = ({
+  t,
+  account,
+  parentAccount,
+  transaction,
+  onChangeTransaction,
+  error,
+  status,
+  bridgePending,
+}: StepProps) => {
+  const unit = useMaybeAccountUnit(account);
+  const bondedBalance = (account as AleoAccount)?.aleoResources?.bondedBalance ?? new BigNumber(0);
+
+  if (!status) return null;
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  return (
+    <Box flow={4}>
+      <TrackPage
+        category="Delegation Flow"
+        name="Step Amount"
+        flow="unbond"
+        action="unbonding"
+        currency="aleo"
+      />
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
+      {error ? <ErrorBanner error={error} /> : null}
+      {!status.errors.amount && status.errors.fees ? (
+        <ErrorBanner error={status.errors.fees} />
+      ) : null}
+      {account && transaction && mainAccount && (
+        <Fragment key={account.id}>
+          {unit ? (
+            <>
+              <Alert type="hint" small data-testid="unbond-info-banner">
+                <Trans
+                  i18nKey="aleo.unbond.flow.steps.amount.belowMinimum"
+                  values={{
+                    minAmount: formatCurrencyUnit(
+                      unit,
+                      new BigNumber(MIN_DELEGATOR_STAKE_MICROCREDITS),
+                      { showCode: true },
+                    ),
+                  }}
+                />
+              </Alert>
+              <UnbondableBanner unit={unit} bondedBalance={bondedBalance} />
+            </>
+          ) : null}
+          <AmountField
+            status={status}
+            account={account}
+            parentAccount={parentAccount}
+            transaction={transaction}
+            onChangeTransaction={onChangeTransaction}
+            bridgePending={bridgePending}
+            t={t}
+            withUseMaxLabel
+          />
+        </Fragment>
+      )}
+    </Box>
+  );
+};
+
+export class StepAmountFooter extends PureComponent<StepProps> {
+  onNext = async () => {
+    const { transitionTo } = this.props;
+    transitionTo("connectDevice");
+  };
+
+  render() {
+    const { account, parentAccount, status, bridgePending } = this.props;
+    const { errors } = status;
+    if (!account) return null;
+    const hasErrors = Object.keys(errors).length;
+    const canNext = !bridgePending && !hasErrors;
+    return (
+      <>
+        <AccountFooter parentAccount={parentAccount} account={account} status={status} />
+        <Button
+          id={"unbond-amount-continue-button"}
+          isLoading={bridgePending}
+          primary
+          disabled={!canNext}
+          onClick={this.onNext}
+        >
+          <Trans i18nKey="common.continue" />
+        </Button>
+      </>
+    );
+  }
+}
+
+export default StepAmount;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/steps/StepConfirmation.tsx
@@ -1,0 +1,10 @@
+import { createStepConfirmation } from "../../shared/StepConfirmation";
+
+const { StepConfirmation, StepConfirmationFooter } = createStepConfirmation({
+  flow: "unbond",
+  action: "unbonding",
+  trackField: "staker",
+});
+
+export { StepConfirmationFooter };
+export default StepConfirmation;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/UnbondFlowModal/types.ts
@@ -1,0 +1,33 @@
+import { TFunction } from "i18next";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { Step } from "~/renderer/components/Stepper";
+import { Account, Operation } from "@ledgerhq/types-live";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/aleo/types";
+import { OpenModal } from "~/renderer/actions/modals";
+
+export type StepId = "amount" | "connectDevice" | "confirmation";
+
+export type StepProps = Readonly<{
+  t: TFunction;
+  transitionTo: (a: string) => void;
+  device: Device | undefined | null;
+  account: Account | undefined | null;
+  parentAccount: Account | undefined | null;
+  onRetry: (a: void) => void;
+  onClose: () => void;
+  openModal: OpenModal;
+  optimisticOperation: Operation | undefined;
+  error: Error | undefined;
+  signed: boolean;
+  transaction: Transaction | undefined | null;
+  status: TransactionStatus;
+  onChangeTransaction: (a: Transaction) => void;
+  onUpdateTransaction: (a: (a: Transaction) => Transaction) => void;
+  onTransactionError: (a: Error) => void;
+  onOperationBroadcasted: (a: Operation) => void;
+  setSigned: (a: boolean) => void;
+  bridgePending: boolean;
+  source?: string;
+}>;
+
+export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/unbondFlow.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/unbondFlow.integ.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { act, render, screen, userEvent, waitFor } from "tests/testSetup";
+import { mockDomMeasurements } from "LLD/features/__tests__/shared";
+import { importLLDCoinFamily } from "~/renderer/families";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import UnbondFlowModal from "../UnbondFlowModal";
+import { ALEO_BONDED_ACCOUNT } from "../__mocks__/account.mock";
+import { mockAleoCoinConfig } from "../__mocks__/config.mock";
+import { mockSignedOperation } from "../__mocks__/signedOperation.mock";
+import { getAleoCurrencyConfig } from "../shared/utils";
+import { initSendSubjects, subjectRefs, prepareTransactionSpy } from "../__mocks__/bridge.mock";
+
+jest.mock("../shared/utils", () => ({
+  ...jest.requireActual("../shared/utils"),
+  getAleoCurrencyConfig: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/crypto-icons", () => ({ CryptoIcon: jest.fn() }));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
+
+beforeEach(async () => {
+  mockDomMeasurements();
+  await importLLDCoinFamily("aleo");
+  initSendSubjects();
+  prepareTransactionSpy.mockClear();
+  mockGetAleoCurrencyConfig.mockReturnValue(mockAleoCoinConfig);
+});
+
+afterEach(() => {
+  subjectRefs.sync.complete();
+  subjectRefs.sign.complete();
+  document.getElementById("modals")?.remove();
+});
+
+function setupModal(account = ALEO_BONDED_ACCOUNT) {
+  const modalsDiv = document.createElement("div");
+  modalsDiv.id = "modals";
+  document.body.appendChild(modalsDiv);
+
+  return render(<UnbondFlowModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_ALEO_UNBOND: {
+          isOpened: true,
+          data: { account, parentAccount: null },
+        },
+      },
+    },
+  });
+}
+
+async function clickContinueWhenEnabled() {
+  const button = () => screen.getByRole("button", { name: "Continue" });
+  await waitFor(() => expect(button()).not.toBeDisabled());
+  await userEvent.click(button());
+}
+
+describe("Aleo unbond flow — full modal", () => {
+  it("unbonds through amount → device → success", async () => {
+    setupModal();
+
+    expect(await screen.findByTestId("unbond-unbondable-banner")).toHaveTextContent(
+      /^20,000 ALEO$/,
+    );
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(() => expect(screen.getByText("Unbond submitted")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+  }, 20000);
+
+  // There is no recipient step: `unbond_public` names the account as its own on-chain
+  // `staker`, so the flow seeds it from the account and prepareTransaction re-pins it.
+  it("seeds the staker from the account's own fresh address", async () => {
+    setupModal();
+
+    await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
+
+    const [, transaction] = prepareTransactionSpy.mock.calls.at(-1)!;
+    expect(transaction).toMatchObject({
+      mode: "unbond_public",
+      recipient: ALEO_BONDED_ACCOUNT.freshAddress,
+    });
+  });
+
+  it("steps back to the amount from the device step", async () => {
+    setupModal();
+
+    await screen.findByTestId("unbond-unbondable-banner");
+    await clickContinueWhenEnabled();
+    await waitFor(() =>
+      expect(screen.queryByTestId("unbond-unbondable-banner")).not.toBeInTheDocument(),
+    );
+
+    await userEvent.click(await screen.findByTestId("modal-back-button"));
+
+    expect(await screen.findByTestId("unbond-unbondable-banner")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/account.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/account.mock.ts
@@ -35,6 +35,14 @@ export const ALEO_MAIN_ACCOUNT: AleoAccount = {
   },
 };
 
+export const ALEO_BONDED_ACCOUNT: AleoAccount = {
+  ...ALEO_MAIN_ACCOUNT,
+  aleoResources: {
+    ...ALEO_MAIN_ACCOUNT.aleoResources!,
+    bondedBalance: new BigNumber(20_000_000_000),
+  },
+};
+
 export const ALEO_TOKEN_ACCOUNT: AleoTokenAccount = {
   type: "TokenAccount",
   id: "aleo-token-sub-account-id",

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/stepProps.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/stepProps.mock.ts
@@ -3,8 +3,9 @@ import type { TFunction } from "i18next";
 
 import type { StepProps } from "~/renderer/modals/Send/types";
 import type { StepProps as BondStepProps } from "../BondPublicFlowModal/types";
+import type { StepProps as UnbondStepProps } from "../UnbondFlowModal/types";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
-import { ALEO_ACCOUNT_1, ALEO_MAIN_ACCOUNT } from "./account.mock";
+import { ALEO_ACCOUNT_1, ALEO_BONDED_ACCOUNT, ALEO_MAIN_ACCOUNT } from "./account.mock";
 
 const makeAleoAccount = (percentage = 0): AleoAccount => ({
   ...ALEO_ACCOUNT_1,
@@ -85,3 +86,10 @@ export const makeBondStepProps = (overrides: Partial<BondStepProps> = {}): BondS
     bridgePending: false,
     ...overrides,
   }) as BondStepProps;
+
+export const makeUnbondStepProps = (overrides: Partial<UnbondStepProps> = {}): UnbondStepProps =>
+  ({
+    ...makeBondStepProps(overrides as Partial<BondStepProps>),
+    account: ALEO_BONDED_ACCOUNT,
+    ...overrides,
+  }) as UnbondStepProps;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
@@ -2,6 +2,7 @@ export enum AleoCustomModal {
   SELF_TRANSFER = "MODAL_ALEO_SELF_TRANSFER",
   BOND_PUBLIC = "MODAL_ALEO_BOND_PUBLIC",
   MANAGE = "MODAL_ALEO_MANAGE",
+  UNBOND = "MODAL_ALEO_UNBOND",
 }
 
 export const DEFAULT_ALEO_VALIDATOR: Record<"mainnet" | "testnet", string> = {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
@@ -21,7 +21,12 @@ const family: AleoFamily = {
   StepSummaryRecipientValue,
   StepSummaryPostAlert,
   StepSummaryAdditionalRows,
-  modalsToPreload: ["MODAL_ALEO_SELF_TRANSFER", "MODAL_ALEO_BOND_PUBLIC", "MODAL_ALEO_MANAGE"],
+  modalsToPreload: [
+    "MODAL_ALEO_SELF_TRANSFER",
+    "MODAL_ALEO_BOND_PUBLIC",
+    "MODAL_ALEO_MANAGE",
+    "MODAL_ALEO_UNBOND",
+  ],
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/StepConfirmation.tsx
@@ -47,9 +47,9 @@ const Container = styled(Box).attrs(() => ({
 // Widen only alongside the matching `aleo.<flow>.*` i18n subtree: a flow named here
 // without one renders raw keys.
 export type StakingConfirmationConfig = {
-  flow: "bond";
-  action: "bonding";
-  trackField: "validator";
+  flow: "bond" | "unbond";
+  action: "bonding" | "unbonding";
+  trackField: "validator" | "staker";
 };
 
 export function createStepConfirmation({ flow, action, trackField }: StakingConfirmationConfig) {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/UnbondableBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/UnbondableBanner.tsx
@@ -1,0 +1,37 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import type { Unit } from "@domain/entity-currency-unit";
+import Alert from "~/renderer/components/Alert";
+import FormattedVal from "~/renderer/components/FormattedVal";
+
+const TextContent = styled.div`
+  display: inline-flex;
+`;
+
+type Props = Readonly<{
+  unit: Unit;
+  bondedBalance: BigNumber;
+}>;
+
+const UnbondableBanner = ({ unit, bondedBalance }: Props) => (
+  <Alert type="secondary" small>
+    <TextContent>
+      <Trans i18nKey="aleo.unbond.flow.steps.amount.unbondableBanner" />
+      <FormattedVal
+        style={{ width: "auto" }}
+        color="neutral.c100"
+        val={bondedBalance}
+        unit={unit}
+        prefix=" "
+        disableRounding
+        showCode
+        alwaysShowValue
+        data-testid="unbond-unbondable-banner"
+      />
+    </TextContent>
+  </Alert>
+);
+
+export default UnbondableBanner;

--- a/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
@@ -3,6 +3,7 @@ import React, { use } from "react";
 import type { Data as AleoSendData } from "./aleo/modals/send/types";
 import type { Data as AleoBondPublicData } from "./aleo/BondPublicFlowModal/Body";
 import type { Data as AleoManageData } from "./aleo/ManageModal/ManageModal";
+import type { Data as AleoUnbondData } from "./aleo/UnbondFlowModal/Body";
 import type { Data as AlgorandOptInData } from "./algorand/OptInFlowModal/Body";
 import type { Data as AlgorandClaimRewardsData } from "./algorand/Rewards/ClaimRewardsFlowModal/Body";
 import type { Props as AlgorandEarnRewardsInfoProps } from "./algorand/Rewards/EarnRewardsInfoModal";
@@ -85,6 +86,7 @@ export type CoinModalsData = {
   MODAL_ALEO_SELF_TRANSFER: AleoSendData;
   MODAL_ALEO_BOND_PUBLIC: AleoBondPublicData;
   MODAL_ALEO_MANAGE: AleoManageData;
+  MODAL_ALEO_UNBOND: AleoUnbondData;
   MODAL_ALGORAND_OPT_IN: AlgorandOptInData;
   MODAL_ALGORAND_CLAIM_REWARDS: AlgorandClaimRewardsData;
   MODAL_ALGORAND_EARN_REWARDS_INFO: AlgorandEarnRewardsInfoProps;
@@ -176,6 +178,7 @@ export const coinModalImports: Record<CoinModalKey, CoinModalImport> = {
   MODAL_ALEO_SELF_TRANSFER: () => import("./aleo/SelfTransferModal"),
   MODAL_ALEO_BOND_PUBLIC: () => import("./aleo/BondPublicFlowModal"),
   MODAL_ALEO_MANAGE: () => import("./aleo/ManageModal/ManageModal"),
+  MODAL_ALEO_UNBOND: () => import("./aleo/UnbondFlowModal"),
   MODAL_ALGORAND_OPT_IN: () => import("./algorand/OptInFlowModal"),
   MODAL_ALGORAND_CLAIM_REWARDS: () => import("./algorand/Rewards/ClaimRewardsFlowModal"),
   MODAL_ALGORAND_EARN_REWARDS_INFO: () => import("./algorand/Rewards/EarnRewardsInfoModal"),

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9573,6 +9573,29 @@
       "claim": {
         "title": "Claim",
         "description": "Claim your unbonded ALEO back to your available balance."
+      },
+      "unbondPendingTooltip": "An unstake is waiting to be confirmed. Aleo tracks one unbonding position at a time, so unbonding is unavailable until it has gone through."
+    },
+    "unbond": {
+      "flow": {
+        "title": "Unbond ALEO",
+        "steps": {
+          "amount": {
+            "title": "Amount",
+            "unbondableBanner": "Maximum unbondable amount is",
+            "belowMinimum": "If unbonding would leave less than {{minAmount}} bonded, your entire bonded balance is unbonded instead, because the minimum stake would no longer be met."
+          },
+          "connectDevice": { "title": "Device" },
+          "confirmation": {
+            "title": "Confirmation",
+            "success": {
+              "title": "Unbond submitted",
+              "text": "Your unbonding request has been broadcast.",
+              "cta": "View details"
+            },
+            "broadcastError": "Your unbond transaction was signed but could not be broadcast."
+          }
+        }
       }
     }
   },

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -24,6 +24,7 @@ import {
   getAvailableBalance,
   getRecordByCommitment,
   isPrivateTransaction,
+  isSelfStakingMode,
   isSelfTransferTransaction,
   isTokenTransaction,
   getAleoSubAccount,
@@ -269,7 +270,9 @@ async function handleTransferTransaction({
   const recipientError = await validateRecipient({
     account,
     recipient: transaction.recipient,
-    allowSelfTransfer,
+    // An unbond names the account as its own on-chain `staker`, so the own-address
+    // recipient is correct here rather than a destination-is-source mistake.
+    allowSelfTransfer: allowSelfTransfer || isSelfStakingMode(transaction),
   });
 
   if (recipientError) {

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { updateTransaction } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import aleoCoinConfig from "../config";
-import { MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION } from "../constants";
+import { MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION, TRANSACTION_TYPE } from "../constants";
 import { estimateFees } from "../logic";
 import {
   calculateAmount,
@@ -179,6 +179,21 @@ export const prepareTransaction: AccountBridge<
   const isSelfTransfer = isSelfTransferTransaction(transaction);
   const subAccount = getAleoSubAccount(account, transaction.subAccountId);
   const isTokenTx = !!subAccount;
+
+  if (transaction.mode === TRANSACTION_TYPE.UNBOND_PUBLIC) {
+    const feeEstimation = estimateFees({
+      configOrCurrencyId: config,
+      transactionType: TRANSACTION_TYPE.UNBOND_PUBLIC,
+    });
+    const estimatedFees = new BigNumber(feeEstimation.value.toString());
+    const calculatedAmount = calculateAmount({ transaction, account, estimatedFees });
+
+    return updateTransaction(transaction, {
+      amount: calculatedAmount.amount,
+      fees: estimatedFees,
+      recipient: account.freshAddress,
+    });
+  }
 
   if (isPrivateTransaction(transaction)) {
     const derivedTransactionMode = derivePrivateTransactionMode({ isTokenTx, isSelfTransfer });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -505,6 +505,11 @@ function getAmountToSpend({
     return tokenAccount?.transparentBalance ?? new BigNumber(0);
   }
 
+  // unbonding spends the bonded position; the fee is paid from the transparent balance
+  if (transaction.mode === TRANSACTION_TYPE.UNBOND_PUBLIC) {
+    return getAvailableBalance(account, transaction);
+  }
+
   const transparentBalance = account.aleoResources?.transparentBalance ?? new BigNumber(0);
 
   return BigNumber.max(0, transparentBalance.minus(estimatedFees));
@@ -520,7 +525,9 @@ export function calculateAmount({
   estimatedFees: BigNumber;
 }) {
   const amount = getAmountToSpend({ account, transaction, estimatedFees });
-  const totalSpent = isTokenTransaction(transaction) ? amount : amount.plus(estimatedFees);
+  const feePaidFromAnotherBalance =
+    isTokenTransaction(transaction) || transaction.mode === TRANSACTION_TYPE.UNBOND_PUBLIC;
+  const totalSpent = feePaidFromAnotherBalance ? amount : amount.plus(estimatedFees);
 
   return {
     amount,
@@ -572,6 +579,11 @@ export function isPrivateTokenTransaction(transaction: Pick<Transaction, "mode">
 
 export function isTokenTransaction(transaction: Pick<Transaction, "mode">): boolean {
   return isPublicTokenTransaction(transaction) || isPrivateTokenTransaction(transaction);
+}
+
+/** Unbonding moves funds within the account itself, so the recipient is the sender. */
+export function isSelfStakingMode(transaction: Pick<Transaction, "mode">): boolean {
+  return transaction.mode === TRANSACTION_TYPE.UNBOND_PUBLIC;
 }
 
 export function isSelfTransferTransaction(
@@ -946,6 +958,18 @@ export function getClaimableStakingBalance(account: AleoAccount): BigNumber {
 }
 
 /**
+ * True while an operation of that type is still in the pending pool.
+ *
+ * The staking figures in `aleoResources` are read straight from the `credits.aleo` mappings
+ * on each sync and carry no optimistic adjustment, so between broadcast and the next sync
+ * `bondedBalance` and `unbondingBalance` still describe the pre-transaction chain state.
+ * A CTA driven by them alone would keep offering an amount the chain has already committed
+ * away — hence the guard on the pending pool rather than on the balances.
+ */
+export const hasPendingOperationType = (account: AleoAccount, type: OperationType): boolean =>
+  (account.pendingOperations ?? []).some(op => op.type === type);
+
+/**
  * Returns the spendable balance for a given Aleo transaction mode.
  *
  * Aleo accounts maintain two balances:
@@ -961,6 +985,8 @@ export function getAvailableBalance(account: AleoAccount, transaction: Transacti
     case TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE:
     case TRANSACTION_TYPE.BOND_PUBLIC:
       return account.aleoResources?.transparentBalance ?? new BigNumber(0);
+    case TRANSACTION_TYPE.UNBOND_PUBLIC:
+      return account.aleoResources?.bondedBalance ?? new BigNumber(0);
     // spending private native balance
     case TRANSACTION_TYPE.TRANSFER_PRIVATE:
     case TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC: {
@@ -1088,6 +1114,11 @@ export function createTransactionIntent({
           type: TRANSACTION_TYPE.BOND_PUBLIC,
           withdrawal: transaction.withdrawal,
         },
+      };
+    case TRANSACTION_TYPE.UNBOND_PUBLIC:
+      return {
+        ...base,
+        data: { type: TRANSACTION_TYPE.UNBOND_PUBLIC },
       };
 
     case TRANSACTION_TYPE.TRANSFER_PRIVATE:

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -67,6 +67,10 @@ export type Transaction = TransactionCommon & {
         withdrawal: string;
         properties?: never;
       }
+    | {
+        mode: typeof TRANSACTION_TYPE.UNBOND_PUBLIC;
+        properties?: never;
+      }
   );
 
 export type TransactionRaw = TransactionCommonRaw & {
@@ -120,6 +124,10 @@ export type TransactionRaw = TransactionCommonRaw & {
     | {
         mode: typeof TRANSACTION_TYPE.BOND_PUBLIC;
         withdrawal: string;
+        properties?: never;
+      }
+    | {
+        mode: typeof TRANSACTION_TYPE.UNBOND_PUBLIC;
         properties?: never;
       }
   );
@@ -221,7 +229,8 @@ export type TransactionSelfTransfer = Extract<
       | typeof TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC
       | typeof TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE
       | typeof TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC
-      | typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE;
+      | typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
+      | typeof TRANSACTION_TYPE.UNBOND_PUBLIC;
   }
 >;
 
@@ -233,7 +242,8 @@ export type TransactionPublic = Extract<
       | typeof TRANSACTION_TYPE.TRANSFER_PUBLIC
       | typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC
       | typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
-      | typeof TRANSACTION_TYPE.BOND_PUBLIC;
+      | typeof TRANSACTION_TYPE.BOND_PUBLIC
+      | typeof TRANSACTION_TYPE.UNBOND_PUBLIC;
   }
 >;
 

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -134,6 +134,9 @@ export type AleoTransactionIntentData =
   | {
       type: typeof TRANSACTION_TYPE.BOND_PUBLIC;
       withdrawal: string;
+    }
+  | {
+      type: typeof TRANSACTION_TYPE.UNBOND_PUBLIC;
     };
 
 export type AleoTransactionIntent = TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds the **Aleo unbond (unstake) flow** on Ledger Live Desktop, on top of the `unbond_public` transaction crafting already landed in `@ledgerhq/coin-aleo` (#21729).

Until now the "Unbond" row in the Aleo Manage modal was a disabled placeholder. This PR wires it to a real 3-step flow (Amount → Device → Confirmation) and completes the missing bridge plumbing for the `UNBOND_PUBLIC` mode.

#### Desktop — new unbond flow

- New `UnbondFlowModal` (`MODAL_ALEO_UNBOND`), built on the existing `createStakingFlowModal` / `createStakingFlowBody` helpers introduced with the bond flow, so the stepper, bridge wiring and broadcast handling are shared rather than duplicated.
  - **StepAmount** — amount field with "use max", plus two banners: the max unbondable amount (bonded balance) and a hint explaining that unbonding below the minimum stake unbonds the whole position instead.
  - **StepConnectDevice** — generic device step.
  - **StepConfirmation** — built from the shared `createStepConfirmation` factory, which is widened to accept the `unbond` / `unbonding` / `staker` variant alongside `bond`.
- New shared `UnbondableBanner` component.
- Modal registered in `modals-loaders.ts`, `AleoCustomModal` and `modalsToPreload`.
- New `aleo.unbond.*` i18n subtree (en).

#### Desktop — Manage modal

The "Unbond" row is now enabled, and disabled in exactly two cases:

1. **Nothing bonded** — `bondedBalance === 0`.
2. **An unbond is already pending** — with a tooltip explaining why.

The second guard is on the **pending operations pool**, not on the balances. `credits.aleo` exposes a single `unbonding` slot per account and the staking figures in `aleoResources` are read straight from the chain mappings on each sync with no optimistic adjustment — so between broadcast and the next sync `bondedBalance` still shows the pre-transaction position. Gating on balances alone would keep offering an amount the chain has already committed away. New helper `hasPendingOperationType(account, type)` in `coin-aleo`.

#### coin-aleo — bridge

- `prepareTransaction`: dedicated `UNBOND_PUBLIC` branch — estimates the unbond fee, computes the amount, and pins `recipient` to the account's own fresh address.
- `getTransactionStatus`: an unbond names the account as its own on-chain `staker`, so the own-address recipient must not be flagged as a "destination is source" error. New `isSelfStakingMode()` guard passed to `validateRecipient`.
- `getAmountToSpend` / `calculateAmount`: unbonding spends the **bonded** balance while the fee is paid from the **transparent** balance, so the fee is no longer added to `totalSpent` for this mode (same treatment as token transactions).
- `getAvailableBalance`: `UNBOND_PUBLIC` → `bondedBalance`.
- `createTransactionIntent`: emits the `unbond_public` intent.
- Types: `UNBOND_PUBLIC` added to `Transaction`, `TransactionRaw`, `AleoTransactionIntentData`, and to both the `TransactionSelfTransfer` and `TransactionPublic` unions.

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-32808](https://ledgerhq.atlassian.net/browse/LIVE-32808)
