### PR TITLE
[LWDM] feat(contacts): prevent duplicate addresses across contacts (LIVE-37007)

### DIFF
--- a/.changeset/LIVE-37007-contacts-duplicate-address-detection.md
+++ b/.changeset/LIVE-37007-contacts-duplicate-address-detection.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Prevent saving duplicate addresses across contacts — show "This address is already used by [Contact Name]." when adding or editing an address that is already saved in another contact

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.deviceIntents.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.deviceIntents.integration.test.tsx
@@ -111,7 +111,7 @@ describe("Contacts device intents integration", () => {
 
     const addressInput = await screen.findByTestId("contacts-add-address-input");
     fireEvent.change(addressInput, {
-      target: { value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034" },
+      target: { value: "0xabcdef1234567890abcdef1234567890abcdef12" },
     });
     await waitFor(() => {
       expect(screen.getByTestId("contacts-add-address-confirm")).toBeEnabled();

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -48,6 +48,7 @@ import {
   createMeDisplayNameFormatter,
   useContacts,
   useContactsMeContact,
+  type OtherContactAddress,
 } from "@features/platform-contacts";
 import { useContactsIntentsOrchestrator } from "@features/platform-contacts/device";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
@@ -97,6 +98,13 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const currencySelection = useContactsCurrencySelectionAdapter();
   const { cancelCurrencySelection } = currencySelection;
   const addressValidation = useContactsAddressValidationAdapter();
+  const allContactsAddresses = useMemo<readonly OtherContactAddress[]>(
+    () =>
+      contacts.flatMap(c =>
+        c.addresses.map(a => ({ contactId: c.id, contactName: c.name, address: a.address })),
+      ),
+    [contacts],
+  );
   const { selectCurrency } = useAddAddressCurrencySelectionViewModel({
     platform: "desktop",
     currencySelection,
@@ -113,7 +121,10 @@ export function useContactsViewModel(): ContactsPageViewModel {
     continueFromReview,
     completeConfirmation,
     close: closeAddAddress,
-  } = useAddAddressFlowViewModel({ addressValidation });
+  } = useAddAddressFlowViewModel({
+    addressValidation,
+    otherContactsAddresses: allContactsAddresses,
+  });
   const saveAddress = useCallback(
     async (
       flowState: Extract<
@@ -313,6 +324,8 @@ export function useContactsViewModel(): ContactsPageViewModel {
       validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
       ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
       ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+      duplicateAddress: (contactName: string) =>
+        t("contacts.addAddressEntry.duplicateAddress", { contactName }),
     }),
     [t],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -20,7 +20,11 @@ import {
   buildContactsSaveAddressClickProperties,
   CONTACTS_EVENT_SOURCE,
 } from "@features/flow-contacts";
-import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
+import {
+  buildContactsGlobalProperties,
+  useContacts,
+  type OtherContactAddress,
+} from "@features/platform-contacts";
 import {
   isPrefillAddAddressFlowOpen,
   useAddAddressFlowViewModel,
@@ -90,6 +94,13 @@ export function useSendPrefillAddAddressFlow({
     intents: contactsIntentLWDDefinitions,
     getLiveConfigMinVersion: getMinVersion,
   });
+  const allContactsAddresses = useMemo<readonly OtherContactAddress[]>(
+    () =>
+      contacts.flatMap(c =>
+        c.addresses.map(a => ({ contactId: c.id, contactName: c.name, address: a.address })),
+      ),
+    [contacts],
+  );
   const {
     state: addressFlowState,
     startWithPrefilled,
@@ -97,7 +108,10 @@ export function useSendPrefillAddAddressFlow({
     continueFromName,
     goBack,
     close,
-  } = useAddAddressFlowViewModel({ addressValidation });
+  } = useAddAddressFlowViewModel({
+    addressValidation,
+    otherContactsAddresses: allContactsAddresses,
+  });
   const isAddressPhase = isPrefillAddAddressFlowOpen(addressFlowState);
   const trackingProperties = useMemo(
     () => ({
@@ -297,6 +311,8 @@ export function useSendPrefillAddAddressFlow({
       validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
       ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
       ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+      duplicateAddress: (contactName: string) =>
+        t("contacts.addAddressEntry.duplicateAddress", { contactName }),
     }),
     [t],
   );

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9925,7 +9925,8 @@
       },
       "validationUnavailable": "Address validation is temporarily unavailable.",
       "ensDisclaimer": "ENS names can change",
-      "ensDisclaimerDescription": "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify."
+      "ensDisclaimerDescription": "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
+      "duplicateAddress": "This address is already used for {{contactName}}."
     },
     "addAddressName": {
       "inputLabel": "Address name",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10744,7 +10744,8 @@
       "sanctioned": {
         "description": "This address has been flagged and Ledger doesn't allow sending to it",
         "learnMore": "Learn more"
-      }
+      },
+      "duplicateAddress": "This address is already used for {{contactName}}."
     },
     "addAddressName": {
       "title": "Name address",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.deviceIntents.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.deviceIntents.integration.test.tsx
@@ -99,7 +99,7 @@ describe("Contacts device intents integration", () => {
     await user.press(await screen.findByTestId("network-item-Ethereum"));
 
     const addressInput = await screen.findByTestId("contacts-add-address-input");
-    await user.type(addressInput, "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+    await user.type(addressInput, "0xabcdef1234567890abcdef1234567890abcdef12");
     await waitFor(() => {
       expect(screen.getByTestId("contacts-add-address-confirm")).toBeEnabled();
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -79,6 +79,8 @@ export function useContactsAddAddressFlowDrawerViewModel({
               validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
               ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
               ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+              duplicateAddress: (contactName: string) =>
+                t("contacts.addAddressEntry.duplicateAddress", { contactName }),
             },
             sanctionedAddressBanner: {
               description: t("contacts.addAddressEntry.sanctioned.description"),

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -37,8 +37,10 @@ import { getMinVersion } from "@ledgerhq/live-common/apps/support";
 import {
   createMeDisplayNameFormatter,
   resolveEligibleAddressCurrencyIds,
+  useContacts,
   useContactsFeature,
   useContactsMeContact,
+  type OtherContactAddress,
 } from "@features/platform-contacts";
 import {
   useContactsIntentsOrchestrator,
@@ -117,7 +119,15 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     onClose: onCloseAddressDetail,
   } = useContactAddressDetailDialog(populatedContactDetail);
   const contact = populatedContactDetail?.contact ?? emptyContact;
+  const allContacts = useContacts();
   const addressValidation = useContactsAddressValidationAdapter();
+  const allContactsAddresses = useMemo<readonly OtherContactAddress[]>(
+    () =>
+      allContacts.flatMap(c =>
+        c.addresses.map(a => ({ contactId: c.id, contactName: c.name, address: a.address })),
+      ),
+    [allContacts],
+  );
   const eligibleNetworkIds = useMemo(
     () =>
       resolveEligibleAddressCurrencyIds(eligibleAddressFamilies, undefined, excludedCurrencyIds),
@@ -137,6 +147,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   } = useAddAddressFlowViewModel({
     addressValidation,
     manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
+    otherContactsAddresses: allContactsAddresses,
   });
   const completeAddressConfirmation = useCallback(
     async (flowState: Extract<AddAddressFlowState, { status: "confirmationRequired" }>) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -6,7 +6,11 @@ import {
   buildContactsSaveAddressClickProperties,
   CONTACTS_EVENT_SOURCE,
 } from "@features/flow-contacts";
-import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
+import {
+  buildContactsGlobalProperties,
+  useContacts,
+  type OtherContactAddress,
+} from "@features/platform-contacts";
 import {
   useContactsIntentsOrchestrator,
   type ContactsDeviceIntentExecutorProps,
@@ -62,6 +66,13 @@ export function useSendPrefillAddAddressFlow({
     intents: contactsIntentLWMDefinitions,
     getLiveConfigMinVersion: getMinVersion,
   });
+  const allContactsAddresses = useMemo<readonly OtherContactAddress[]>(
+    () =>
+      contacts.flatMap(c =>
+        c.addresses.map(a => ({ contactId: c.id, contactName: c.name, address: a.address })),
+      ),
+    [contacts],
+  );
   const {
     state: addressFlowState,
     startWithPrefilled,
@@ -69,7 +80,10 @@ export function useSendPrefillAddAddressFlow({
     continueFromName,
     goBack,
     close,
-  } = useAddAddressFlowViewModel({ addressValidation });
+  } = useAddAddressFlowViewModel({
+    addressValidation,
+    otherContactsAddresses: allContactsAddresses,
+  });
   const isAddressPhase = isPrefillAddAddressFlowOpen(addressFlowState);
   const trackingProperties = useMemo(
     () => ({

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
@@ -14,7 +14,7 @@ export type ContactAddressDetailActionsLabels = Readonly<{
   ReturnType<typeof resolveContactEditSignerActionLabels>;
 
 export type ResolveContactAddressDetailActionsLabelsOptions = Readonly<{
-  t: (key: string) => string;
+  t: (key: string, options?: Record<string, unknown>) => string;
   addressLabelTooLongKey?: string;
 }>;
 
@@ -48,6 +48,8 @@ export function resolveContactAddressDetailActionsLabels({
         validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
         ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
         ensDisclaimerDescription: t("contacts.addAddressEntry.ensDisclaimerDescription"),
+        duplicateAddress: (contactName: string) =>
+          t("contacts.addAddressEntry.duplicateAddress", { contactName }),
       },
     },
     ...resolveContactEditSignerActionLabels(t),

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.ts
@@ -1,13 +1,17 @@
 import {
   selectContactAddressById,
   selectContactById,
+  selectContacts,
   type ContactAddressId,
   type ContactId,
 } from "@domain/entity-contact";
 import { ContactAddressIdSchema } from "@domain/entity-contact";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
-import type { ContactsAddressValidationPort } from "@features/platform-contacts";
+import type {
+  ContactsAddressValidationPort,
+  OtherContactAddress,
+} from "@features/platform-contacts";
 import {
   type ContactAddressEditSavePayload,
   useRenameAddressDialogViewModel,
@@ -63,6 +67,16 @@ export function useContactAddressDetailActionsFlowBindings({
         .map(address => address.label) ?? [],
     [addressId, contact?.addresses],
   );
+  const allContacts = useSelector((state: ContactsStateRoot) => selectContacts(state));
+  const otherContactsAddresses = useMemo<readonly OtherContactAddress[]>(
+    () =>
+      allContacts.flatMap(c =>
+        c.id !== contactId
+          ? c.addresses.map(a => ({ contactId: c.id, contactName: c.name, address: a.address }))
+          : [],
+      ),
+    [allContacts, contactId],
+  );
   const renameViewModel = useRenameAddressDialogViewModel({
     contactId,
     addressId: resolvedAddressId,
@@ -73,6 +87,7 @@ export function useContactAddressDetailActionsFlowBindings({
     editPort: ports.edit,
     addressValidation,
     manualValidationDebounceMs,
+    otherContactsAddresses,
     isRequestedOpen: flow.editUiState === "edit-open",
     isEditSessionActive: flow.isEditSessionActive,
     onCloseRequest: flow.onEditClose,

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.test.tsx
@@ -17,6 +17,7 @@ const labels: AddAddressEntryLabels = {
   ensDisclaimer: "ENS names resolve to wallet addresses.",
   ensDisclaimerDescription:
     "ENS names can point to different addresses over time. We save the underlying address now to ensure your funds only reach the address you verify.",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 
 const VALID_ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/viewModel/useContactsAddAddressEntryViewModel.web.test.ts
@@ -21,6 +21,7 @@ const labels: AddAddressEntryLabels = {
   validationUnavailable: "Address validation is temporarily unavailable.",
   ensDisclaimer: "ENS disclaimer",
   ensDisclaimerDescription: "ENS names can change over time.",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
   "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
@@ -26,6 +26,7 @@ const entryLabels: AddAddressEntryLabels = {
   validationUnavailable: "Address validation is unavailable",
   ensDisclaimer: "ENS disclaimer",
   ensDisclaimerDescription: "ENS names can change over time.",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 const nameLabels: AddAddressNameLabels = {
   title: "Address name",

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -36,6 +36,7 @@ const entryLabels: AddAddressEntryLabels = {
   validationUnavailable: "Address validation is unavailable",
   ensDisclaimer: "ENS disclaimer",
   ensDisclaimerDescription: "ENS names can change over time.",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 const nameLabels: ContactsAddAddressNameLabels = {
   inputLabel: "Address name",

--- a/features/flow/flow-contacts-add-address/src/state/types.ts
+++ b/features/flow/flow-contacts-add-address/src/state/types.ts
@@ -9,12 +9,15 @@ import type {
   ContactsAddressEntryState,
   ContactsAddressInputMethod,
   ContactsAddressInputSource,
+  OtherContactAddress,
 } from "@features/platform-contacts";
 
 export type AddAddressInputMethod = ContactsAddressInputMethod;
 export type AddAddressInputSource = ContactsAddressInputSource;
 
 export type AddAddressContact = Pick<Contact, "id" | "addresses">;
+
+export type { OtherContactAddress };
 
 export type AddAddressCurrencySelection = Readonly<{
   currencyId: ContactAddress["currencyId"];
@@ -48,6 +51,7 @@ export type PrefillAddAddressStartResult =
       status: "invalid_address";
       error: PrefillAddAddressInvalidReason;
     }>
+  | Readonly<{ status: "duplicate_address"; contactName: string }>
   | Readonly<{ status: "cancelled" }>
   | Readonly<{ status: "unavailable" }>;
 
@@ -150,6 +154,7 @@ export type AddAddressEntryLabels = Readonly<{
   validationUnavailable: string;
   ensDisclaimer: string;
   ensDisclaimerDescription: string;
+  duplicateAddress: (contactName: string) => string;
 }>;
 
 export type AddAddressNameLabels = Readonly<{

--- a/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.ts
+++ b/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.ts
@@ -8,6 +8,7 @@ import {
   type ContactId,
 } from "@domain/entity-contact";
 import {
+  addressesMatch,
   createValidatingAddressEntryState,
   EMPTY_ADDRESS_ENTRY_STATE,
   requestAddressValidation,
@@ -23,6 +24,7 @@ import type {
   AddAddressFlowViewModel,
   AddAddressInputSource,
   AddAddressLabelState,
+  OtherContactAddress,
   PrefillAddAddressParams,
   PrefillAddAddressStartResult,
   ValidAddAddressEntryState,
@@ -32,6 +34,19 @@ const CLOSED_ADD_ADDRESS_FLOW_STATE = {
   status: "closed",
 } as const satisfies AddAddressFlowState;
 
+function findDuplicateContactName(
+  resolvedAddress: string,
+  otherContactsAddresses: readonly OtherContactAddress[],
+  excludeContactId: string,
+): string | null {
+  return (
+    otherContactsAddresses.find(
+      other =>
+        other.contactId !== excludeContactId && addressesMatch(other.address, resolvedAddress),
+    )?.contactName ?? null
+  );
+}
+
 const UNAVAILABLE_ADDRESS_VALIDATION: ContactsAddressValidationPort = {
   validateAddress: async () => ({ status: "unavailable" }),
 };
@@ -39,6 +54,7 @@ const UNAVAILABLE_ADDRESS_VALIDATION: ContactsAddressValidationPort = {
 export type UseAddAddressFlowViewModelOptions = Readonly<{
   addressValidation?: ContactsAddressValidationPort;
   manualValidationDebounceMs?: number;
+  otherContactsAddresses?: readonly OtherContactAddress[];
 }>;
 
 function createAddressLabelState(
@@ -97,6 +113,7 @@ function applyAddressEntryState(
 export function useAddAddressFlowViewModel({
   addressValidation = UNAVAILABLE_ADDRESS_VALIDATION,
   manualValidationDebounceMs = 0,
+  otherContactsAddresses = [],
 }: UseAddAddressFlowViewModelOptions = {}): AddAddressFlowViewModel {
   const [state, setState] = useState<AddAddressFlowState>(CLOSED_ADD_ADDRESS_FLOW_STATE);
   const validationRequestId = useRef(0);
@@ -146,6 +163,16 @@ export function useAddAddressFlowViewModel({
         return { status: "invalid_address", error: validationResult.status };
       }
 
+      const duplicateName = findDuplicateContactName(
+        validationResult.resolvedAddress,
+        otherContactsAddresses,
+        params.contact.id,
+      );
+      if (duplicateName !== null) {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "duplicate_address", contactName: duplicateName };
+      }
+
       const addressEntry: ValidAddAddressEntryState = {
         status: "valid",
         value: normalizedAddress,
@@ -172,7 +199,7 @@ export function useAddAddressFlowViewModel({
 
       return { status: "started" };
     },
-    [addressValidation, cancelAddressValidation],
+    [addressValidation, cancelAddressValidation, otherContactsAddresses],
   );
   const completeCurrencySelection = useCallback(
     (selectedContactId: ContactId, selection: AddAddressCurrencySelection) => {
@@ -209,6 +236,7 @@ export function useAddAddressFlowViewModel({
 
       const normalizedAddress = value.trim();
       const selectedCurrencyId = state.selectedCurrencyId;
+      const selectedContactId = state.selectedContactId;
       const requestId = validationRequestId.current + 1;
       validationRequestId.current = requestId;
 
@@ -244,16 +272,30 @@ export function useAddAddressFlowViewModel({
         return;
       }
 
+      let finalEntry = resolveAddressEntryState(value, inputMethod, validationResult);
+      if (finalEntry.status === "valid") {
+        const dup = findDuplicateContactName(
+          finalEntry.resolvedAddress,
+          otherContactsAddresses,
+          selectedContactId,
+        );
+        if (dup !== null) {
+          finalEntry = {
+            status: "invalid",
+            value,
+            resolvedAddress: null,
+            inputMethod: finalEntry.inputMethod,
+            error: "duplicate_address",
+            contactName: dup,
+          };
+        }
+      }
+
       setState(currentState =>
-        applyAddressEntryState(
-          currentState,
-          selectedCurrencyId,
-          resolveAddressEntryState(value, inputMethod, validationResult),
-          value,
-        ),
+        applyAddressEntryState(currentState, selectedCurrencyId, finalEntry, value),
       );
     },
-    [addressValidation, manualValidationDebounceMs, state],
+    [addressValidation, manualValidationDebounceMs, otherContactsAddresses, state],
   );
   const updateAddressLabel = useCallback((value: string) => {
     setState(currentState => {

--- a/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.web.test.ts
@@ -1073,4 +1073,55 @@ describe("useAddAddressFlowViewModel", () => {
       });
     });
   });
+
+  describe("duplicate address detection", () => {
+    it("should mark a valid address as invalid when it is already used by another contact", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() =>
+        useAddAddressFlowViewModel({
+          addressValidation,
+          otherContactsAddresses: [
+            { contactId: "contact-other", contactName: "Alice", address: VALID_ADDRESS },
+          ],
+        }),
+      );
+
+      act(() => result.current.start(contact));
+      act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+      await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+
+      expect(result.current.state).toMatchObject({
+        status: "enteringAddress",
+        addressEntry: {
+          status: "invalid",
+          error: "duplicate_address",
+          contactName: "Alice",
+        },
+      });
+    });
+
+    it("should not flag an address already assigned to the selected contact", async () => {
+      const existingAddress = mockContactAddress({ address: VALID_ADDRESS });
+      const contact = mockContact({ addresses: [existingAddress] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() =>
+        useAddAddressFlowViewModel({
+          addressValidation,
+          otherContactsAddresses: [
+            { contactId: contact.id, contactName: contact.name, address: VALID_ADDRESS },
+          ],
+        }),
+      );
+
+      act(() => result.current.start(contact));
+      act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+      await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+
+      expect(result.current.state).toMatchObject({
+        status: "enteringAddress",
+        addressEntry: { status: "valid", resolvedAddress: VALID_ADDRESS },
+      });
+    });
+  });
 });

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDialog.web.test.tsx
@@ -46,6 +46,8 @@ function createViewModel(
         validationUnavailable: "Validation unavailable",
         ensDisclaimer: "ENS addresses are supported.",
         ensDisclaimerDescription: "ENS names can change over time.",
+        duplicateAddress: (contactName: string) =>
+          `This address is already used for ${contactName}.`,
       },
     },
     onOpen: jest.fn(),

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
@@ -46,6 +46,8 @@ function createViewModel(
         validationUnavailable: "Validation unavailable",
         ensDisclaimer: "ENS addresses are supported.",
         ensDisclaimerDescription: "ENS names can change over time.",
+        duplicateAddress: (contactName: string) =>
+          `This address is already used for ${contactName}.`,
       },
     },
     onOpen: jest.fn(),

--- a/features/flow/flow-contacts-edit-address/src/model/addressEntryValidation.ts
+++ b/features/flow/flow-contacts-edit-address/src/model/addressEntryValidation.ts
@@ -19,7 +19,3 @@ export function createInitialEditAddressEntryState(
     inputMethod: "manual",
   };
 }
-
-export function addressesMatch(value: string, currentAddress: ContactAddress["address"]): boolean {
-  return value.trim().toLowerCase() === currentAddress.toLowerCase();
-}

--- a/features/flow/flow-contacts-edit-address/src/types.ts
+++ b/features/flow/flow-contacts-edit-address/src/types.ts
@@ -73,6 +73,7 @@ export type ContactsEditAddressValidationLabels = Readonly<{
   validationUnavailable: string;
   ensDisclaimer: string;
   ensDisclaimerDescription: string;
+  duplicateAddress: (contactName: string) => string;
 }>;
 
 export type EditAddressAddressEntryPresentation = Readonly<{

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntry.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntry.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ContactAddress } from "@domain/entity-contact";
-import { wait } from "@features/platform-contacts";
+import { addressesMatch, wait } from "@features/platform-contacts";
 import type {
   ContactsAddressEntryState,
   ContactsAddressInputSource,
   ContactsAddressValidationPort,
+  OtherContactAddress,
 } from "@features/platform-contacts";
 import {
-  addressesMatch,
   applyAddressEntryState,
   createInitialEditAddressEntryState,
   createValidatingAddressEntryState,
@@ -24,8 +24,10 @@ export type UseEditAddressAddressEntryOptions = Readonly<{
   addressValidation?: ContactsAddressValidationPort;
   currencyId: ContactAddress["currencyId"] | undefined;
   currentAddress: ContactAddress["address"] | undefined;
+  contactId?: string;
   isActive: boolean;
   manualValidationDebounceMs?: number;
+  otherContactsAddresses?: readonly OtherContactAddress[];
 }>;
 
 export type UseEditAddressAddressEntryResult = Readonly<{
@@ -37,8 +39,10 @@ export function useEditAddressAddressEntry({
   addressValidation = UNAVAILABLE_ADDRESS_VALIDATION,
   currencyId,
   currentAddress,
+  contactId,
   isActive,
   manualValidationDebounceMs = 0,
+  otherContactsAddresses = [],
 }: UseEditAddressAddressEntryOptions): UseEditAddressAddressEntryResult {
   const [addressEntry, setAddressEntry] = useState<ContactsAddressEntryState>(() =>
     currentAddress === undefined
@@ -129,16 +133,38 @@ export function useEditAddressAddressEntry({
           return;
         }
 
-        setAddressEntry(currentEntry =>
-          applyAddressEntryState(
-            currentEntry,
-            resolveAddressEntryState(value, inputMethod, validationResult),
-            value,
-          ),
-        );
+        let finalEntry = resolveAddressEntryState(value, inputMethod, validationResult);
+        if (finalEntry.status === "valid") {
+          const resolvedAddress = finalEntry.resolvedAddress;
+          const dup =
+            otherContactsAddresses.find(
+              other =>
+                (contactId === undefined || other.contactId !== contactId) &&
+                addressesMatch(other.address, resolvedAddress),
+            )?.contactName ?? null;
+          if (dup !== null) {
+            finalEntry = {
+              status: "invalid",
+              value,
+              resolvedAddress: null,
+              inputMethod: finalEntry.inputMethod,
+              error: "duplicate_address",
+              contactName: dup,
+            };
+          }
+        }
+
+        setAddressEntry(currentEntry => applyAddressEntryState(currentEntry, finalEntry, value));
       })();
     },
-    [addressValidation, currencyId, currentAddress, manualValidationDebounceMs],
+    [
+      addressValidation,
+      contactId,
+      currencyId,
+      currentAddress,
+      manualValidationDebounceMs,
+      otherContactsAddresses,
+    ],
   );
 
   return { addressEntry, onAddressChange };

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntry.web.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntry.web.test.ts
@@ -140,6 +140,39 @@ describe("useEditAddressAddressEntry", () => {
     });
   });
 
+  it("should mark a valid address as duplicate when it belongs to another contact", async () => {
+    const otherAddress = validAddress;
+    const validateAddress = jest
+      .fn<
+        ReturnType<ContactsAddressValidationPort["validateAddress"]>,
+        Parameters<ContactsAddressValidationPort["validateAddress"]>
+      >()
+      .mockResolvedValue({ status: "valid", resolvedAddress: otherAddress, isDomain: false });
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntry({
+        addressValidation: createValidationPort(validateAddress),
+        currencyId,
+        currentAddress,
+        contactId: "contact-self",
+        isActive: true,
+        otherContactsAddresses: [
+          { contactId: "contact-other", contactName: "Alice", address: otherAddress },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      result.current.onAddressChange(otherAddress, "manual");
+      await Promise.resolve();
+    });
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "invalid",
+      error: "duplicate_address",
+      contactName: "Alice",
+    });
+  });
+
   it("should keep the input editable when currencyId is missing", () => {
     const { result } = renderHook(() =>
       useEditAddressAddressEntry({

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressAddressEntryPresentation.native.test.ts
@@ -13,6 +13,7 @@ const labels = {
   validationUnavailable: "Unavailable",
   ensDisclaimer: "ENS disclaimer",
   ensDisclaimerDescription: "ENS names can change over time.",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 
 describe("useEditAddressAddressEntryPresentation", () => {

--- a/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
+++ b/features/flow/flow-contacts-edit-address/src/useEditAddressDialogPresentation.web.test.ts
@@ -14,6 +14,7 @@ const labels = {
   validationUnavailable: "Unavailable",
   ensDisclaimer: "ENS disclaimer",
   ensDisclaimerDescription: "ENS names can change over time.",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 
 describe("useEditAddressDialogPresentation", () => {

--- a/features/flow/flow-contacts-edit-address/src/useRenameAddressDialogViewModel.ts
+++ b/features/flow/flow-contacts-edit-address/src/useRenameAddressDialogViewModel.ts
@@ -1,6 +1,9 @@
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import { useCallback, useEffect, useState } from "react";
-import type { ContactsAddressValidationPort } from "@features/platform-contacts";
+import type {
+  ContactsAddressValidationPort,
+  OtherContactAddress,
+} from "@features/platform-contacts";
 import { useEditAddressAddressEntry } from "./useEditAddressAddressEntry";
 import { useRenameAddressViewModel } from "./useRenameAddressViewModel";
 import type { RenameAddressDialogViewModel, UseRenameAddressDialogViewModelOptions } from "./types";
@@ -10,6 +13,7 @@ export type UseRenameAddressDialogViewModelOptionsWithValidation =
     Readonly<{
       addressValidation?: ContactsAddressValidationPort;
       manualValidationDebounceMs?: number;
+      otherContactsAddresses?: readonly OtherContactAddress[];
     }>;
 
 export function useRenameAddressDialogViewModel({
@@ -22,6 +26,7 @@ export function useRenameAddressDialogViewModel({
   editPort,
   addressValidation,
   manualValidationDebounceMs,
+  otherContactsAddresses,
   isRequestedOpen,
   isEditSessionActive = isRequestedOpen,
   onCloseRequest,
@@ -35,8 +40,10 @@ export function useRenameAddressDialogViewModel({
     addressValidation,
     currencyId,
     currentAddress,
+    contactId,
     isActive: isEditSessionActive,
     manualValidationDebounceMs,
+    otherContactsAddresses,
   });
   const { invalidLabelError, isConfirmEnabled, save } = useRenameAddressViewModel({
     contactId,

--- a/features/platform/contacts/src/addressEntry/presentation.ts
+++ b/features/platform/contacts/src/addressEntry/presentation.ts
@@ -7,6 +7,7 @@ export type ContactsAddressValidationLabels = Readonly<{
   domainNotFound: string;
   sanctionedAddress: string;
   validationUnavailable: string;
+  duplicateAddress: (contactName: string) => string;
 }>;
 
 export type ContactsAddressInputPresentation = Readonly<{
@@ -40,6 +41,8 @@ export function resolveAddressInputPresentation(
         helperText = labels.domainNotFound;
       } else if (addressEntry.error === "sanctioned") {
         helperText = labels.sanctionedAddress;
+      } else if (addressEntry.error === "duplicate_address") {
+        helperText = labels.duplicateAddress(addressEntry.contactName);
       }
 
       return {

--- a/features/platform/contacts/src/addressEntry/presentation.web.test.ts
+++ b/features/platform/contacts/src/addressEntry/presentation.web.test.ts
@@ -8,6 +8,7 @@ const labels = {
   domainNotFound: "Domain not found",
   sanctionedAddress: "Sanctioned",
   validationUnavailable: "Unavailable",
+  duplicateAddress: (contactName: string) => `This address is already used for ${contactName}.`,
 };
 
 describe("resolveAddressInputPresentation", () => {
@@ -64,6 +65,26 @@ describe("resolveAddressInputPresentation", () => {
     ).toEqual({
       inputStatus: "error",
       helperText: "Sanctioned",
+      showEnsDisclaimer: false,
+    });
+  });
+
+  it("should show the contact name when address is already used for another contact", () => {
+    expect(
+      resolveAddressInputPresentation(
+        {
+          status: "invalid",
+          value: "0xduplicate",
+          resolvedAddress: null,
+          inputMethod: "manual",
+          error: "duplicate_address",
+          contactName: "Alice",
+        },
+        labels,
+      ),
+    ).toEqual({
+      inputStatus: "error",
+      helperText: "This address is already used for Alice.",
       showEnsDisclaimer: false,
     });
   });

--- a/features/platform/contacts/src/addressEntry/types.ts
+++ b/features/platform/contacts/src/addressEntry/types.ts
@@ -30,8 +30,22 @@ export type ContactsAddressEntryState =
       error: "invalid_format" | "domain_not_found" | "sanctioned";
     }>
   | Readonly<{
+      status: "invalid";
+      value: string;
+      resolvedAddress: null;
+      inputMethod: ContactsAddressInputMethod;
+      error: "duplicate_address";
+      contactName: string;
+    }>
+  | Readonly<{
       status: "unavailable";
       value: string;
       resolvedAddress: null;
       inputMethod: ContactsAddressInputSource;
     }>;
+
+export type OtherContactAddress = Readonly<{
+  contactId: string;
+  contactName: string;
+  address: string;
+}>;


### PR DESCRIPTION
### 📝 Description

When adding or editing a contact address, if the resolved address is already saved under another contact, the user now sees an inline validation error: **"This address is already used for [Contact Name]."** — consistent with how invalid format, sanctioned address, and domain-not-found errors are displayed.

**Problem**: Nothing prevented two contacts from sharing the same address. The UI accepted the address as valid even when it was already saved elsewhere.

**Solution**:
- Added a `duplicate_address` error variant to `ContactsAddressEntryState`
- After successful network validation in `useAddAddressFlowViewModel` and `useEditAddressAddressEntry`, a cross-contact address lookup runs against a flat list of all other contacts' addresses (`OtherContactAddress[]`)
- If a match is found, the entry is downgraded to `invalid` with `error: "duplicate_address"` and the matching contact's name
- `resolveAddressInputPresentation` maps this new error to the display string via the `duplicateAddress` label (a function taking `contactName`)
- Desktop (`useContactsViewModel`) and mobile (`useContactDetailScreenViewModel`) compute and pass `otherContactsAddresses` down to the add-address ViewModel
- Rename-address flow (`useContactAddressDetailActionsFlowBindings`) similarly computes and passes `otherContactsAddresses` to `useRenameAddressDialogViewModel`

https://github.com/user-attachments/assets/5d4958ff-e209-4e94-a172-f0d8aeacf7be


https://github.com/user-attachments/assets/0db9fec0-3183-4c5b-b396-863e8069ecdb


### 🔗 Context

- **JIRA issue**: [LIVE-37007](https://ledgerhq.atlassian.net/browse/LIVE-37007)

[LIVE-37007]: https://ledgerhq.atlassian.net/browse/LIVE-37007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ