### PR TITLE
chore(live-mobile): bump react-native-splash-screen to 3.3.0

### DIFF
--- a/.changeset/tame-lions-wave.md
+++ b/.changeset/tame-lions-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bump react-native-splash-screen from 3.2.0 to 3.3.0 (LIVE-37287)

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2413,8 +2413,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-splash-screen (3.2.0):
-    - React
+  - react-native-splash-screen (3.3.0):
+    - React-Core
   - react-native-startup-time (2.1.0):
     - React-Core
   - react-native-tcp-socket (6.0.6):
@@ -3689,7 +3689,7 @@ DEPENDENCIES:
   - "react-native-restart (from `../../../node_modules/.pnpm/react-native-restart@0.0.24_react-native@0.81.6_3490b89e86473c217d6f2b0593c9edc0/node_modules/react-native-restart`)"
   - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.6.1_react-nati_dc140c40b533e12ecb3cd17960e9d3aa/node_modules/react-native-safe-area-context`)"
   - "react-native-slider (from `../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider`)"
-  - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen`)"
+  - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.3.0_react-native@0_aab91b328bf357ade659c0bedf41097a/node_modules/react-native-splash-screen`)"
   - "react-native-startup-time (from `../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time`)"
   - "react-native-tcp-socket (from `../../../node_modules/.pnpm/react-native-tcp-socket@6.0.6_react-native@0.81_34ca5ceafa440bcbde428f36b080d61a/node_modules/react-native-tcp-socket`)"
   - "react-native-version-number (from `../../../node_modules/.pnpm/react-native-version-number@0.3.6/node_modules/react-native-version-number`)"
@@ -3946,7 +3946,7 @@ EXTERNAL SOURCES:
   react-native-slider:
     :path: "../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider"
   react-native-splash-screen:
-    :path: "../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen"
+    :path: "../../../node_modules/.pnpm/react-native-splash-screen@3.3.0_react-native@0_aab91b328bf357ade659c0bedf41097a/node_modules/react-native-splash-screen"
   react-native-startup-time:
     :path: "../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time"
   react-native-tcp-socket:
@@ -4175,7 +4175,7 @@ SPEC CHECKSUMS:
   react-native-restart: df7caae89026a8ab2ecdd82839978f657701f51d
   react-native-safe-area-context: ee1e8e2a7abf737a8d4d9d1a5686a7f2e7466236
   react-native-slider: 05e7080478df08489251c2a6739a0d5628b7c198
-  react-native-splash-screen: a43276f9cf4b2e65d7ce30efe372ffc528064293
+  react-native-splash-screen: 95994222cc95c236bd3cdc59fe45ed5f27969594
   react-native-startup-time: c7297d8a7892400239e6828bb94a3721c1a1a9df
   react-native-tcp-socket: ae8abcfebc071216302a09d9ed1e375d4e877484
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -289,7 +289,7 @@
     "react-native-safe-area-context": "catalog:",
     "react-native-screens": "catalog:",
     "react-native-share": "12.2.0",
-    "react-native-splash-screen": "3.2.0",
+    "react-native-splash-screen": "3.3.0",
     "react-native-startup-time": "2.1.0",
     "react-native-svg": "catalog:",
     "react-native-tcp-socket": "6.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2277,8 +2277,8 @@ importers:
         specifier: 12.2.0
         version: 12.2.0
       react-native-splash-screen:
-        specifier: 3.2.0
-        version: 3.2.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        specifier: 3.3.0
+        version: 3.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-startup-time:
         specifier: 2.1.0
         version: 2.1.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -37789,8 +37789,8 @@ packages:
     resolution: {integrity: sha512-f6MB9BsKa9xVvu0DKbxq5jw4IyYHqQeqUlCNkD8eAFoJx6SD31ObPAn7SQ6NG9AOuhCy6aYuSJYJvx25DaoMZQ==}
     engines: {node: '>=16'}
 
-  react-native-splash-screen@3.2.0:
-    resolution: {integrity: sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==}
+  react-native-splash-screen@3.3.0:
+    resolution: {integrity: sha512-rGjt6HkoSXxMqH4SQUJ1gnPQlPJV8+J47+4yhgTIan4bVvAwJhEeJH7wWt9hXSdH4+VfwTS0GTaflj1Tw83IhA==}
     peerDependencies:
       react-native: '>=0.57.0'
 
@@ -68871,7 +68871,7 @@ snapshots:
 
   react-native-share@12.2.0: {}
 
-  react-native-splash-screen@3.2.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
+  react-native-splash-screen@3.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
     dependencies:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 


### PR DESCRIPTION
- [x] tested iOS and android

### 📝 Description

Bumps `react-native-splash-screen` 3.2.0 → 3.3.0, the last version upstream ever released (repo has been dead since Dec 2021) — this bump is a ceiling, not a fix; replacing the library is the real follow-up.

Real diff between the two versions: JS API (`show()`/`hide()`) is unchanged; Android `build.gradle` adds a `safeExtGet()` helper for `minSdkVersion` and drops a redundant, unused `<application>` stub from the manifest (fewer manifest-merger surface, no functional change); native `SplashScreen.java` gained an opt-in full-screen/notch-handling path but our only native call site (`MainActivity.kt` → `SplashScreen.show(this, true)`) hits an overload whose signature didn't change; iOS `.m` is untouched, only the podspec's dependency name modernized from `React` to `React-Core`. Net: no code changes needed on our side, low risk.

Existing coverage: `rebootMiddleware.test.ts` mocks `{ show: jest.fn() }` and still passes as-is (module shape unchanged). `SplashScreenHandle.tsx` has no test coverage before or after this bump.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-37287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
