### PR TITLE
[LWM] chore(mobile): bump react-native-tcp-socket to 6.4.2 (LIVE-37286)

### DIFF
--- a/.changeset/loud-bears-shout.md
+++ b/.changeset/loud-bears-shout.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bump react-native-tcp-socket from 6.0.6 to 6.4.2 (LIVE-37286)

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2417,7 +2417,7 @@ PODS:
     - React
   - react-native-startup-time (2.1.0):
     - React-Core
-  - react-native-tcp-socket (6.0.6):
+  - react-native-tcp-socket (6.4.2):
     - CocoaAsyncSocket
     - React-Core
   - react-native-version-number (0.3.6):
@@ -3691,7 +3691,7 @@ DEPENDENCIES:
   - "react-native-slider (from `../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider`)"
   - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen`)"
   - "react-native-startup-time (from `../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time`)"
-  - "react-native-tcp-socket (from `../../../node_modules/.pnpm/react-native-tcp-socket@6.0.6_react-native@0.81_34ca5ceafa440bcbde428f36b080d61a/node_modules/react-native-tcp-socket`)"
+  - "react-native-tcp-socket (from `../../../node_modules/.pnpm/react-native-tcp-socket@6.4.2_react-native@0.81_327f68c7b97e83fdd9f586e1781ec795/node_modules/react-native-tcp-socket`)"
   - "react-native-version-number (from `../../../node_modules/.pnpm/react-native-version-number@0.3.6/node_modules/react-native-version-number`)"
   - "react-native-video (from `../../../node_modules/.pnpm/react-native-video@6.16.1_react-native@0.81.6_p_f6cee87bac56333e1bcaa7ed5e65d1cc/node_modules/react-native-video`)"
   - "react-native-view-shot (from `../../../node_modules/.pnpm/react-native-view-shot@5.1.1_react-native@0.81._83e6766540172c22b2f788432d1311fb/node_modules/react-native-view-shot`)"
@@ -3950,7 +3950,7 @@ EXTERNAL SOURCES:
   react-native-startup-time:
     :path: "../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time"
   react-native-tcp-socket:
-    :path: "../../../node_modules/.pnpm/react-native-tcp-socket@6.0.6_react-native@0.81_34ca5ceafa440bcbde428f36b080d61a/node_modules/react-native-tcp-socket"
+    :path: "../../../node_modules/.pnpm/react-native-tcp-socket@6.4.2_react-native@0.81_327f68c7b97e83fdd9f586e1781ec795/node_modules/react-native-tcp-socket"
   react-native-version-number:
     :path: "../../../node_modules/.pnpm/react-native-version-number@0.3.6/node_modules/react-native-version-number"
   react-native-video:
@@ -4177,7 +4177,7 @@ SPEC CHECKSUMS:
   react-native-slider: 05e7080478df08489251c2a6739a0d5628b7c198
   react-native-splash-screen: a43276f9cf4b2e65d7ce30efe372ffc528064293
   react-native-startup-time: c7297d8a7892400239e6828bb94a3721c1a1a9df
-  react-native-tcp-socket: ae8abcfebc071216302a09d9ed1e375d4e877484
+  react-native-tcp-socket: 83a30b5da1deed4c720ee25595737ee851c23339
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
   react-native-video: 6ed94120c73e29c8fbea89ec4e3cedf3528751d6
   react-native-view-shot: 5ed55de8892be2746074c2f8066e6abc21dd6fd3

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -292,7 +292,7 @@
     "react-native-splash-screen": "3.2.0",
     "react-native-startup-time": "2.1.0",
     "react-native-svg": "catalog:",
-    "react-native-tcp-socket": "6.0.6",
+    "react-native-tcp-socket": "6.4.2",
     "react-native-url-polyfill": "1.3.0",
     "react-native-version-number": "0.3.6",
     "react-native-video": "6.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2286,8 +2286,8 @@ importers:
         specifier: 'catalog:'
         version: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-tcp-socket:
-        specifier: 6.0.6
-        version: 6.0.6(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        specifier: 6.4.2
+        version: 6.4.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-url-polyfill:
         specifier: 1.3.0
         version: 1.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
@@ -37816,8 +37816,8 @@ packages:
       react-native: '*'
       react-native-pager-view: '>= 6.0.0'
 
-  react-native-tcp-socket@6.0.6:
-    resolution: {integrity: sha512-FIFSP+3S5OnJRjl7ddD7G9NfVbVEiQ4WROEmOBei1cKE0pDz2R/Kcm4XkFlnMd5sdoG6Wbv830Yd/ZsmOjkEKw==}
+  react-native-tcp-socket@6.4.2:
+    resolution: {integrity: sha512-x3piN60BLaVA7or3n6HKhsa15QDpb1hu+X7Mh99ldV+ZXUGDVKymsLLyu7vzEybTzF3sC17ubpCEgjik5aXfcA==}
     peerDependencies:
       react-native: '>=0.60.0'
 
@@ -68920,7 +68920,7 @@ snapshots:
       react-native-pager-view: 7.0.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       use-latest-callback: 0.1.9(react@19.1.4)
 
-  react-native-tcp-socket@6.0.6(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
+  react-native-tcp-socket@6.4.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
     dependencies:
       buffer: 5.7.1
       eventemitter3: 4.0.7


### PR DESCRIPTION
### 📝 Description

Bumps `react-native-tcp-socket` 6.0.6 → 6.4.2 (used only as the bundler-level `net` polyfill for React Native, aliased in `apps/ledger-live-mobile/rspack.config.mjs`; no direct JS import in app code).

**Benefits (6.1.0 → 6.4.2 changelog):** TLS listen-option passthrough fix, `allowHalfOpen` behavior fix, `connectTimeout` support, and several Android crash fixes (`NullPointerException` in `write()`/`TcpReceiverTask`, TOCTOU race with `destroy()`).

**Risk:** package still exports `main: src/index.js` with no `exports` map, so the rspack `net` alias resolves identically; `peerDependencies.react-native: >=0.60.0` still covers our RN 0.81.6. No patch existed for this package before or after. The `scripts/post.mjs` issue-61 workaround removes `node_modules/react-native-tcp/ios/CocoaAsyncSocket` — that's a different, no-longer-installed package (`react-native-tcp`, not `-socket`), already a no-op before this bump; left untouched as out of scope.

**Test coverage:** no unit/integration test exercises this dependency directly (it's a Metro/rspack `net` fallback, not imported by app code) — verified via `git diff --stat pnpm-lock.yaml` scoping and a passing mobile jest sanity run after the bump.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-37286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
