### PR TITLE
[LWM] chore(deps): bump react-native-config from 1.5.3 to 1.7.2

### DIFF
--- a/.changeset/bump-rn-config.md
+++ b/.changeset/bump-rn-config.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@features/platform-device-action-content": patch
+---
+
+Bump react-native-config from 1.5.3 to 1.7.2 (LIVE-37288)

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -306,6 +306,7 @@ jobs:
             e2e/tooling/filter
             libs/ledger-live-common/src/bridge/generic-coin-framework/genericCoinFrameworkFamilies.json
             .pnpmfile.cjs
+            pnpm-workspace.yaml
             tools
             .mise/tasks
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -172,6 +172,7 @@ jobs:
             e2e/mobile
             e2e/tooling
             pnpm-lock.yaml
+            pnpm-workspace.yaml
             .pnpmfile.cjs
             tools
             .mise/tasks

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2164,10 +2164,36 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-config (1.5.3):
-    - react-native-config/App (= 1.5.3)
-  - react-native-config/App (1.5.3):
+  - react-native-config (1.7.2):
+    - react-native-config/App (= 1.7.2)
+  - react-native-config/App (1.7.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - react-native-fast-crypto (3.0.0):
     - React-Core
   - react-native-fast-pbkdf2 (0.3.1):
@@ -3675,7 +3701,7 @@ DEPENDENCIES:
   - "React-microtasksnativemodule (from `../../../node_modules/.pnpm/react-native@0.81.6_patch_hash=fbb22f6ab81c7336_40b065189c08febd012a31e10dcb1091/node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)"
   - "react-native-biometrics (from `../../../node_modules/.pnpm/react-native-biometrics@3.0.1_react-native@0.81_6107268f132f753441abdb0f4a753a27/node_modules/react-native-biometrics`)"
   - "react-native-ble-plx (from `../../../node_modules/.pnpm/react-native-ble-plx@3.5.1_react-native@0.81.6__754cd35e9c22570bd4ae3f51b32245ed/node_modules/react-native-ble-plx`)"
-  - "react-native-config (from `../../../node_modules/.pnpm/react-native-config@1.5.3_react-native@0.81.6_p_91b8471f5fa8329e21ee06a26a59f0d8/node_modules/react-native-config`)"
+  - "react-native-config (from `../../../node_modules/.pnpm/react-native-config@1.7.2_react-native@0.81.6_p_f2da349b4c9c5d38d61c2169cbc760d2/node_modules/react-native-config`)"
   - "react-native-fast-crypto (from `../../../node_modules/.pnpm/react-native-fast-crypto@3.0.0_react-native@0.8_c964805093320a1bef0eac9f7f7988e2/node_modules/react-native-fast-crypto`)"
   - "react-native-fast-pbkdf2 (from `../../../node_modules/.pnpm/react-native-fast-pbkdf2@0.3.1_patch_hash=9dfb8_82077b482b4e45a2986abf061e25f0ca/node_modules/react-native-fast-pbkdf2`)"
   - "react-native-get-random-values (from `../../../node_modules/.pnpm/react-native-get-random-values@1.11.0_react-nat_f6c2cc36e39b20a87b2c98ebcaeb6c82/node_modules/react-native-get-random-values`)"
@@ -3918,7 +3944,7 @@ EXTERNAL SOURCES:
   react-native-ble-plx:
     :path: "../../../node_modules/.pnpm/react-native-ble-plx@3.5.1_react-native@0.81.6__754cd35e9c22570bd4ae3f51b32245ed/node_modules/react-native-ble-plx"
   react-native-config:
-    :path: "../../../node_modules/.pnpm/react-native-config@1.5.3_react-native@0.81.6_p_91b8471f5fa8329e21ee06a26a59f0d8/node_modules/react-native-config"
+    :path: "../../../node_modules/.pnpm/react-native-config@1.7.2_react-native@0.81.6_p_f2da349b4c9c5d38d61c2169cbc760d2/node_modules/react-native-config"
   react-native-fast-crypto:
     :path: "../../../node_modules/.pnpm/react-native-fast-crypto@3.0.0_react-native@0.8_c964805093320a1bef0eac9f7f7988e2/node_modules/react-native-fast-crypto"
   react-native-fast-pbkdf2:
@@ -4161,7 +4187,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: f4762eb5cc8d2287f2513c9e404e48b30bf9fc69
   react-native-biometrics: 43ed5b828646a7862dbc7945556446be00798e7d
   react-native-ble-plx: 3badd256b90d238ff01addaa12c7a05b4ea62cda
-  react-native-config: ea75335a7cca1d3326de1da384227e580a7c082e
+  react-native-config: 713a638bfc2b359f4606a9a161bb16e6a5068568
   react-native-fast-crypto: ad4845c4dd1314c9c6e7272b91c09ff60439c6aa
   react-native-fast-pbkdf2: 329e89b9929a51ed4d9ba88bf355a266f13d9d93
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,8 +451,8 @@ catalogs:
       specifier: 0.81.6
       version: 0.81.6
     react-native-config:
-      specifier: 1.5.3
-      version: 1.5.3
+      specifier: 1.7.2
+      version: 1.7.2
     react-native-keychain:
       specifier: 10.0.0
       version: 10.0.0
@@ -2203,7 +2203,7 @@ importers:
         version: 3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-config:
         specifier: 'catalog:'
-        version: 1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        version: 1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-device-info:
         specifier: 11.1.0
         version: 11.1.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
@@ -8160,7 +8160,7 @@ importers:
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
       react-native-config:
         specifier: 'catalog:'
-        version: 1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))
+        version: 1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-test-renderer:
         specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)
@@ -37652,14 +37652,13 @@ packages:
       react: 19.1.4
       react-native: '*'
 
-  react-native-config@1.5.3:
-    resolution: {integrity: sha512-3D05Abgk5DfDw9w258EzXvX5AkU7eqj3u9H0H0L4gUga4nYg/zuupcrpGbpF4QeXBcJ84jjs6g8JaEP6VBT7Pg==}
+  react-native-config@1.7.2:
+    resolution: {integrity: sha512-sOzjs2oGPqlgJu7WjlYa/zA8/uShebQeQVYumgPd8pO+l/TrHWhOZPWrDAphxrshpnFVgPgQeXXT3eVSTNQGpg==}
     peerDependencies:
+      react: 19.1.4
       react-native: '*'
       react-native-windows: '>=0.61'
     peerDependenciesMeta:
-      react-native:
-        optional: true
       react-native-windows:
         optional: true
 
@@ -68690,12 +68689,14 @@ snapshots:
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4)
 
-  react-native-config@1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
-    optionalDependencies:
+  react-native-config@1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  react-native-config@1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)):
-    optionalDependencies:
+  react-native-config@1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
 
   react-native-crypto@2.2.0(react-native-randombytes@3.6.1):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -159,7 +159,7 @@ catalog:
   react: 19.1.4
   react-dom: 19.1.4
   react-i18next: 16.5.0
-  react-native-config: 1.5.3
+  react-native-config: 1.7.2
   react-native-keychain: 10.0.0
   react-native-reanimated: 4.3.0
   react-native-worklets: 0.8.1


### PR DESCRIPTION
### 📝 Description

Bumps `react-native-config` from 1.5.3 to 1.7.2 (pnpm catalog entry only, consumers stay on `catalog:`).

**Benefits**: New Architecture (Fabric) support added in 1.6.0; improved iOS build handling ("accumulate dotenv values without copying the hash" in 1.7.2, per-build-configuration env file support in 1.7.0); clearer errors when `Config` resolves empty instead of failing silently (1.6.2).

**Risks**: `react` is now a required (non-optional) peer dependency and `react-native` is no longer marked optional in peer deps — both are already satisfied here (react-native 0.81.6 well above the RN 0.74 floor implied by 1.6.0's `BaseReactPackage` Android rewrite). The `NativeConfig` TypeScript shape (`{ [name: string]: string | undefined }`) is unchanged since 1.5.3, so no typecheck fallout — confirmed clean on `live-mobile` and `device-action-content`.

> [!IMPORTANT]
> **1.6.0+ changes `Config` from silent-empty to app-killing on native-registration gaps.** 1.5.3's JS entrypoint was `export const Config = NativeModules.RNCConfigModule || {}` — a safe fallback that can never throw. 1.7.2 switched to the New Architecture TurboModule path: it resolves `NativeConfigModule` via `TurboModuleRegistry.get`, throws an explicit error if that's `null`, and otherwise eagerly calls `NativeConfigModule.getConfig().config` at import time. Any native-registration mismatch that used to degrade silently to an empty `Config` object now throws synchronously during module load — an uncaught JS exception at that point crashes the whole app (SIGABRT) instead of quietly losing config. We hit exactly this while validating this PR (traced to a CI cache-key gap building against a stale native APK, not an incompatibility in the bump itself — see PR comments), but it's a real risk characteristic of this upgrade worth a deliberate QA pass, not just an incidental CI hiccup.

**Test coverage**: Config is globally mocked in `__mocks__/react-native-config.ts` (via `jest.mock("react-native-config")` in `jest-setup.js`), so all ~51 call sites render under test, but only 2 files assert Config-driven behaviour directly (`Lottie.test.tsx`'s `Config.DETOX` branching, `useCyclingPlaceholder.test.ts`). Both pass, along with the Datadog/segment/store/locale suites that read `Config` indirectly (56 tests) and the full `device-action-content` suite (43 tests). Most call sites (env token reads, feature flags) have no dedicated assertions beyond render-without-crash.

Native `Podfile.lock` regenerated locally (`pnpm mobile pod`) and included in this PR. The diff is scoped to `react-native-config` and its new transitive pod deps (`React-Fabric`, `React-graphics`, `React-renderercss`, etc.) pulled in by 1.6.0's New Architecture support — expected signal, not local CocoaPods drift.

This bump touches native Android/iOS build plumbing on both platforms — **recommend a QA pass on Android + iOS** before merge, per the ticket.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37288](https://ledgerhq.atlassian.net/browse/LIVE-37288)
- **ADR** (if any): N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-37288]: https://ledgerhq.atlassian.net/browse/LIVE-37288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ