### PR TITLE
[LWM] chore(mobile): drop react-native-haptic-feedback (LIVE-37290)

### DIFF
--- a/.changeset/brave-otters-wander.md
+++ b/.changeset/brave-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Replace react-native-haptic-feedback with expo-haptics, already present as a Lumen peer

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -114,12 +114,6 @@ jest.mock("react-native-gesture-handler", () => {
 
 jest.mock("react-native-gesture-handler/ReanimatedSwipeable");
 
-jest.mock("react-native-haptic-feedback", () => ({
-  default: {
-    trigger: jest.fn(),
-  },
-}));
-
 jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn().mockResolvedValue(undefined),
   notificationAsync: jest.fn().mockResolvedValue(undefined),

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -3234,34 +3234,6 @@ PODS:
     - Yoga
   - RNLocalize (2.2.6):
     - React-Core
-  - RNReactNativeHapticFeedback (2.3.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RNReanimated (4.3.0):
     - boost
     - DoubleConversion
@@ -3739,7 +3711,6 @@ DEPENDENCIES:
   - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.28.0_react-nativ_0a7cb677e518f2e9f30a24dde608028e/node_modules/react-native-gesture-handler`)"
   - "RNKeychain (from `../../../node_modules/.pnpm/react-native-keychain@10.0.0/node_modules/react-native-keychain`)"
   - "RNLocalize (from `../../../node_modules/.pnpm/react-native-localize@2.2.6_react-native@0.81.6_22b59121ec847ba53fb2e7d8aec6c181/node_modules/react-native-localize`)"
-  - "RNReactNativeHapticFeedback (from `../../../node_modules/.pnpm/react-native-haptic-feedback@2.3.3_react-native_4be985a7c9ac5a85953ef361e5810bbb/node_modules/react-native-haptic-feedback`)"
   - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.0_react-native-work_428dfbb78210a4eccefe4ea5b615ab19/node_modules/react-native-reanimated`)"
   - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.15.4_react-native@0.81.6_d34209bb2ab45ed965aa2e8d5e51931e/node_modules/react-native-screens`)"
   - "RNShare (from `../../../node_modules/.pnpm/react-native-share@12.2.0/node_modules/react-native-share`)"
@@ -4045,8 +4016,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/.pnpm/react-native-keychain@10.0.0/node_modules/react-native-keychain"
   RNLocalize:
     :path: "../../../node_modules/.pnpm/react-native-localize@2.2.6_react-native@0.81.6_22b59121ec847ba53fb2e7d8aec6c181/node_modules/react-native-localize"
-  RNReactNativeHapticFeedback:
-    :path: "../../../node_modules/.pnpm/react-native-haptic-feedback@2.3.3_react-native_4be985a7c9ac5a85953ef361e5810bbb/node_modules/react-native-haptic-feedback"
   RNReanimated:
     :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.0_react-native-work_428dfbb78210a4eccefe4ea5b615ab19/node_modules/react-native-reanimated"
   RNScreens:
@@ -4225,7 +4194,6 @@ SPEC CHECKSUMS:
   RNGestureHandler: b8d2e75c2e88fc2a1f6be3b3beeeed80b88fa37d
   RNKeychain: 76d042fc1dfba47f3945920bc82e0bce9ad1ff55
   RNLocalize: 8bf466de4c92d4721b254aabe1ff0a1456e7b9f4
-  RNReactNativeHapticFeedback: 5f1542065f0b24c9252bd8cf3e83bc9c548182e4
   RNReanimated: c74d47574d33045e2129b2a192be1deac616c3a0
   RNScreens: 4f2aed147a2775017923789d8a0a2d377712ec2e
   RNShare: 81b8cfb58b1460c4a197d5379934bdf70980c124

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -271,7 +271,6 @@
     "react-native-fast-shadow": "0.1.1",
     "react-native-gesture-handler": "2.28.0",
     "react-native-get-random-values": "1.11.0",
-    "react-native-haptic-feedback": "2.3.3",
     "react-native-image-crop-tools": "1.6.4",
     "react-native-image-picker": "8.2.0",
     "react-native-keychain": "catalog:",

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -3,7 +3,7 @@ import { Dimensions, Linking, Platform, Share, View } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import QRCode from "react-native-qrcode-svg";
 import { useTranslation } from "~/context/Locale";
-import ReactNativeHapticFeedback from "react-native-haptic-feedback";
+import * as Haptics from "expo-haptics";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { TokenCurrency } from "@domain/entity-currency-token";
@@ -216,16 +216,11 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
         button: eventName,
         page: "Receive Account Qr Code",
       });
-      const options = {
-        enableVibrateFallback: false,
-        ignoreAndroidSystemSettings: false,
-      };
-
       setTimeout(() => {
         setCopied(false);
       }, 3000);
 
-      ReactNativeHapticFeedback.trigger("soft", options);
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Soft);
       pushToast({
         id: `copy-receive`,
         type: "success",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2222,9 +2222,6 @@ importers:
       react-native-get-random-values:
         specifier: 1.11.0
         version: 1.11.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
-      react-native-haptic-feedback:
-        specifier: 2.3.3
-        version: 2.3.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-image-crop-tools:
         specifier: 1.6.4
         version: 1.6.4(patch_hash=8dc28ff513f78de4133eb71abe17699348337c4354a1e7fa23aeb5083009e0b2)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -37665,11 +37662,6 @@ packages:
     peerDependencies:
       react-native: '>=0.56'
 
-  react-native-haptic-feedback@2.3.3:
-    resolution: {integrity: sha512-svS4D5PxfNv8o68m9ahWfwje5NqukM3qLS48+WTdhbDkNUkOhP9rDfDSRHzlhk4zq+ISjyw95EhLeh8NkKX5vQ==}
-    peerDependencies:
-      react-native: '>=0.60.0'
-
   react-native-image-crop-tools@1.6.4:
     resolution: {integrity: sha512-GhI76SlKAI7vfUfg/UnG/MrPTe7ffwjsOowBnYYAB2npJ2ij/iAG4LRXOPlQygoY+yiCy158sYo4wmKDc0RfLQ==}
     peerDependencies:
@@ -68714,10 +68706,6 @@ snapshots:
     dependencies:
       fast-base64-decode: 1.0.0
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
-
-  react-native-haptic-feedback@2.3.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
-    dependencies:
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
   react-native-image-crop-tools@1.6.4(patch_hash=8dc28ff513f78de4133eb71abe17699348337c4354a1e7fa23aeb5083009e0b2)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:


### PR DESCRIPTION
- [x] tested on Android
- [x] tested on iOS

### 📝 Description

`expo-haptics` is already installed as a Lumen peer dependency, so the two haptics libraries were a duplicate capability. This drops `react-native-haptic-feedback`.

There is a single call site — the receive screen, when the address is copied:

```diff
-ReactNativeHapticFeedback.trigger("soft", {
-  enableVibrateFallback: false,
-  ignoreAndroidSystemSettings: false,
-})
+void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Soft)
```

On iOS, behaviour is unchanged: on any device with a Taptic Engine both libraries call the same `UIImpactFeedbackGenerator(style: .soft)` API, and `enableVibrateFallback: false` only ever affected the fallback path on very old/non-haptic devices, which was already disabled.

On Android there is a real, minor behaviour change: the old library checked `ignoreAndroidSystemSettings: false` against the device's ringer/vibrate system setting (`AudioManager`) and silently skipped the vibration when the phone was silenced. `expo-haptics`' Android implementation calls `Vibrator.vibrate()` unconditionally with no such check, so this haptic will now fire even for a user who has silenced vibration feedback system-wide. Accepted as low-impact for a single soft tap on address-copy.

`Podfile.lock` is regenerated because `RNReactNativeHapticFeedback` was an autolinked pod: 32 deletions, all of them that pod's spec block, dependency entry, external source and checksum. `PODFILE CHECKSUM` is unchanged and `ExpoHaptics` was already present, so no pod is added.

The global `react-native-haptic-feedback` jest mock is removed from `jest-setup.js`. The `expo-haptics` mock was already there and already covers `ImpactFeedbackStyle.Soft`, so no test scaffolding was needed.

**Validated locally:** mobile typecheck clean, receive-flow tests pass, oxlint introduces no new warning, oxfmt clean. No existing test covers this specific call site (no unit/integration/e2e test exercises `onCopyAddress` in `03-Confirmation.tsx`); not adding new coverage here since the screen has no existing test harness and wiring one up is out of scope for this swap.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-37290
- **ADR** (if any): n/a
