### PR TITLE
[LWM] chore(mobile): bump react-native-qrcode-svg 6.3.24 (LIVE-37281)

### DIFF
--- a/.changeset/lucky-pandas-wander.md
+++ b/.changeset/lucky-pandas-wander.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bump react-native-qrcode-svg from 6.1.1 to 6.3.24

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -284,7 +284,7 @@
     "react-native-navigation-bar-color": "2.0.2",
     "react-native-nitro-modules": "0.35.9",
     "react-native-pager-view": "7.0.0",
-    "react-native-qrcode-svg": "6.1.1",
+    "react-native-qrcode-svg": "6.3.24",
     "react-native-randombytes": "3.6.1",
     "react-native-reanimated": "catalog:",
     "react-native-restart": "0.0.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2259,8 +2259,8 @@ importers:
         specifier: 7.0.0
         version: 7.0.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-qrcode-svg:
-        specifier: 6.1.1
-        version: 6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        specifier: 6.3.24
+        version: 6.3.24(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-randombytes:
         specifier: 3.6.1
         version: 3.6.1
@@ -37765,12 +37765,12 @@ packages:
     peerDependencies:
       react-native: '*'
 
-  react-native-qrcode-svg@6.1.1:
-    resolution: {integrity: sha512-98cc8fkl61g2V5cesmxjlMr1WaJZcB6dyeN8T9d/shIWtJxU8KRCinNCZNBlIvO9fxbIpo5SgK+pqSItK0+vow==}
+  react-native-qrcode-svg@6.3.24:
+    resolution: {integrity: sha512-oqv2OrEldXArsB3pqMJCLs2RNr4kRkawAe8dSiYKySRPEE/6WSt3/0o5mWnshmd8a8SbYNdj8UKwKYxh2hzPaA==}
     peerDependencies:
       react: 19.1.4
       react-native: '>=0.63.4'
-      react-native-svg: ^12.1.0
+      react-native-svg: '>=14.0.0'
 
   react-native-randombytes@3.6.1:
     resolution: {integrity: sha512-qxkwMbOZ0Hff1V7VqpaWrR6ItkA+oF6bnI79Qp9F3Tk8WBsdKDi6m1mi3dEdFWePoRLrhJ2L03rU0yabst1tVw==}
@@ -39542,6 +39542,10 @@ packages:
 
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
+  text-encoding@0.7.0:
+    resolution: {integrity: sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==}
+    deprecated: no longer maintained
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
@@ -68830,13 +68834,14 @@ snapshots:
     dependencies:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+  react-native-qrcode-svg@6.3.24(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       prop-types: 15.8.1
       qrcode: 1.5.4
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      text-encoding: 0.7.0
 
   react-native-randombytes@3.6.1:
     dependencies:
@@ -71294,6 +71299,8 @@ snapshots:
   text-encoding-polyfill@0.6.7: {}
 
   text-encoding-utf-8@1.0.2: {}
+
+  text-encoding@0.7.0: {}
 
   text-hex@1.0.0: {}
 


### PR DESCRIPTION
### 📝 Description

Bumps `react-native-qrcode-svg` from **6.1.1** (Feb 2021) to **6.3.24** — 67 months of drift, the largest single gap in the mobile dependency surface, and entirely within the same major.

No application code change is needed. Across the 4 call sites (receive, WalletSync pairing, Concordium onboard, Hedera) the props in use are `value`, `size`, `ecl`, `logo` and `logoSize`, all unchanged between 6.1 and 6.3. `react-native-svg@15.15.1` already satisfies the new `>=14.0.0` peer range.

`Podfile.lock` is untouched: the library is pure JS and delegates rendering to `react-native-svg`, which is not modified here.

Transitively picks up `qrcode` 1.5.0 → 1.5.4, which carries generation bug fixes.

> [!NOTE]
> Coverage of the 4 call sites is uneven and unchanged by this bump: the 2 WalletSync integration tests render the real (unmocked) component (`ws-qr-code-displayed`), the 5 Concordium suites (StepPair + 4 integration tests) render a local `jest.mock` stand-in, and the ReceiveFunds and Hedera call sites have no test exercising their render at all — 7 suites / 31 tests total. Validation here is the mobile typecheck plus these existing suites, run locally against the bumped version.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-37281
- **ADR** (if any): n/a

