### PR TITLE
fix(ci): bust Android native E2E cache on catalog bumps (LIVE-37297)

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -417,7 +417,7 @@ jobs:
             PREFIX="develop/"
           fi
           echo "ios_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-${{ inputs.production_firebase == true && 'prod-2' || '3' }}" >> $GITHUB_OUTPUT
-          echo "android_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/android', 'apps/ledger-live-mobile/package.json') }}-detox-native-android-${{ inputs.production_firebase == true && 'prod-2' || '3' }}" >> $GITHUB_OUTPUT
+          echo "android_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/android', 'apps/ledger-live-mobile/package.json', 'pnpm-workspace.yaml') }}-detox-native-android-${{ inputs.production_firebase == true && 'prod-2' || '3' }}" >> $GITHUB_OUTPUT
           HEAD_SHA=$(git rev-parse HEAD)
           echo "ios_js_key=${PREFIX}${HEAD_SHA}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${PREFIX}${HEAD_SHA}-detox-js-android" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -188,7 +188,7 @@ jobs:
             PREFIX="develop/"
           fi
           echo "ios_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-3" >> $GITHUB_OUTPUT
-          echo "android_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/android', 'apps/ledger-live-mobile/package.json') }}-detox-native-android-3" >> $GITHUB_OUTPUT
+          echo "android_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/android', 'apps/ledger-live-mobile/package.json', 'pnpm-workspace.yaml') }}-detox-native-android-3" >> $GITHUB_OUTPUT
           HEAD_SHA=$(git rev-parse HEAD)
           echo "ios_js_key=${PREFIX}${HEAD_SHA}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${PREFIX}${HEAD_SHA}-detox-js-android" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### 📝 Description

The Android native cache key for the mobile E2E jobs hashes only `apps/ledger-live-mobile/android` and that app's `package.json`. A dependency bumped through the **pnpm catalog** changes `pnpm-workspace.yaml` instead, so the key is unchanged and CI restores a **pre-bump APK** from S3 while rebuilding the JS bundle — which is keyed on the commit SHA — with the new version. The native/JS mismatch then reads exactly like a product bug.

Caught on #21858 (`react-native-config` 1.5.3 → 1.7.2): all 10 Android E2E suites failed identically through 3 Detox retries with `The app has unexpectedly disconnected from Detox server`, because 1.7.2's TurboModule JS entry throws at import when the native module isn't registered — and the cached APK predates the bump. "Android Build Native" showed as `skipping`, which is the tell.

**Benefit:** catalog bumps of packages with Android native code stop producing meaningless Android E2E results — a false red as here, or worse a false green that validates nothing.

**Risk:** one extra Android native rebuild whenever `pnpm-workspace.yaml` changes. That file carries the catalog and moves rarely, so the added cache churn is negligible.

iOS is deliberately untouched: its key hashes `apps/ledger-live-mobile/ios`, so the regenerated `Podfile.lock` already busts it — confirmed on #21858, where iOS native rebuilt and iOS E2E passed on the very commit Android failed.

**Test coverage:** none is possible — cache keys are only exercised by CI itself. The fix is verified by #21858, which carries the same one-line change and whose Android E2E can only go green once the native rebuild actually happens.

### 🔗 Context

- **JIRA**: [LIVE-37297](https://ledgerhq.atlassian.net/browse/LIVE-37297)
- Found while delivering LIVE-37288 (#21858)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-37297]: https://ledgerhq.atlassian.net/browse/LIVE-37297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ