### PR TITLE
fix(e2e): add annotations even for CLI fails

### DIFF
--- a/e2e/desktop/docs/add-or-update-e2e.md
+++ b/e2e/desktop/docs/add-or-update-e2e.md
@@ -195,9 +195,10 @@ test.use({
 - Use `@step` decorator in Page Objects
 - Access methods via `app` fixture (e.g., `app.layout`, `app.send`, `app.speculos`)
 - **MANDATORY:** Test on all 6 device models (LNS, LNSP, LNX, STAX, FLEX, NG5) before marking tests complete
-- **Every `test()` must include a TMS annotation** with a valid `B2CQA-XXXX` id. Omitting it causes
-  `getDescription(test.info().annotations, "TMS")` to return the literal string `"Type not found"`,
-  which `addTmsLink()` then renders in Allure as a dead link.
+- **Every `test()` must include a TMS annotation** with a valid `B2CQA-XXXX` id. The `annotationLinks` auto
+  fixture reads that annotation and publishes the Allure TMS link before any other fixture runs, so
+  the link is present even when CLI/Speculos setup fails and the body never executes. Never call
+  `addTmsLink()` from a test body — a test with no annotation simply gets no link.
 
   ```typescript
   const xrayTicket = "B2CQA-XXXX"; // obtain from QA before merging

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -12,6 +12,7 @@ import { launchApp } from "tests/utils/electronUtils";
 import {
   captureArtifacts,
   addTeamOwner,
+  addAnnotationLinks,
   attachMergedFeatureFlags,
   runCliStep,
 } from "tests/utils/allureUtils";
@@ -64,6 +65,7 @@ type TestFixtures = {
   localManifestOverride?: LiveAppManifest[];
   teamOwner?: Team;
   teamOwnerLabel: void;
+  annotationLinks: void;
   speculos: SpeculosFixtureHandle;
   speculosForSetupOnly?: boolean;
 };
@@ -106,6 +108,14 @@ export const test = base.extend<TestFixtures>({
       if (teamOwner !== undefined) {
         await addTeamOwner(teamOwner);
       }
+      await use();
+    },
+    { auto: true },
+  ],
+
+  annotationLinks: [
+    async ({}, use, testInfo) => {
+      await addAnnotationLinks(testInfo.annotations);
       await use();
     },
     { auto: true },

--- a/e2e/desktop/tests/specs/accounts.swap.spec.ts
+++ b/e2e/desktop/tests/specs/accounts.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import {
   setupEnv,
   performSwapUntilQuoteSelectionStep,
@@ -58,8 +57,6 @@ test.describe("Swap - default currency", () => {
       annotation: { type: "TMS", description: "B2CQA-3079, B2CQA-3080" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await test.step("Default currency is set when landing on swap", async () => {
         await app.swap.goAndWaitForSwapToBeReady(() =>
           app.mainNavigation.openTargetFromMainNavigation("swap"),
@@ -128,8 +125,6 @@ test.describe("Swap - rejected on device", () => {
       annotation: { type: "TMS", description: "B2CQA-2212" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
       const rejectedSwap = new Swap(fromAccount, toAccount, minAmount);
 
@@ -222,8 +217,6 @@ for (const {
         annotation: { type: "TMS", description: xrayTicket },
       },
       async ({ app }) => {
-        const tmsDescription = getDescription(test.info().annotations, "TMS");
-        await addTmsLink(tmsDescription.split(", "));
         swap.accountToDebit.address = addressFrom;
         swap.accountToCredit.address = addressTo;
 
@@ -274,7 +267,6 @@ test.describe("Swap - account not present", () => {
       annotation: { type: "TMS", description: xrayTicket },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );
@@ -337,7 +329,6 @@ test.describe("Swap - account not present", () => {
       annotation: { type: "TMS", description: xrayTicket },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );
@@ -391,7 +382,6 @@ test.describe("Swap - account not present", () => {
       annotation: { type: "TMS", description: xrayTicket },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );
@@ -453,8 +443,6 @@ test.describe("Swap - switch currencies", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await performSwapUntilQuoteSelectionStep(app, swap, swap.amount ?? "0");
       await app.swap.switchYouSendAndYouReceive();
       await app.swap.checkAssetFromContains(swap.accountToCredit.currency.ticker);

--- a/e2e/desktop/tests/specs/activate.private.balance.spec.ts
+++ b/e2e/desktop/tests/specs/activate.private.balance.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { buildTags } from "tests/utils/tagsUtils";
 
 const accounts = [
@@ -34,7 +33,6 @@ for (const account of accounts) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(account.account.accountName);
         await app.account.expectAccountVisibility(account.account.accountName);

--- a/e2e/desktop/tests/specs/add.account.spec.ts
+++ b/e2e/desktop/tests/specs/add.account.spec.ts
@@ -1,7 +1,6 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import { isAssetSectionEnabled } from "tests/utils/featureFlagUtils";
 import { buildTags } from "tests/utils/tagsUtils";
@@ -73,7 +72,6 @@ for (const currency of currencies) {
         },
       },
       async ({ app, userdataFile }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         const firstAccountName = `${currency.currency.name} 1`;
 
         await app.portfolio.waitForPortfolioEmptyState();
@@ -148,7 +146,6 @@ test.describe("Add account", () => {
       },
     },
     async ({ app, userdataFile }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       const firstAccountName = `${Currency.ALEO.name} 1`;
 
       await app.portfolio.waitForPortfolioEmptyState();

--- a/e2e/desktop/tests/specs/assets.addresses.spec.ts
+++ b/e2e/desktop/tests/specs/assets.addresses.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { expect } from "@playwright/test";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { FF_LWD_WALLET_40_Q2 } from "tests/utils/featureFlagUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 import { coinDetailUrlPattern } from "tests/utils/urlUtils";
@@ -56,8 +55,6 @@ test.describe("Wallet assets", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.expectHeaderVisible("cryptos");
@@ -127,7 +124,6 @@ test.describe("Wallet assets", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.expectHeaderVisible("cryptos");
@@ -155,8 +151,6 @@ test.describe("Wallet assets", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.expectHeaderVisible("cryptos");

--- a/e2e/desktop/tests/specs/assets.aggregation.spec.ts
+++ b/e2e/desktop/tests/specs/assets.aggregation.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { expect } from "@playwright/test";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT } from "tests/utils/featureFlagUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
@@ -34,8 +33,6 @@ test.describe("Asset aggregation", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.expectSingleAggregatedRow("stablecoins", "USD Coin");
@@ -71,8 +68,6 @@ test.describe("Asset aggregation", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.clickAssetInSection("cryptos", Currency.BTC);
@@ -118,8 +113,6 @@ test.describe("Asset aggregation", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         const ticker = Currency.BTC.ticker;
 
         await app.mainNavigation.openTargetFromMainNavigation("home");
@@ -172,8 +165,6 @@ test.describe("Asset aggregation", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.clickAssetInSection("cryptos", Currency.ETH);

--- a/e2e/desktop/tests/specs/assets.discoverability.spec.ts
+++ b/e2e/desktop/tests/specs/assets.discoverability.spec.ts
@@ -1,7 +1,6 @@
 import { test } from "tests/fixtures/common";
 import { expect } from "@playwright/test";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { FF_LWD_WALLET_40_Q2 } from "tests/utils/featureFlagUtils";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
@@ -25,8 +24,6 @@ test.describe("Asset discoverability", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectStocksDiscoveryVisible();
 
@@ -57,8 +54,6 @@ test.describe("Asset discoverability", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectStocksHoldingsVisible();
 
@@ -87,8 +82,6 @@ test.describe("Asset discoverability", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.topBarSearch.open();
       await app.topBarSearch.expectCategoriesVisible();
 
@@ -113,8 +106,6 @@ test.describe("Asset discoverability", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.topBarSearch.open();
 
       await app.topBarSearch.searchFor("btc");

--- a/e2e/desktop/tests/specs/borrow.spec.ts
+++ b/e2e/desktop/tests/specs/borrow.spec.ts
@@ -1,7 +1,6 @@
 import { resolve as resolvePath } from "node:path";
 import test from "tests/fixtures/common";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import {
@@ -88,8 +87,6 @@ test.describe("Borrow", () => {
       annotation: { type: "TMS", description: "B2CQA-6062" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectBorrowEntryPointVisible();
 
@@ -123,7 +120,6 @@ test.describe("Borrow", () => {
     },
     async ({ app }) => {
       test.setTimeout(BORROW_TEST_TIMEOUT_MS);
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectBorrowEntryPointVisible();
@@ -186,7 +182,6 @@ test.describe("Borrow", () => {
     },
     async ({ app }) => {
       test.setTimeout(BORROW_TEST_TIMEOUT_MS);
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectBorrowEntryPointVisible();
@@ -246,7 +241,6 @@ test.describe("Borrow", () => {
     },
     async ({ app }) => {
       test.setTimeout(BORROW_TEST_TIMEOUT_MS);
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectBorrowEntryPointVisible();

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import {
   Account,
   TokenAccount,
@@ -69,7 +68,6 @@ for (const asset of assets) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.clickAsset(crypto.currency);
         await app.assetPage.startBuyFlow();
@@ -89,7 +87,6 @@ for (const asset of assets) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.marketBanner.clickExploreMarketHeader();
         await app.market.search(crypto.currency.ticker);
         await app.market.openBuyPage(crypto.currency.ticker);
@@ -109,7 +106,6 @@ for (const asset of assets) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(getParentAccountName(asset.buySell.crypto));
         if (asset.buySell.crypto.tokenType) {
@@ -139,7 +135,6 @@ for (const asset of assets) {
         },
       },
       async ({ app, userdataDestinationPath }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.portfolio.clickBuyButton();
         await app.buyAndSell.chooseAssetIfNotSelected(crypto);
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
@@ -206,7 +201,6 @@ for (const sellAsset of sellAssets) {
         },
       },
       async ({ app, userdataDestinationPath }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.portfolio.clickSellButton();
         await app.buyAndSell.chooseAssetIfNotSelected(crypto);
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Sell);

--- a/e2e/desktop/tests/specs/crossAccount.warning.swap.spec.ts
+++ b/e2e/desktop/tests/specs/crossAccount.warning.swap.spec.ts
@@ -1,7 +1,6 @@
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import test from "tests/fixtures/common";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { performSwapUntilQuoteSelectionStep, setupEnv } from "tests/utils/swapUtils";
 import { keepRunningProviders } from "@ledgerhq/live-e2e-shared/swap";
 import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
@@ -59,7 +58,6 @@ test.describe("Swap - cross account warning", () => {
           `${provider.uiName} provider is currently down — skipping cross-account warning check`,
         );
 
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
         const swap = new Swap(fromAccount, toAccount, minAmount, provider);
         const errorMessage =

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -8,7 +8,6 @@ import {
 } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
-import { addTmsLink } from "tests/utils/allureUtils";
 import { setupEnv, selectAccountFromDeeplinkDrawer } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import {
@@ -65,8 +64,6 @@ test.describe("Swap - deeplinks", () => {
     "Swap deeplinks - all scenarios",
     { tag: TAGS, annotation: { type: "TMS", description: TMS } },
     async ({ app }) => {
-      await addTmsLink([TMS]);
-
       setExchangeDependencies([
         { name: btcAccount.currency.speculosApp.name.replace(/ /g, "_") },
         { name: ethAccount.currency.speculosApp.name.replace(/ /g, "_") },

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -5,7 +5,6 @@ import { Addresses } from "@ledgerhq/live-e2e-shared/enum/Addresses";
 import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
 import { getEnv } from "@shared/env";
-import { addBugLink, addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import {
   liveDataCommand,
@@ -117,14 +116,12 @@ for (const account of e2eDelegationAccounts) {
           currencyId: account.delegate.account.currency.id,
           skipLNS: account.supportsLNS === false,
         }),
-        annotation: { type: "TMS", description: account.xrayTicket },
+        annotation: [
+          { type: "TMS", description: account.xrayTicket },
+          ...(account.bugTicket ? [{ type: "BUG", description: account.bugTicket }] : []),
+        ],
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-        if (account.bugTicket) {
-          await addBugLink([account.bugTicket]);
-        }
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(account.delegate.account.accountName);
 
@@ -185,8 +182,6 @@ test.describe("Delegate", () => {
       annotation: { type: "TMS", description: "B2CQA-3023" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();
@@ -223,8 +218,6 @@ test.describe("Delegate", () => {
       annotation: { type: "TMS", description: "B2CQA-3020" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();
@@ -268,8 +261,6 @@ test.describe("Delegate", () => {
       annotation: { type: "TMS", description: "B2CQA-2742" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();
@@ -314,7 +305,6 @@ test.describe("Delegate", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();
@@ -345,7 +335,6 @@ test.describe("Delegate", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();
@@ -384,14 +373,12 @@ for (const validator of validators) {
           currencyId: validator.delegate.account.currency.id,
           skipLNS: validator.delegate.account.currency.id === Currency.MULTIVERS_X.id,
         }),
-        annotation: { type: "TMS", description: validator.xrayTicket },
+        annotation: [
+          { type: "TMS", description: validator.xrayTicket },
+          ...(validator.bugTicket ? [{ type: "BUG", description: validator.bugTicket }] : []),
+        ],
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-        if (validator.bugTicket) {
-          await addBugLink([validator.bugTicket]);
-        }
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(validator.delegate.account.accountName);
 
@@ -460,7 +447,6 @@ test.describe("Select a validator", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.marketBanner.clickExploreMarketHeader();
       // The asset-discoverability Market has no search input and no per-row stake CTA: staking is
       // reached by opening the asset detail page. Both entry points open the same stake flow.
@@ -501,8 +487,6 @@ for (const currency of liveApps) {
         annotation: { type: "TMS", description: currency.xrayTicket },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(currency.delegate.account.accountName);
 
@@ -541,8 +525,6 @@ test.describe("Delegate", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(seiDelegation.account.accountName);
 
@@ -594,8 +576,6 @@ test.describe("Delegate - MINA", () => {
       annotation: { type: "TMS", description: "B2CQA-387" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
 
@@ -645,8 +625,6 @@ test.describe("Redelegate - MINA", () => {
       annotation: { type: "TMS", description: "B2CQA-387" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
 

--- a/e2e/desktop/tests/specs/delete.account.spec.ts
+++ b/e2e/desktop/tests/specs/delete.account.spec.ts
@@ -1,7 +1,6 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { buildTags } from "tests/utils/tagsUtils";
 
@@ -46,8 +45,6 @@ for (const account of accounts) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(account.account.accountName);
         await app.account.expectAccountVisibility(account.account.accountName);

--- a/e2e/desktop/tests/specs/discreet.swap.spec.ts
+++ b/e2e/desktop/tests/specs/discreet.swap.spec.ts
@@ -2,7 +2,6 @@ import { Account, type AccountType, TokenAccount } from "@ledgerhq/live-e2e-shar
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import test from "tests/fixtures/common";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { setupEnv } from "tests/utils/swapUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
@@ -50,7 +49,6 @@ test.describe("Swap - discreet mode", () => {
       ],
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       const fundedAssetTickers = fundedAssetsAccounts.map(account => account.currency.ticker);
       await app.swap.selectFromAccountCoinSelector();
       await app.modularDialog.validateItems();
@@ -70,7 +68,6 @@ test.describe("Swap - discreet mode", () => {
       ],
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.swap.selectFromAccountCoinSelector();
       await app.modularDialog.selectAsset(balanceCheckAccount.currency);
       await app.modularDialog.selectNetwork(balanceCheckAccount.currency);
@@ -92,7 +89,6 @@ test.describe("Swap - discreet mode", () => {
       ],
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );

--- a/e2e/desktop/tests/specs/earn.v2.spec.ts
+++ b/e2e/desktop/tests/specs/earn.v2.spec.ts
@@ -10,7 +10,6 @@ import {
   FF_STAKE_PROGRAMS_MODAL,
   useLocalEarnManifest,
 } from "tests/utils/featureFlagUtils";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import earnLocalManifestJson from "tests/utils/earnLocalManifest.json";
 import {
@@ -29,7 +28,6 @@ function setupEnv(disableBroadcast?: boolean) {
 }
 
 async function navigateToEarn(app: Application) {
-  await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
   await app.earnV2Dashboard.goAndWaitForEarnToBeReady(() =>
     app.mainNavigation.openTargetFromMainNavigation("earn"),
   );
@@ -422,7 +420,6 @@ test.describe("Select a validator", () => {
       annotation: { type: "TMS", description: "B2CQA-3024" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -8,7 +8,6 @@ import {
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
 import { getEnv } from "@shared/env";
@@ -60,7 +59,6 @@ test.describe("Swap - entry points", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.clickAsset(swapEntryPoint.swap.accountToDebit.currency);
       if (await isAggregatedAssetsEnabled(app.getPage())) {
@@ -84,7 +82,6 @@ test.describe("Swap - entry points", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.marketBanner.clickExploreMarketHeader();
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.market.startSwapForSelectedTicker(swapEntryPoint.swap.accountToDebit.currency.ticker),
@@ -106,7 +103,6 @@ test.describe("Swap - entry points", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.marketBanner.clickExploreMarketHeader();
       await app.market.clickCoinRow(swapEntryPoint.swap.accountToDebit.currency.ticker);
       if (await isAggregatedAssetsEnabled(app.getPage())) {
@@ -133,7 +129,6 @@ test.describe("Swap - entry points", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(
         getParentAccountName(swapEntryPoint.swap.accountToDebit),
@@ -156,8 +151,6 @@ test.describe("Swap - entry points", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );
@@ -225,7 +218,6 @@ for (const { fromAccount, toAccount, xrayTicket } of swapMax) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.swap.goAndWaitForSwapToBeReady(() =>
           app.mainNavigation.openTargetFromMainNavigation("swap"),
         );
@@ -305,8 +297,6 @@ test.describe("Swap - history", () => {
       annotation: { type: "TMS", description: "B2CQA-604" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       swapHistory.swap.accountToDebit.address = swapHistory.addressFrom;
       swapHistory.swap.accountToCredit.address = swapHistory.addressTo;
 
@@ -331,8 +321,6 @@ test.describe("Swap - history", () => {
       annotation: { type: "TMS", description: "B2CQA-602" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("swap");
       await app.swap.goToSwapHistory();
       await app.swap.checkSwapOperation(swapHistory.swapId, swapHistory.provider, swapHistory.swap);
@@ -388,8 +376,6 @@ test.describe("Swap - blacklisted address", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       const sanctionedAddressUrl = getEnv("SANCTIONED_ADDRESSES_URL");
       await overrideNetworkPayload(app, sanctionedAddressUrl, (json: any) => {
         json.bannedAddresses = [fromAccount.address];

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -2,7 +2,6 @@ import { type CliCommand, test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { LedgerSyncCliHelper } from "@ledgerhq/live-e2e-shared/ledgerSync/helper";
 import { ledgerSyncEnvironment } from "@ledgerhq/live-e2e-shared/ledgerSync/environment";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
@@ -80,8 +79,6 @@ test.describe("Ledger Sync - add account", () => {
       },
     },
     async ({ app, speculos }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await speculos.relaunch(addedCurrency.speculosApp.name);
 
       await app.portfolio.expectAddAccountButtonVisible();
@@ -136,8 +133,6 @@ test.describe("Ledger Sync - rename account", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.accounts.expectReduxAccountIds([ethAccount.id]);
       await app.trustchain.expectAccountToHaveDefaultName(ethAccount.id);
 
@@ -176,8 +171,6 @@ test.describe("Ledger Sync - delete account", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.accounts.expectReduxAccountIds([ethAccount.id, secondEthAccount.id]);
       await app.trustchain.expectAccountIds([ethAccount.id, secondEthAccount.id]);
 
@@ -216,8 +209,6 @@ test.describe("Ledger Sync - delete instance", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.openManageLedgerSync();
       await app.ledgerSync.manageInstances();
@@ -254,8 +245,6 @@ test.describe("Ledger Sync - delete backup", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.trustchain.expectToHoldAccount(ethAccount.id, ethAccount.currencyId);
 
       await app.mainNavigation.openSettings();
@@ -317,8 +306,6 @@ test.describe("Ledger Sync - entry point in settings", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.expectLedgerSyncSettingsRow();
       await app.settings.expectLedgerSyncSettingsEntryPoint();
@@ -339,8 +326,6 @@ test.describe("Ledger Sync - activation flow no backup activated", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.expectLedgerSyncSettingsRow();
       await app.settings.expectLedgerSyncSettingsEntryPoint();
@@ -366,8 +351,6 @@ test.describe("Ledger Sync - activation flow backup activated", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.expectLedgerSyncSettingsRow();
       await app.settings.expectLedgerSyncSettingsEntryPoint();

--- a/e2e/desktop/tests/specs/main.navigation.spec.ts
+++ b/e2e/desktop/tests/specs/main.navigation.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
 test.describe("Main navigation", () => {
@@ -19,8 +18,6 @@ test.describe("Main navigation", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.mainNavigation.validateTargetFromMainNavigation("home");
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
@@ -47,8 +44,6 @@ test.describe("Main navigation", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openNotificationCenter();
       await app.mainNavigation.clickActivityIndicator();
       await app.mainNavigation.openMyLedger();

--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
@@ -20,8 +19,6 @@ test.describe("Market", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.marketBanner.clickExploreMarketHeader();
       await app.market.validateMarketList();
 

--- a/e2e/desktop/tests/specs/marketBanner.spec.ts
+++ b/e2e/desktop/tests/specs/marketBanner.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
 import { expect } from "@playwright/test";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 import { coinDetailUrlPattern } from "tests/utils/urlUtils";
 
@@ -22,7 +21,6 @@ test.describe("Market banner", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.marketBanner.expectMarketBannerToBeVisible();
       await app.marketBanner.expectFearAndGreedCardToBeVisible();

--- a/e2e/desktop/tests/specs/myWallet.spec.ts
+++ b/e2e/desktop/tests/specs/myWallet.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { FF_LWD_WALLET_40_Q2 } from "tests/utils/featureFlagUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
@@ -29,8 +28,6 @@ test.describe("My Wallet", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
 
       await app.myWallet.openMyWalletPopover();

--- a/e2e/desktop/tests/specs/numberFormat.swap.spec.ts
+++ b/e2e/desktop/tests/specs/numberFormat.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
 import { expectFormattedAmount } from "tests/utils/amountUtils";
 import { getExpectedSeparators } from "@ledgerhq/live-e2e-shared/data/numberFormat";
@@ -58,8 +57,6 @@ test.describe("Swap - amount formatting by language", () => {
         annotation: { type: "TMS", description: "B2CQA-4014" },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         // The userdata fixture already boots in English; only switch away from it.
         if (languageId !== "en") {
           await app.mainNavigation.openSettings();

--- a/e2e/desktop/tests/specs/operationsList.spec.ts
+++ b/e2e/desktop/tests/specs/operationsList.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { FF_LWD_WALLET_40_Q2 } from "tests/utils/featureFlagUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
@@ -21,7 +20,6 @@ test.describe("Operations history", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       const { testId } = test.info();
 
       await app.mainNavigation.openTargetFromMainNavigation("home");

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import { FF_LWD_WALLET_40_Q2 } from "tests/utils/featureFlagUtils";
@@ -22,8 +21,6 @@ test.describe("Portfolio", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.portfolio.checkNoBalanceTitleVisibility();
       await app.portfolio.expectPortfolioTotalBalanceNotVisible();
       await app.portfolio.expectOneDayPerformanceIndicatorNotVisible();
@@ -59,8 +56,6 @@ test.describe("Portfolio", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.portfolio.checkReceiveButtonVisibility();
       await app.portfolio.checkBuyButtonVisibility();
       await app.portfolio.checkSellButtonDisabled();
@@ -91,8 +86,6 @@ test.describe("Portfolio", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.portfolio.checkSellButtonEnabled();
       await app.portfolio.checkSendButtonEnabled();
       await app.portfolio.expectBalanceVisibility();
@@ -117,8 +110,6 @@ test.describe("Portfolio", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.portfolio.checkNoDeviceTitleVisibility();
       await app.portfolio.checkConnectButtonVisibility();
       await app.portfolio.checkBuyALedgerButtonVisibility();
@@ -144,8 +135,6 @@ test.describe("Portfolio", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.portfolio.checkReceiveButtonVisibility();
       await app.portfolio.checkBuyButtonVisibility();
       await app.portfolio.checkSellButtonDisabled();

--- a/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
+++ b/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
@@ -1,6 +1,5 @@
 import test from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { FF_POST_ONBOARDING_DESKTOP } from "tests/utils/featureFlagUtils";
 import { deviceTagsWithoutLNS } from "tests/utils/tagsUtils";
 import {
@@ -27,8 +26,6 @@ test.describe("Post-onboarding hub", () => {
       annotation: { type: "TMS", description: "B2CQA-6545" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.postOnboarding.expectWidgetVisible();
       await app.postOnboarding.openDialogFromWidget();

--- a/e2e/desktop/tests/specs/provider.swap.spec.ts
+++ b/e2e/desktop/tests/specs/provider.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addBugLink, addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import {
   setupEnv,
@@ -67,12 +66,10 @@ for (const { fromAccount, toAccount, provider, xrayTicket, bugTickets } of provi
             type: "TMS",
             description: xrayTicket,
           },
+          ...bugTickets.map(id => ({ type: "BUG", description: id })),
         ],
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-        await addBugLink(bugTickets);
-
         await revokeTokenApproval(fromAccount, provider);
         const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
         await ensureTokenApproval(fromAccount, provider, minAmount);
@@ -134,8 +131,6 @@ test.describe("Swap - landing page", () => {
       annotation: { type: "TMS", description: "B2CQA-2918, B2CQA-2327" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
 
       if (!minAmount) {

--- a/e2e/desktop/tests/specs/quickAmount.swap.spec.ts
+++ b/e2e/desktop/tests/specs/quickAmount.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
 import { parseBalanceAmount } from "tests/utils/amountUtils";
 import { expect } from "@playwright/test";
@@ -88,8 +87,6 @@ test.describe("Swap - quick amount buttons", () => {
       annotation: { type: "TMS", description: "B2CQA-5582" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       for (const { fromAccount, fromAccountId, toAccountId } of swapMaxBalancePairs) {
         await test.step(`Currency: ${fromAccount.currency.name}`, async () => {
           await openSwapPairViaDeeplink(app, fromAccountId, toAccountId);
@@ -113,8 +110,6 @@ test.describe("Swap - quick amount buttons", () => {
       annotation: { type: "TMS", description: "B2CQA-5582" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       const { fromAccountId, toAccountId } = swapMaxBalancePairs[0];
       await openSwapPairViaDeeplink(app, fromAccountId, toAccountId);
 
@@ -131,8 +126,6 @@ test.describe("Swap - quick amount buttons", () => {
       annotation: { type: "TMS", description: "B2CQA-5582" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       for (const { fromAccountId, toAccountId } of swapMaxBalancePairs) {
         await openSwapPairViaDeeplink(app, fromAccountId, toAccountId);
 
@@ -181,8 +174,6 @@ test.describe("Swap - quick amount buttons", () => {
       annotation: { type: "TMS", description: "B2CQA-5582" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await performSwapUntilQuoteSelectionStep(app, new Swap(fromAccount, toAccount, ""), "");
 
       expect(await app.swap.isMaxToggleEnabled()).toBe(false);
@@ -227,8 +218,6 @@ test.describe("Swap - quick amount buttons", () => {
       annotation: { type: "TMS", description: "B2CQA-5582" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await performSwapUntilQuoteSelectionStep(app, new Swap(fromAccount, toAccount, ""), "");
 
       expect(await app.swap.isMaxToggleEnabled()).toBe(false);

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -5,7 +5,6 @@ import {
   TokenAccount,
   getParentAccountName,
 } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import type { Application } from "tests/page";
 import {
   addEmptyAccountCommand,
@@ -72,7 +71,6 @@ for (const receive of nativeAccounts) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(receive.account.accountName);
         await app.account.expectAccountVisibility(receive.account.accountName);
@@ -107,8 +105,6 @@ test.describe("Receive", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.accountName);
       await app.account.expectAccountVisibility(account.accountName);
@@ -136,8 +132,6 @@ test.describe("Receive", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(getParentAccountName(tokenAccount.account));
       await app.account.expectAccountVisibility(getParentAccountName(tokenAccount.account));

--- a/e2e/desktop/tests/specs/rename.account.spec.ts
+++ b/e2e/desktop/tests/specs/rename.account.spec.ts
@@ -1,7 +1,6 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { waitForAccountRenamed } from "tests/utils/userdata";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { buildTags } from "tests/utils/tagsUtils";
@@ -28,7 +27,6 @@ for (const account of accounts) {
         },
       },
       async ({ app, userdataFile }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
         await app.redux.listenToReduxActions();
 
         await app.mainNavigation.openTargetFromMainNavigation("accounts");

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import {
   setupEnv,
   performSwapUntilQuoteSelectionStep,
@@ -228,8 +227,6 @@ for (const { fromAccount, toAccount, xrayTicket, tag, postSeedHook, skipReason }
         },
       },
       async ({ app, speculos }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
         const swap = new Swap(fromAccount, toAccount, minAmount);
 

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -3,7 +3,6 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Fee } from "@ledgerhq/live-e2e-shared/enum/Fee";
 import { Transaction } from "@ledgerhq/live-e2e-shared/models/Transaction";
-import { addBugLink, addTmsLink, getDescription } from "tests/utils/allureUtils";
 import {
   getAccountAddress,
   liveDataWithRecipientAddressCommand,
@@ -341,14 +340,12 @@ test.describe("Send", () => {
                 ? ["@smoke"]
                 : [],
           }),
-          annotation: { type: "TMS", description: transaction.xrayTicket },
+          annotation: [
+            { type: "TMS", description: transaction.xrayTicket },
+            ...(transaction.bugTickets ?? []).map(id => ({ type: "BUG", description: id })),
+          ],
         },
         async ({ app }) => {
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-          if (transaction.bugTickets) {
-            await addBugLink(transaction.bugTickets);
-          }
-
           await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
@@ -395,8 +392,6 @@ test.describe("Send", () => {
           annotation: { type: "TMS", description: transaction.xrayTicket },
         },
         async ({ app }) => {
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
           await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
@@ -446,8 +441,6 @@ test.describe("Send", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(
           transactionInputValid.accountToDebit.accountName,
@@ -490,8 +483,6 @@ test.describe("Send", () => {
           },
         },
         async ({ app }) => {
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
           await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
@@ -560,8 +551,6 @@ test.describe("Send", () => {
           },
         },
         async ({ app }) => {
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
           await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
@@ -612,8 +601,6 @@ test.describe("Send", () => {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(
           transactionEnsAddress.accountToDebit.accountName,
@@ -676,8 +663,6 @@ test.describe("Send", () => {
         annotation: { type: "TMS", description: "B2CQA-2949" },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(ccdTx.accountToDebit.accountName);
 

--- a/e2e/desktop/tests/specs/settings.spec.ts
+++ b/e2e/desktop/tests/specs/settings.spec.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import { expect } from "@playwright/test";
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { waitForIdentitiesInAppJson } from "tests/utils/userdata";
 import { FileUtils } from "tests/utils/fileUtils";
@@ -23,8 +22,6 @@ test.describe("Settings", () => {
       annotation: [{ type: "TMS", description: "B2CQA-817" }],
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.showParentAccountTokens(Account.ETH_1.accountName);
       await app.accounts.verifyTokenVisibility(TokenAccount.ETH_USDT_1.currency);
@@ -61,8 +58,6 @@ test.describe("Settings", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.expectCryptoAccountRowVisible(account.accountName);
       const countBeforeLock = await app.accounts.countAccounts();
@@ -103,8 +98,6 @@ test.describe("Settings", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.changeCounterValue("euro");
       await app.settings.expectCounterValue("Euro - EUR");
@@ -136,8 +129,6 @@ test.describe("Settings", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.goToHelpTab();
 
@@ -162,8 +153,6 @@ test.describe("Settings", () => {
       },
     },
     async ({ app, userdataFile, userdataDestinationPath }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       const { userId: userIdBefore } = await waitForIdentitiesInAppJson(userdataFile);
 
@@ -200,8 +189,6 @@ test.describe("Settings", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openSettings();
       await app.settings.goToHelpTab();
       await app.settings.checkViewUserDataButtonIsEnabled();
@@ -253,8 +240,6 @@ test.describe("Settings", () => {
         annotation: { type: "TMS", description: "B2CQA-2344" },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openSettings();
         await app.settings.changeLanguage(l10n.lang);
         await app.settings.expectLanguageSelected(l10n.lang);

--- a/e2e/desktop/tests/specs/stake.spec.ts
+++ b/e2e/desktop/tests/specs/stake.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { buildTags } from "tests/utils/tagsUtils";
 
@@ -35,7 +34,6 @@ test.describe("Staking - Tezos", () => {
       annotation: { type: "TMS", description: "B2CQA-5915" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
 
@@ -70,7 +68,6 @@ test.describe("Staking - Tezos", () => {
       annotation: { type: "TMS", description: "B2CQA-5917" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       // Already delegated => opens MODAL_TEZOS_STAKE directly at the amount step.
@@ -99,7 +96,6 @@ test.describe("Staking - Tezos", () => {
       annotation: { type: "TMS", description: "B2CQA-5918" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       // Delegated + staked => the account page shows the staking section with the unstake menu.
@@ -126,7 +122,6 @@ test.describe("Staking - Tezos", () => {
       annotation: { type: "TMS", description: "B2CQA-5919" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.tezosUnstakeRequired.openChangeValidator();
@@ -149,7 +144,6 @@ test.describe("Staking - Tezos", () => {
       annotation: { type: "TMS", description: "B2CQA-5921" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.tezosUnstakeRequired.openStopDelegation();

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -1,6 +1,5 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import {
   Account,
   TokenAccount,
@@ -118,8 +117,6 @@ for (const token of subAccounts) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.portfolio.clickAddAccountButton();
 
         const selector = await getModularSelector(app, "ASSET");
@@ -169,8 +166,6 @@ for (const token of subAccountReceive) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(getParentAccountName(token.account));
         await app.account.expectAccountVisibility(getParentAccountName(token.account));
@@ -218,8 +213,6 @@ for (const token of subAccounts.filter(subAccount => !subAccount.notPreSeeded)) 
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         const parentAccountName = getParentAccountName(token.account);
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(parentAccountName);
@@ -282,8 +275,6 @@ for (const transaction of transactionE2E) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(
           getParentAccountName(transaction.tx.accountToDebit),
@@ -395,8 +386,6 @@ for (const transaction of transactionsAddressInvalid) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.portfolio.clickSendButton();
 
         await app.send.selectDebitCurrency(transaction.transaction);
@@ -445,8 +434,6 @@ for (const transaction of transactionsAddressValid) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.portfolio.clickSendButton();
 
         await app.send.selectDebitCurrency(transaction.transaction);
@@ -523,8 +510,6 @@ for (const transaction of tokenTransactionInvalid) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(
           getParentAccountName(transaction.tx.accountToDebit),

--- a/e2e/desktop/tests/specs/token.approval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.approval.swap.spec.ts
@@ -9,7 +9,6 @@ import {
   revokeTokenApproval,
 } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/swap";
 
@@ -69,7 +68,6 @@ test.describe("Swap - token approval", () => {
       // Approval (Step 1) can take 1-5 min; extend beyond the 400s CI default.
       test.setTimeout(480_000);
       await app.swap.logSelectedProvider(provider.uiName);
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await revokeTokenApproval(fromAccount, provider);
       const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
       const swap = new Swap(fromAccount, toAccount, minAmount, provider);

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -11,7 +11,6 @@ import {
   ensureTokenApproval,
 } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 import BigNumber from "bignumber.js";
 import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/swap";
@@ -70,7 +69,6 @@ test.describe("Swap - token reapproval", () => {
       // Reapproval broadcasts revoke + approve and waits for each to confirm on mainnet; extend beyond the 400s CI default.
       test.setTimeout(600_000);
       await app.swap.logSelectedProvider(provider.uiName);
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await revokeTokenApproval(fromAccount, provider);
       const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
       const smallAmount = new BigNumber(minAmount).div(4).toFixed(6, BigNumber.ROUND_DOWN);

--- a/e2e/desktop/tests/specs/ui.swap.spec.ts
+++ b/e2e/desktop/tests/specs/ui.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
@@ -63,8 +62,6 @@ test.describe("Swap - feedback link", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       const minAmount = await app.swap.getMinimumAmount(kycFromAccount, kycToAccount);
       const initialSwap = new Swap(kycFromAccount, kycToAccount, minAmount);
 

--- a/e2e/desktop/tests/specs/undelegate.spec.ts
+++ b/e2e/desktop/tests/specs/undelegate.spec.ts
@@ -3,7 +3,6 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
 import { delegateTeamOwner } from "@ledgerhq/live-e2e-shared/data/delegateTeamOwner";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import {
   liveDataCommand,
   liveDataWithAddressCommand,
@@ -31,8 +30,6 @@ test.describe("Undelegate", () => {
       annotation: { type: "TMS", description: "B2CQA-387" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(suiAccount.account.accountName);
 
@@ -75,8 +72,6 @@ test.describe("Undelegate - MINA", () => {
       annotation: { type: "TMS", description: "B2CQA-387" },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(minaAccount.account.accountName);
 

--- a/e2e/desktop/tests/specs/validation.swap.spec.ts
+++ b/e2e/desktop/tests/specs/validation.swap.spec.ts
@@ -4,7 +4,6 @@ import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
-import { addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
@@ -100,8 +99,6 @@ for (const swap of tooLowAmountForQuoteSwaps) {
         },
       },
       async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         const swapAmount =
           swap.swap.amount === "USE_MIN_AMOUNT"
             ? await app.swap.getMinimumAmount(accountToDebit, accountToCredit)
@@ -184,7 +181,6 @@ test.describe("Swap - network fees above balance", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       const minAmount = await app.swap.getMinimumAmount(accountToDebit, accountToCredit);
 
       await performSwapUntilQuoteSelectionStep(
@@ -211,7 +207,6 @@ test.describe("Swap - network fees above balance", () => {
       },
     },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       const minAmount = await app.swap.getMinimumAmount(
         swapEthNeededForNetworkFeesTestConfig.swap.accountToDebit,
         swapEthNeededForNetworkFeesTestConfig.swap.accountToCredit,

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -111,11 +111,6 @@ function serializeCliError(error: unknown) {
   };
 }
 
-export function getDescription(annotations: TestInfo["annotations"], type: "TMS" | "BUG") {
-  const annotation = annotations.find(ann => ann.type === type);
-  return annotation?.description ?? "Type not found";
-}
-
 export async function addTmsLink(ids: string[]) {
   for (const id of ids) {
     await allure.tms(id);
@@ -126,6 +121,20 @@ export async function addBugLink(ids: string[]) {
   for (const id of ids) {
     await allure.issue(id);
   }
+}
+
+export async function addAnnotationLinks(annotations: TestInfo["annotations"]) {
+  const idsOf = (type: string) => [
+    ...new Set(
+      annotations
+        .filter(annotation => annotation.type === type)
+        .flatMap(annotation => (annotation.description ?? "").split(","))
+        .map(id => id.trim())
+        .filter(Boolean),
+    ),
+  ];
+  await addTmsLink(idsOf("TMS"));
+  await addBugLink(idsOf("BUG"));
 }
 
 export async function addTeamOwner(team: Team) {

--- a/e2e/desktop/tests/utils/newSendFlowUtils.ts
+++ b/e2e/desktop/tests/utils/newSendFlowUtils.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { TokenAccount, getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Transaction } from "@ledgerhq/live-e2e-shared/models/Transaction";
-import { addBugLink, addTmsLink, getDescription } from "tests/utils/allureUtils";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { liveDataWithRecipientAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED } from "tests/utils/featureFlagUtils";
@@ -112,17 +111,15 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
         }${validMemoTag ? " with memo" : ""}`,
         {
           tag: buildTags({ currencyId: tx.accountToDebit.currency.id }),
-          annotation: { type: "TMS", description: entry.xrayTicket },
+          annotation: [
+            { type: "TMS", description: entry.xrayTicket },
+            ...(entry.bugTicket ? [{ type: "BUG", description: entry.bugTicket }] : []),
+          ],
         },
         async ({ app }) => {
           const isTokenTransaction = tx.accountToDebit instanceof TokenAccount;
 
           const requiresMemoStep = family ? MEMO_STEP_FAMILIES.has(family) : false;
-
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-          if (entry.bugTicket) {
-            await addBugLink([entry.bugTicket]);
-          }
 
           await app.mainNavigation.openTargetFromMainNavigation("accounts");
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Updates E2E annotation handling so Allure TMS/BUG links are generated even when CLI or Speculos setup fails.


### 🔗 Context

- [Allure](https://allure-new.aws.sbx.ldg-tech.com/reports/6cba0543-fb11-4ae0-aac7-6e5792d9ac4b/view)
