### PR TITLE
chore(pay-card): share the card MSW test store (LIVE-37295)

### DIFF
--- a/.changeset/shared-pay-card-msw.md
+++ b/.changeset/shared-pay-card-msw.md
@@ -1,0 +1,10 @@
+---
+"@support/msw-features-flow-pay-card": minor
+"@features/flow-pay-card-details": patch
+---
+
+Share the Pay Card MSW test store across card flows.
+
+`@support/msw-features-flow-pay-card` holds the store, the signed-in and signed-out wrappers and the
+MSW server that every Pay Card flow package needs to test a view model against the card API, so each
+one no longer keeps its own copy. `pay-card-details` reads it from there now.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -82,6 +82,7 @@ tools/nx-plugins/generators/                             @ledgerhq/platform
 support/jest-devtools/                                   @ledgerhq/platform
 support/jest-features-flow/                              @ledgerhq/platform
 support/jest-shared/                                     @ledgerhq/platform
+support/msw-features-flow-pay-card/                      @ledgerhq/wallet-xp
 
 # Wallet — libs
 libs/live-countervalues-react/                           @ledgerhq/wallet-xp

--- a/features/flow/pay-card-details/package.json
+++ b/features/flow/pay-card-details/package.json
@@ -36,12 +36,12 @@
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {
-    "@shared/api-services": "workspace:*",
     "@features/platform-style": "workspace:*",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@support/jest-features-flow": "workspace:*",
+    "@support/msw-features-flow-pay-card": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.native.test.tsx
@@ -1,16 +1,19 @@
 import React, { type PropsWithChildren } from "react";
 import { render, screen, userEvent } from "@testing-library/react-native";
-import { SignedInCardApiProviders, listenToSignedInCardApi } from "../../__tests__/cardApiStore";
+import { cardApiWrapper, listenToCardApi } from "@support/msw-features-flow-pay-card";
 import { CARD_COPY, MORE_COPY, I18nWrapper } from "../../__tests__/i18nWrapper";
+import { signedInCardApiHandlers } from "./signedInCardApi";
 import { CardDetails } from "./CardDetails";
 
-listenToSignedInCardApi();
+listenToCardApi(signedInCardApiHandlers);
+
+const StoreWrapper = cardApiWrapper({ signedIn: true });
 
 function Wrapper({ children }: PropsWithChildren) {
   return (
-    <SignedInCardApiProviders>
+    <StoreWrapper>
       <I18nWrapper>{children}</I18nWrapper>
-    </SignedInCardApiProviders>
+    </StoreWrapper>
   );
 }
 

--- a/features/flow/pay-card-details/src/components/CardDetails/CardDetails.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardDetails/CardDetails.web.test.tsx
@@ -1,15 +1,14 @@
-import React, { type PropsWithChildren } from "react";
+import React from "react";
 import { screen } from "@testing-library/react";
-import { SignedInCardApiProviders, listenToSignedInCardApi } from "../../__tests__/cardApiStore";
+import { cardApiWrapper, listenToCardApi } from "@support/msw-features-flow-pay-card";
 import { CARD_COPY, MORE_COPY } from "../../__tests__/i18nWrapper";
 import { renderWeb } from "../../__tests__/renderWeb";
+import { signedInCardApiHandlers } from "./signedInCardApi";
 import { CardDetails } from "./CardDetails";
 
-listenToSignedInCardApi();
+listenToCardApi(signedInCardApiHandlers);
 
-function Wrapper({ children }: PropsWithChildren) {
-  return <SignedInCardApiProviders>{children}</SignedInCardApiProviders>;
-}
+const Wrapper = cardApiWrapper({ signedIn: true });
 
 describe("CardDetails (web)", () => {
   it("shows the card face with the freeze and more actions", async () => {

--- a/features/flow/pay-card-details/src/components/CardDetails/signedInCardApi.ts
+++ b/features/flow/pay-card-details/src/components/CardDetails/signedInCardApi.ts
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from "msw";
+import { CARD_API_BASE_URL } from "@support/msw-features-flow-pay-card";
+
+export const CARD_STATUS_URL = `${CARD_API_BASE_URL}/v1/card/status`;
+export const CARD_USER_URL = `${CARD_API_BASE_URL}/v1/user`;
+
+export const CARD_STATUS = {
+  id: "000000000050277836",
+  holderName: "JOHN DOE",
+  expiryDate: "2028/01",
+  panLast4: "1234",
+  status: "ACTIVE",
+  type: "VIRTUAL",
+  orderedAt: "2023-03-27T17:07:12.662Z",
+} as const;
+
+export const CARD_USER = {
+  id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+  verificationState: "VERIFIED",
+} as const;
+
+export const signedInCardApiHandlers = [
+  http.get(CARD_STATUS_URL, () => HttpResponse.json(CARD_STATUS)),
+  http.get(CARD_USER_URL, () => HttpResponse.json(CARD_USER)),
+];

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.native.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
-import { CardApiStoreProvider, makeCardApiStore } from "../../__tests__/cardApiStore";
+import { CardApiStoreProvider, makeCardApiStore } from "@support/msw-features-flow-pay-card";
 import { CardNumbers } from "./CardNumbers";
 
 describe("CardNumbers (native)", () => {

--- a/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/CardNumbers.web.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { CardApiStoreProvider, makeCardApiStore } from "../../__tests__/cardApiStore";
+import { CardApiStoreProvider, makeCardApiStore } from "@support/msw-features-flow-pay-card";
 import { CardNumbers } from "./CardNumbers";
 
 describe("CardNumbers (web)", () => {

--- a/features/flow/pay-card-details/src/components/CardNumbers/useCardNumbersViewModel.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardNumbers/useCardNumbersViewModel.native.test.tsx
@@ -1,28 +1,26 @@
 import React, { type PropsWithChildren } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react-native";
 import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
 import {
-  CARD_DETAILS,
-  CARD_DETAILS_IMAGE_URL,
-  CARD_DETAILS_TOKEN,
-  CARD_DETAILS_TOKEN_URL,
+  CARD_API_BASE_URL,
   CardApiStoreProvider,
+  listenToCardApi,
   makeCardApiStore,
-} from "../../__tests__/cardApiStore";
+} from "@support/msw-features-flow-pay-card";
 import { useCardNumbersViewModel } from "./useCardNumbersViewModel";
 
-const server = setupServer();
+const CARD_DETAILS_TOKEN = "00000000-0000-4000-8000-000000000000";
+const CARD_DETAILS_IMAGE_URL = `${CARD_API_BASE_URL}/details-image?token=${CARD_DETAILS_TOKEN}`;
+const CARD_DETAILS = {
+  token: CARD_DETAILS_TOKEN,
+  imageUrl: CARD_DETAILS_IMAGE_URL,
+};
+const CARD_DETAILS_TOKEN_URL = `${CARD_API_BASE_URL}/v1/card/details/token`;
 
-beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
-afterAll(() => server.close());
+const server = listenToCardApi();
 
 beforeEach(() => {
   server.use(http.post(CARD_DETAILS_TOKEN_URL, () => HttpResponse.json(CARD_DETAILS)));
-});
-
-afterEach(() => {
-  server.resetHandlers();
 });
 
 function deferred<T>() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6951,12 +6951,12 @@ importers:
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.60(@ledgerhq/lumen-design-core@0.1.28)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      '@shared/api-services':
-        specifier: workspace:*
-        version: link:../../../shared/api-services
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
+      '@support/msw-features-flow-pay-card':
+        specifier: workspace:*
+        version: link:../../../support/msw-features-flow-pay-card
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -18229,6 +18229,49 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  support/msw-features-flow-pay-card:
+    dependencies:
+      '@domain/api-card-management':
+        specifier: workspace:*
+        version: link:../../domain/api/card-management
+      '@features/flow-pay-card-auth':
+        specifier: workspace:*
+        version: link:../../features/flow/pay-card-auth
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/api-services':
+        specifier: workspace:*
+        version: link:../../shared/api-services
+    devDependencies:
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.67.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.82.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   support/test-quarantine:
     devDependencies:
       '@jest/reporters':
@@ -23159,6 +23202,7 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -25926,12 +25970,6 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.3.0':
-    resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-core@5.5.1':
     resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
     engines: {node: '>=20.18.0'}
@@ -25950,12 +25988,6 @@ packages:
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
     peerDependencies:
       typescript: '>=5'
-
-  '@solana/codecs-numbers@2.3.0':
-    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@5.5.1':
     resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
@@ -25982,13 +26014,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5'
-
-  '@solana/errors@2.3.0':
-    resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.3.3'
 
   '@solana/errors@5.5.1':
     resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
@@ -26022,9 +26047,6 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
-
-  '@solana/web3.js@1.98.4':
-    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
   '@solana/web3.js@1.99.0':
     resolution: {integrity: sha512-QZYQ2T1z6xWisoyALPq25i/QZTsRlM02BABtAsfaQ1p8wX4SdTfxrKTRue/ZZqrhNVh5oL7T/DUFiTS9DRgxow==}
@@ -37356,7 +37378,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -43981,7 +44002,7 @@ snapshots:
 
   '@bunli/generator@0.6.5(@typescript/typescript6@6.0.2)(react@19.1.4)':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
       '@bunli/core': 0.9.1(patch_hash=fbe5c853111cb92eab35c575f445da139fd7664c9be9bbca5ebbadfb0f292565)(@typescript/typescript6@6.0.2)(react@19.1.4)
       better-result: 2.8.2
@@ -48065,7 +48086,7 @@ snapshots:
       '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
-      '@solana/web3.js': 1.98.4(@typescript/typescript6@6.0.2)
+      '@solana/web3.js': 1.99.0(@typescript/typescript6@6.0.2)
       bs58: 6.0.0
       buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -53333,11 +53354,6 @@ snapshots:
       '@solana/errors': 2.0.0-rc.1(@typescript/typescript6@6.0.2)
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@solana/codecs-core@2.3.0(@typescript/typescript6@6.0.2)':
-    dependencies:
-      '@solana/errors': 2.3.0(@typescript/typescript6@6.0.2)
-      typescript: '@typescript/typescript6@6.0.2'
-
   '@solana/codecs-core@5.5.1(@typescript/typescript6@6.0.2)':
     dependencies:
       '@solana/errors': 5.5.1(@typescript/typescript6@6.0.2)
@@ -53355,12 +53371,6 @@ snapshots:
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(@typescript/typescript6@6.0.2)
       '@solana/errors': 2.0.0-rc.1(@typescript/typescript6@6.0.2)
-      typescript: '@typescript/typescript6@6.0.2'
-
-  '@solana/codecs-numbers@2.3.0(@typescript/typescript6@6.0.2)':
-    dependencies:
-      '@solana/codecs-core': 2.3.0(@typescript/typescript6@6.0.2)
-      '@solana/errors': 2.3.0(@typescript/typescript6@6.0.2)
       typescript: '@typescript/typescript6@6.0.2'
 
   '@solana/codecs-numbers@5.5.1(@typescript/typescript6@6.0.2)':
@@ -53392,12 +53402,6 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       commander: 12.1.0
-      typescript: '@typescript/typescript6@6.0.2'
-
-  '@solana/errors@2.3.0(@typescript/typescript6@6.0.2)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.2
       typescript: '@typescript/typescript6@6.0.2'
 
   '@solana/errors@5.5.1(@typescript/typescript6@6.0.2)':
@@ -53446,29 +53450,6 @@ snapshots:
       - bufferutil
       - encoding
       - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
-
-  '@solana/web3.js@1.98.4(@typescript/typescript6@6.0.2)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(@typescript/typescript6@6.0.2)
-      agentkeepalive: 4.6.0
-      bn.js: 5.2.5
-      borsh: 0.7.0
-      bs58: 4.0.1
-      buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
-      fast-stable-stringify: 1.0.0
-      jayson: 4.3.0
-      node-fetch: 2.7.0
-      rpc-websockets: 9.0.4
-      superstruct: 2.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
       - typescript
       - utf-8-validate
 

--- a/support/README.md
+++ b/support/README.md
@@ -39,6 +39,7 @@ Two kinds of preset:
 | [`jest-features-flow`](./jest-features-flow) | `features/flow/*` — dual web/native jest preset plus Lumen passthrough stubs |
 | [`jest-shared`](./jest-shared) | `shared/*` — flat node preset for logic packages, dual web/native and native-only presets for UI packages |
 | [`lint-rules`](./lint-rules) | monorepo-wide custom ESLint rules |
+| [`msw-features-flow-pay-card`](./msw-features-flow-pay-card) | `features/flow/pay-card-*` — MSW + RTK Query test store and server |
 
 ## Adding a package
 

--- a/support/msw-features-flow-pay-card/README.md
+++ b/support/msw-features-flow-pay-card/README.md
@@ -1,0 +1,38 @@
+# @support/msw-features-flow-pay-card
+
+> [!CAUTION]
+> **Status: UNSTABLE** — New package; the harness is still being adopted by Pay Card flows.
+
+MSW + RTK Query test store for `features/flow/pay-card-*` packages.
+
+Every Pay Card flow that talks to card-management needs the same signed-in session stub, the same
+`cardApi` extra argument, and an MSW server that fails on unhandled requests.
+
+## Usage
+
+```jsonc
+// package.json
+"devDependencies": {
+  "@support/msw-features-flow-pay-card": "workspace:*"
+}
+```
+
+```ts
+import {
+  CARD_API_BASE_URL,
+  cardApiWrapper,
+  listenToCardApi,
+  makeCardApiStore,
+} from "@support/msw-features-flow-pay-card";
+
+const server = listenToCardApi();
+```
+
+`listenToCardApi` accepts optional default handlers (restored on `resetHandlers`). `cardApiWrapper`
+and `CardApiStoreProvider` only mount Redux — i18n and endpoint fixtures stay in the consumer.
+
+## What stays in the consumer
+
+- Endpoint URLs and response bodies for that flow
+- Extra providers (`I18nTestProvider`, theme, navigation)
+- Handlers that only one flow needs

--- a/support/msw-features-flow-pay-card/package.json
+++ b/support/msw-features-flow-pay-card/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@support/msw-features-flow-pay-card",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared MSW + RTK Query test harness for Pay Card features/flow packages",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "lint": "oxlint src",
+    "lint:ci": "oxlint src --quiet",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@domain/api-card-management": "workspace:*",
+    "@features/flow-pay-card-auth": "workspace:*",
+    "@reduxjs/toolkit": "catalog:",
+    "@shared/api-services": "workspace:*"
+  },
+  "peerDependencies": {
+    "msw": "catalog:",
+    "react": "catalog:",
+    "react-redux": "catalog:"
+  },
+  "devDependencies": {
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "msw": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-redux": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/support/msw-features-flow-pay-card/project.json
+++ b/support/msw-features-flow-pay-card/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@support/msw-features-flow-pay-card",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/support/msw-features-flow-pay-card/src/cardApiStore.tsx
+++ b/support/msw-features-flow-pay-card/src/cardApiStore.tsx
@@ -1,42 +1,12 @@
 import React, { useMemo, type PropsWithChildren } from "react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
-import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { cardManagementApi } from "@domain/api-card-management";
 import { payCardAuthSlice, type PayCardAuthState } from "@features/flow-pay-card-auth/state";
 import { cardApi, cardApiExtra } from "@shared/api-services";
 
 export const CARD_API_BASE_URL = "https://card.test";
-export const CARD_DETAILS_TOKEN = "00000000-0000-4000-8000-000000000000";
-export const CARD_DETAILS_IMAGE_URL = `${CARD_API_BASE_URL}/details-image?token=${CARD_DETAILS_TOKEN}`;
-export const CARD_DETAILS = {
-  token: CARD_DETAILS_TOKEN,
-  imageUrl: CARD_DETAILS_IMAGE_URL,
-};
-export const CARD_DETAILS_TOKEN_URL = `${CARD_API_BASE_URL}/v1/card/details/token`;
-export const CARD_STATUS_URL = `${CARD_API_BASE_URL}/v1/card/status`;
-export const CARD_USER_URL = `${CARD_API_BASE_URL}/v1/user`;
-
-export const CARD_STATUS = {
-  id: "000000000050277836",
-  holderName: "JOHN DOE",
-  expiryDate: "2028/01",
-  panLast4: "1234",
-  status: "ACTIVE",
-  type: "VIRTUAL",
-  orderedAt: "2023-03-27T17:07:12.662Z",
-} as const;
-
-export const CARD_USER = {
-  id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
-  verificationState: "VERIFIED",
-} as const;
-
-export const signedInCardApiHandlers = [
-  http.get(CARD_STATUS_URL, () => HttpResponse.json(CARD_STATUS)),
-  http.get(CARD_USER_URL, () => HttpResponse.json(CARD_USER)),
-];
 
 export function makeCardApiStore({ signedIn = false }: { signedIn?: boolean } = {}) {
   return configureStore({
@@ -73,13 +43,16 @@ export function CardApiStoreProvider({
   return <Provider store={store}>{children}</Provider>;
 }
 
-export function SignedInCardApiProviders({ children }: PropsWithChildren) {
-  const store = useMemo(() => makeCardApiStore({ signedIn: true }), []);
-  return <CardApiStoreProvider store={store}>{children}</CardApiStoreProvider>;
+export function cardApiWrapper({ signedIn = false }: { signedIn?: boolean } = {}) {
+  return function CardApiWrapper({ children }: PropsWithChildren) {
+    const store = useMemo(() => makeCardApiStore({ signedIn }), []);
+
+    return <CardApiStoreProvider store={store}>{children}</CardApiStoreProvider>;
+  };
 }
 
-export function listenToSignedInCardApi() {
-  const server = setupServer(...signedInCardApiHandlers);
+export function listenToCardApi(handlers: Parameters<typeof setupServer> = []) {
+  const server = setupServer(...handlers);
 
   beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
   afterEach(() => server.resetHandlers());

--- a/support/msw-features-flow-pay-card/src/index.ts
+++ b/support/msw-features-flow-pay-card/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./cardApiStore";

--- a/support/msw-features-flow-pay-card/tsconfig.json
+++ b/support/msw-features-flow-pay-card/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### 📝 Description

Every Pay Card flow package that tests a view model against the card API rebuilt the same MSW + RTK Query harness: a store wiring the card API reducer, the auth slice preloaded as signed in or signed out, the `cardApiExtra` thunk argument, and an MSW server that errors on unhandled requests. `pay-card-details` held the only copy, and `pay-card-transactions` needs the same one, so this extracts it once.

`@support/msw-features-flow-pay-card` exposes `makeCardApiStore`, `CardApiStoreProvider`, `cardApiWrapper`, `listenToCardApi` and `CARD_API_BASE_URL`. `pay-card-details` reads them from there and its local copy is gone; the fixtures that only its own tests used moved next to those tests, in `signedInCardApi.ts`.

Test infrastructure only: no product code is touched and no behaviour changes.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37295](https://ledgerhq.atlassian.net/browse/LIVE-37295)

[LIVE-37295]: https://ledgerhq.atlassian.net/browse/LIVE-37295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ