### PR TITLE
[LWDM] feat(pay-card): list transactions by category (LIVE-34954)

### DIFF
--- a/.changeset/pay-card-transactions-categorizer.md
+++ b/.changeset/pay-card-transactions-categorizer.md
@@ -1,0 +1,12 @@
+---
+"@features/flow-pay-card-transactions": minor
+"@domain/api-card-management": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Read the card transactions and give each one its spend category.
+
+- `useCardTransactionsViewModel` reads the first page of `GET /v1/card/transactions` while a session is live, and hands each transaction its category and that category's translated label.
+- `mccCategory` is now the closed set the provider documents (`PayCardTransactionCategory`), and a grouping it never named reads as `MISC` so one new label cannot fail a whole page.
+- `mockPayCardTransactions` answers a page covering every category, served by the desktop and mobile MSW workers on `GET /v1/card/transactions`.

--- a/apps/ledger-live-desktop/src/mocks/browser.ts
+++ b/apps/ledger-live-desktop/src/mocks/browser.ts
@@ -6,6 +6,7 @@ import { mockStocksResponse } from "@domain/api-aggregated-assets/mock/stocks";
 import { mockLedgerStatus } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/mocks/ledgerStatus";
 import { mockFearAndGreedLatest } from "@domain/api-market-sentiment/mock";
 import { getMockCardOnboardingStatus } from "@domain/api-card-management/mock";
+import { mockPayCardTransactions } from "@domain/api-card-management/mock/card-transactions";
 import countervaluesHandlers from "../../tests/handlers/countervalues";
 import marketHandlers from "../../tests/handlers/market";
 
@@ -28,6 +29,7 @@ const handlers = [
   ...marketHandlers,
   ...countervaluesHandlers,
   http.get("*/v1/card/onboarding-status", () => HttpResponse.json(getMockCardOnboardingStatus())),
+  http.get("*/v1/card/transactions", () => HttpResponse.json(mockPayCardTransactions())),
 ];
 
 const mswWorker = setupWorker(...handlers);

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -919,6 +919,18 @@
         "retry": "Try again"
       }
     },
+    "cardTransactions": {
+      "categories": {
+        "SUBSCRIPTIONS": "Subscriptions",
+        "FOOD": "Food",
+        "TRAVEL": "Travel",
+        "ENTERTAINMENT": "Entertainment",
+        "HEALTH": "Health",
+        "ATM": "ATM",
+        "UTILITIES": "Utilities",
+        "MISC": "Other"
+      }
+    },
     "cardOnboarding": {
       "widget": {
         "title": "Set up your card",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10304,6 +10304,18 @@
         "retry": "Try again"
       }
     },
+    "cardTransactions": {
+      "categories": {
+        "SUBSCRIPTIONS": "Subscriptions",
+        "FOOD": "Food",
+        "TRAVEL": "Travel",
+        "ENTERTAINMENT": "Entertainment",
+        "HEALTH": "Health",
+        "ATM": "ATM",
+        "UTILITIES": "Utilities",
+        "MISC": "Other"
+      }
+    },
     "selectContact": {
       "placeholder": "Enter contact"
     },

--- a/apps/ledger-live-mobile/src/mocks/README.md
+++ b/apps/ledger-live-mobile/src/mocks/README.md
@@ -65,6 +65,13 @@ reaches the real provider. Only the answer buttons and the renewal counter need 
 > So a Pay Card handler counts only what it answers. Do not count a pass-through here: count it in
 > the client. The `[card api]` trace in `@shared/api-services` prints one line per request.
 
+## Pay Card transactions
+
+`GET /v1/card/transactions` is always answered from
+`@domain/api-card-management/mock/card-transactions`, so a transaction list renders without a funded
+card. The page holds one transaction per spend category, which is how every
+`payTab.cardTransactions.categories` label becomes visible.
+
 `src/mocks/card/state.ts` holds the switchboard the panel and the handler share. It lives on
 `globalThis`, because the panel's props are built in `@devtools/bindings`, which cannot import from
 an app.

--- a/apps/ledger-live-mobile/src/mocks/card/handler.ts
+++ b/apps/ledger-live-mobile/src/mocks/card/handler.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse, passthrough, delay } from "msw";
 import { getMockCardOnboardingStatus } from "@domain/api-card-management/mock";
+import { mockPayCardTransactions } from "@domain/api-card-management/mock/card-transactions";
 import {
   mockPayCardInternalWallets,
   mockPayCardLinkedWallets,
@@ -140,6 +141,7 @@ const handlers = [
   http.get("*/v1/card/onboarding-status", () => {
     return HttpResponse.json(getMockCardOnboardingStatus());
   }),
+  http.get("*/v1/card/transactions", () => HttpResponse.json(mockPayCardTransactions())),
   http.get("*/v1/wallet/internal", ({ request }) => {
     const { walletFunded } = readCardOnboardingStatusMock();
     if (walletFunded !== undefined) {

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -11,6 +11,7 @@ shared `cardApi` service (`@shared/api-services`, `services/card`) rather than d
 - `types.ts` — the inferred response types and the request arguments each endpoint takes.
 - `transforms.ts` — maps a validated wire response onto its canonical shape.
 - `constants.ts` — `CARD_MANAGEMENT_TAGS` and the OAuth2 token path.
+- `*.mock.ts` — wire-shaped answers for the apps' MSW workers, behind the `./mock/*` exports.
 
 Every endpoint is declarative: `query`, never `queryFn`, with the schemas and the transform doing the
 rest. [`.agents/skills/card-endpoint-shape`](.agents/skills/card-endpoint-shape/SKILL.md) has the

--- a/domain/api/card-management/package.json
+++ b/domain/api/card-management/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./mock": "./src/onboardingStatus.mock.ts",
     "./mock/card-onboarding-status": "./src/cardOnboardingStatus.mock.ts",
+    "./mock/card-transactions": "./src/cardTransactions.mock.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/domain/api/card-management/src/cardTransactions.mock.test.ts
+++ b/domain/api/card-management/src/cardTransactions.mock.test.ts
@@ -1,0 +1,22 @@
+import { PAY_CARD_TRANSACTION_CATEGORIES, PayCardTransactionsResponseSchema } from "./schema";
+import { mockPayCardTransactions } from "./cardTransactions.mock";
+
+describe("mockPayCardTransactions", () => {
+  it("answers a page the transaction schema accepts", () => {
+    expect(PayCardTransactionsResponseSchema.parse(mockPayCardTransactions())).toHaveLength(
+      PAY_CARD_TRANSACTION_CATEGORIES.length,
+    );
+  });
+
+  it("covers every spend category, so each one can be seen in a list", () => {
+    const categories = mockPayCardTransactions().map(({ mccCategory }) => mccCategory);
+
+    expect([...categories].sort()).toEqual([...PAY_CARD_TRANSACTION_CATEGORIES].sort());
+  });
+
+  it("keeps the provider's documented charge as the miscellaneous one", () => {
+    const misc = mockPayCardTransactions().find(({ mccCategory }) => mccCategory === "MISC");
+
+    expect(misc?.merchantNameLocation).toBe("WWW.ALIEXPRESS.COM, LONDON");
+  });
+});

--- a/domain/api/card-management/src/cardTransactions.mock.ts
+++ b/domain/api/card-management/src/cardTransactions.mock.ts
@@ -1,0 +1,62 @@
+import { PAY_CARD_TRANSACTION_CATEGORIES } from "./schema";
+
+const DOCUMENTED_TRANSACTION = {
+  id: "100a99cf-f4d3-4fa1-9be9-2e9828b20ebb",
+  cardId: "1234537292209260487",
+  panLast4: "9189",
+  transactionId: "1122334477422",
+  dateTime: "2024-10-14T10:44:36.276Z",
+  sign: "DEBIT" as const,
+  merchantNameLocation: "WWW.ALIEXPRESS.COM, LONDON",
+  merchantType: "OutOfWalletOnline",
+  mcc: 5964,
+  transactionCurrency: "EUR",
+  amountInTransactionCurrency: "0.79",
+  feesInTransactionCurrency: "0",
+  originalCurrency: "USD",
+  amountInOriginalCurrency: "0.85",
+  feesInOriginalCurrency: "0",
+  billingConversionRate: "0.9294117647058824",
+  ecbRate: "0.9161704076958315",
+  status: "CONFIRMED" as const,
+  declineReason: "",
+  fundingSources: [
+    {
+      id: "3181a37a-07fa-41dc-b423-6c2db07a7ba1",
+      address: "0x3a11a86cf218c448be519728cd3ac5c741fb3424",
+      network: "linea",
+      txHash: "0xb92de09d893e8162b0861c0f7321f68df02212efbc58f208839ae3f176d89638",
+      currency: "usdc",
+      amount: "0.104201",
+      fees: "0",
+      swapFee: "0.00208",
+      sign: "DEBIT" as const,
+      status: "CONFIRMED" as const,
+      dateTime: "2024-10-14T10:44:36.288Z",
+    },
+  ],
+};
+
+const MERCHANT_BY_CATEGORY = {
+  SUBSCRIPTIONS: "NETFLIX.COM, LOS GATOS",
+  FOOD: "STARBUCKS, LONDON",
+  TRAVEL: "BRITISH AIRWAYS, LONDON",
+  ENTERTAINMENT: "SPOTIFY AB, STOCKHOLM",
+  HEALTH: "BOOTS UK, LONDON",
+  ATM: "ATM WITHDRAWAL, LONDON",
+  UTILITIES: "BRITISH GAS, WINDSOR",
+  MISC: DOCUMENTED_TRANSACTION.merchantNameLocation,
+} as const satisfies Record<(typeof PAY_CARD_TRANSACTION_CATEGORIES)[number], string>;
+
+/**
+ * A wire-shaped page for the apps' MSW workers: the provider's documented charge, repeated once per
+ * spend category, so a transaction list can be seen without a funded card.
+ */
+export function mockPayCardTransactions() {
+  return PAY_CARD_TRANSACTION_CATEGORIES.map((mccCategory, index) => ({
+    ...DOCUMENTED_TRANSACTION,
+    id: `${DOCUMENTED_TRANSACTION.id.slice(0, -1)}${index}`,
+    merchantNameLocation: MERCHANT_BY_CATEGORY[mccCategory],
+    mccCategory,
+  }));
+}

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -10,8 +10,10 @@ import {
   PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
+  PAY_CARD_TRANSACTION_CATEGORIES,
   PayCardTransactionSchema,
   PayCardTransactionsRequestSchema,
+  PayCardTransactionsResponseSchema,
   PayCardWalletHistoryEntrySchema,
   PayCardWalletHistoryRequestSchema,
   PayCardUserResponseSchema,
@@ -432,6 +434,29 @@ describe("PayCardTransactionSchema", () => {
 
   it("rejects a direction the wire contract does not name", () => {
     expect(() => PayCardTransactionSchema.parse({ ...documented, sign: "REFUND" })).toThrow();
+  });
+
+  it.each(PAY_CARD_TRANSACTION_CATEGORIES)("reads a %s spend category", mccCategory => {
+    expect(PayCardTransactionSchema.parse({ ...documented, mccCategory }).mccCategory).toBe(
+      mccCategory,
+    );
+  });
+
+  it("reads a spend category the provider does not name as MISC", () => {
+    expect(
+      PayCardTransactionSchema.parse({ ...documented, mccCategory: "SHOPPING" }).mccCategory,
+    ).toBe("MISC");
+  });
+
+  it("keeps the whole page when one transaction carries an unnamed spend category", () => {
+    const page = [
+      { ...documented, mccCategory: "FOOD" },
+      { ...documented, id: "second", mccCategory: "SHOPPING" },
+    ];
+
+    expect(
+      PayCardTransactionsResponseSchema.parse(page).map(({ mccCategory }) => mccCategory),
+    ).toEqual(["FOOD", "MISC"]);
   });
 });
 

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -77,6 +77,20 @@ export const PayCardDetailsTokenResponseSchema = z.object({
     .refine(value => value.startsWith("https://"), { message: "must be an https URL" }),
 });
 
+/** The provider's spend groupings. It sends the label; the numeric MCC behind it is dropped. */
+export const PAY_CARD_TRANSACTION_CATEGORIES = [
+  "SUBSCRIPTIONS",
+  "FOOD",
+  "TRAVEL",
+  "ENTERTAINMENT",
+  "HEALTH",
+  "ATM",
+  "UTILITIES",
+  "MISC",
+] as const;
+
+export const PayCardTransactionCategorySchema = z.enum(PAY_CARD_TRANSACTION_CATEGORIES);
+
 /**
  * One card transaction, narrowed to what a transaction list shows.
  *
@@ -91,8 +105,7 @@ export const PayCardTransactionSchema = z.object({
   dateTime: z.string().min(1),
   sign: z.enum(["DEBIT", "CREDIT"]),
   merchantNameLocation: z.string().min(1),
-  /** The provider's own grouping, not an id we map: `SUBSCRIPTIONS`, `FOOD`, `MISC` and so on. */
-  mccCategory: z.string().min(1),
+  mccCategory: PayCardTransactionCategorySchema.catch("MISC"),
   status: z.enum(["CONFIRMED", "PENDING", "DECLINED", "REVERTED"]),
   /** The provider sends `""` on a transaction that was not declined, so an empty one is expected. */
   declineReason: z.string().optional(),

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -13,6 +13,7 @@ import {
   PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
+  PayCardTransactionCategorySchema,
   PayCardTransactionSchema,
   PayCardTransactionsRequestSchema,
   PayCardWalletHistoryEntrySchema,
@@ -38,6 +39,8 @@ export type PayCardErrorResponse = z.infer<typeof PayCardErrorResponseSchema>;
 export type PayCardStatus = z.infer<typeof PayCardStatusResponseSchema>;
 
 export type PayCardDetailsCss = z.infer<typeof PayCardDetailsCssSchema>;
+
+export type PayCardTransactionCategory = z.infer<typeof PayCardTransactionCategorySchema>;
 
 export type PayCardTransaction = z.infer<typeof PayCardTransactionSchema>;
 

--- a/features/flow/pay-card-transactions/README.md
+++ b/features/flow/pay-card-transactions/README.md
@@ -1,3 +1,30 @@
 # @features/flow-pay-card-transactions
 
 Pay Card Transactions flow: displays card transaction history for Ledger Wallet.
+
+```ts
+import { useCardTransactionsViewModel } from "@features/flow-pay-card-transactions";
+```
+
+`useCardTransactionsViewModel` reads the first page of `getCardTransactions`
+([`@domain/api-card-management`](../../../domain/api/card-management/README.md)) while a Card
+session is live, and answers one item per transaction:
+
+| Field           | What it holds                                                       |
+| --------------- | ------------------------------------------------------------------- |
+| `transaction`   | The transaction as the API package narrowed it                      |
+| `category`      | `PayCardTransactionCategory` — the provider's own spend grouping    |
+| `categoryLabel` | That category translated, from `payTab.cardTransactions.categories` |
+
+The provider classifies each charge itself and sends the label on the transaction, so `categoryOf`
+reads it rather than deriving one from the numeric MCC, which the API package drops before the
+cache. `transactionHasCategory` is the same answer as a predicate, for filtering.
+
+Signed out, the query is skipped and the list reads empty, so a host composing this flow around a
+signed-out session provokes no 401.
+
+## Mocked transactions
+
+`GET /v1/card/transactions` is mocked in both apps when MSW is enabled (`MSW_ENABLED=true` on
+mobile), from `@domain/api-card-management/mock/card-transactions`. That page holds one transaction
+per category, so every label can be seen without a funded card.

--- a/features/flow/pay-card-transactions/package.json
+++ b/features/flow/pay-card-transactions/package.json
@@ -27,8 +27,14 @@
     "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -c features/flow/pay-card-transactions/knip.web.config.mjs -W features/flow/pay-card-transactions --tsConfig tsconfig.web.json && pnpm knip --directory ../../.. -c features/flow/pay-card-transactions/knip.native.config.mjs -W features/flow/pay-card-transactions --tsConfig tsconfig.native.json"
   },
+  "dependencies": {
+    "@domain/api-card-management": "workspace:^",
+    "@features/flow-pay-card-auth": "workspace:*",
+    "@shared/i18n": "workspace:*"
+  },
   "devDependencies": {
     "@support/jest-features-flow": "workspace:*",
+    "@support/msw-features-flow-pay-card": "workspace:*",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@swc/core": "catalog:",
@@ -46,18 +52,21 @@
     "eslint-plugin-better-tailwindcss": "catalog:",
     "jest": "catalog:",
     "jest-environment-jsdom": "catalog:",
+    "msw": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
+    "react-redux": "catalog:",
     "react-test-renderer": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
   },
   "peerDependencies": {
     "react": "catalog:",
-    "react-native": "catalog:"
+    "react-native": "catalog:",
+    "react-redux": "catalog:"
   },
   "peerDependenciesMeta": {
     "react-native": {

--- a/features/flow/pay-card-transactions/src/__tests__/cardApiStore.tsx
+++ b/features/flow/pay-card-transactions/src/__tests__/cardApiStore.tsx
@@ -1,0 +1,41 @@
+import React, { type PropsWithChildren } from "react";
+import {
+  CARD_API_BASE_URL,
+  cardApiWrapper as storeWrapper,
+} from "@support/msw-features-flow-pay-card";
+import { I18nTestProvider } from "@shared/i18n/testing";
+
+export const CARD_TRANSACTIONS_URL = `${CARD_API_BASE_URL}/v1/card/transactions`;
+
+export const CATEGORY_LABELS = {
+  SUBSCRIPTIONS: "Subscriptions",
+  FOOD: "Food",
+  TRAVEL: "Travel",
+  ENTERTAINMENT: "Entertainment",
+  HEALTH: "Health",
+  ATM: "ATM",
+  UTILITIES: "Utilities",
+  MISC: "Other",
+} as const;
+
+const CARD_TRANSACTIONS_RESOURCES = {
+  en: {
+    translation: {
+      payTab: {
+        cardTransactions: { categories: CATEGORY_LABELS },
+      },
+    },
+  },
+};
+
+export function cardApiWrapper({ signedIn = false }: { signedIn?: boolean } = {}) {
+  const StoreWrapper = storeWrapper({ signedIn });
+
+  return function CardApiWrapper({ children }: PropsWithChildren) {
+    return (
+      <StoreWrapper>
+        <I18nTestProvider resources={CARD_TRANSACTIONS_RESOURCES}>{children}</I18nTestProvider>
+      </StoreWrapper>
+    );
+  };
+}

--- a/features/flow/pay-card-transactions/src/__tests__/useCardTransactionsViewModel.web.test.tsx
+++ b/features/flow/pay-card-transactions/src/__tests__/useCardTransactionsViewModel.web.test.tsx
@@ -1,0 +1,115 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse, type JsonBodyType } from "msw";
+import { mockPayCardTransactions } from "@domain/api-card-management/mock/card-transactions";
+import { useCardTransactionsViewModel } from "../hooks/useCardTransactionsViewModel";
+import { listenToCardApi } from "@support/msw-features-flow-pay-card";
+import { CARD_TRANSACTIONS_URL, CATEGORY_LABELS, cardApiWrapper } from "./cardApiStore";
+
+const server = listenToCardApi();
+
+function answerWith(body: JsonBodyType, status = 200) {
+  const requests: URL[] = [];
+
+  server.use(
+    http.get(CARD_TRANSACTIONS_URL, ({ request }) => {
+      requests.push(new URL(request.url));
+      return HttpResponse.json(body, { status });
+    }),
+  );
+
+  return requests;
+}
+
+function renderViewModel({ signedIn = true }: { signedIn?: boolean } = {}) {
+  return renderHook(() => useCardTransactionsViewModel(), {
+    wrapper: cardApiWrapper({ signedIn }),
+  });
+}
+
+describe("useCardTransactionsViewModel", () => {
+  it("reads the page the provider answers, and keeps the order it sent", async () => {
+    const page = mockPayCardTransactions();
+    answerWith(page);
+
+    const { result } = renderViewModel();
+
+    await waitFor(() => expect(result.current.transactions).toHaveLength(page.length));
+    expect(result.current.transactions.map(({ transaction }) => transaction.id)).toEqual(
+      page.map(({ id }) => id),
+    );
+  });
+
+  it("gives every transaction the category the provider classified it in, translated", async () => {
+    answerWith(mockPayCardTransactions());
+
+    const { result } = renderViewModel();
+
+    await waitFor(() => expect(result.current.transactions.length).toBeGreaterThan(0));
+
+    const aliExpress = result.current.transactions.find(
+      ({ transaction }) => transaction.merchantNameLocation === "WWW.ALIEXPRESS.COM, LONDON",
+    );
+    expect(aliExpress?.category).toBe("MISC");
+    expect(aliExpress?.categoryLabel).toBe(CATEGORY_LABELS.MISC);
+
+    for (const { category, categoryLabel } of result.current.transactions) {
+      expect(categoryLabel).toBe(CATEGORY_LABELS[category]);
+    }
+  });
+
+  it("still lists a transaction the provider put in a category it never documented", async () => {
+    const [first] = mockPayCardTransactions();
+    answerWith([{ ...first, mccCategory: "SHOPPING" }]);
+
+    const { result } = renderViewModel();
+
+    await waitFor(() => expect(result.current.transactions).toHaveLength(1));
+    expect(result.current.transactions[0]?.category).toBe("MISC");
+    expect(result.current.transactions[0]?.categoryLabel).toBe(CATEGORY_LABELS.MISC);
+  });
+
+  it("reads an empty history as an empty list, not as a failure", async () => {
+    answerWith([]);
+
+    const { result } = renderViewModel();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.transactions).toEqual([]);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("reports a failed read as one, with nothing to list", async () => {
+    answerWith({ message: "Internal server error" }, 500);
+
+    const { result } = renderViewModel();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.transactions).toEqual([]);
+  });
+
+  it("asks for nothing while nobody is signed in, so the provider never answers a 401", async () => {
+    const requests = answerWith(mockPayCardTransactions());
+
+    const { result } = renderViewModel({ signedIn: false });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(requests).toEqual([]);
+    expect(result.current.transactions).toEqual([]);
+
+    result.current.refetch();
+
+    expect(requests).toEqual([]);
+  });
+
+  it("reads the page again on request", async () => {
+    const requests = answerWith(mockPayCardTransactions());
+
+    const { result } = renderViewModel();
+
+    await waitFor(() => expect(requests).toHaveLength(1));
+
+    result.current.refetch();
+
+    await waitFor(() => expect(requests).toHaveLength(2));
+  });
+});

--- a/features/flow/pay-card-transactions/src/exports.ts
+++ b/features/flow/pay-card-transactions/src/exports.ts
@@ -1,1 +1,3 @@
-export const PAY_CARD_TRANSACTIONS = "pay-card-transactions";
+export * from "./hooks/useCardTransactionsViewModel";
+export * from "./logic/categoryOf";
+export * from "./types";

--- a/features/flow/pay-card-transactions/src/hooks/useCardTransactionsViewModel.ts
+++ b/features/flow/pay-card-transactions/src/hooks/useCardTransactionsViewModel.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from "react";
+import { useGetCardTransactionsQuery } from "@domain/api-card-management";
+import { useIsCardSignedIn } from "@features/flow-pay-card-auth/hooks";
+import { useTranslation } from "@shared/i18n";
+import { categoryOf } from "../logic/categoryOf";
+import type { CardTransactionItem, CardTransactionsViewModel } from "../types";
+
+const NO_TRANSACTIONS: readonly [] = [];
+
+export function useCardTransactionsViewModel(): CardTransactionsViewModel {
+  const { t } = useTranslation();
+  const isSignedIn = useIsCardSignedIn();
+  const { data, isLoading, isFetching, isError, refetch } = useGetCardTransactionsQuery(undefined, {
+    skip: !isSignedIn,
+  });
+
+  const transactions = useMemo<readonly CardTransactionItem[]>(
+    () =>
+      (data ?? NO_TRANSACTIONS).map(transaction => {
+        const category = categoryOf(transaction);
+
+        return {
+          transaction,
+          category,
+          categoryLabel: t(`payTab.cardTransactions.categories.${category}`),
+        };
+      }),
+    [data, t],
+  );
+
+  const refetchWhenSignedIn = useCallback(() => {
+    if (!isSignedIn) {
+      return;
+    }
+
+    refetch();
+  }, [isSignedIn, refetch]);
+
+  return useMemo(
+    () => ({
+      transactions,
+      isLoading,
+      isFetching,
+      isError,
+      refetch: refetchWhenSignedIn,
+    }),
+    [transactions, isLoading, isFetching, isError, refetchWhenSignedIn],
+  );
+}

--- a/features/flow/pay-card-transactions/src/logic/categoryOf.test.ts
+++ b/features/flow/pay-card-transactions/src/logic/categoryOf.test.ts
@@ -1,0 +1,32 @@
+import {
+  PAY_CARD_TRANSACTION_CATEGORIES,
+  PayCardTransactionsResponseSchema,
+} from "@domain/api-card-management";
+import { mockPayCardTransactions } from "@domain/api-card-management/mock/card-transactions";
+import { categoryOf, transactionHasCategory } from "./categoryOf";
+
+const transactions = PayCardTransactionsResponseSchema.parse(mockPayCardTransactions());
+
+const [aliExpress] = transactions.filter(
+  ({ merchantNameLocation }) => merchantNameLocation === "WWW.ALIEXPRESS.COM, LONDON",
+);
+
+describe("categoryOf", () => {
+  it("reads the documented AliExpress charge as a miscellaneous purchase", () => {
+    expect(categoryOf(aliExpress)).toBe("MISC");
+  });
+
+  it.each(PAY_CARD_TRANSACTION_CATEGORIES)(
+    "reads a transaction the provider classified as %s",
+    category => {
+      expect(categoryOf({ ...aliExpress, mccCategory: category })).toBe(category);
+    },
+  );
+});
+
+describe("transactionHasCategory", () => {
+  it("answers whether a transaction falls in a given category", () => {
+    expect(transactionHasCategory(aliExpress, "MISC")).toBe(true);
+    expect(transactionHasCategory(aliExpress, "FOOD")).toBe(false);
+  });
+});

--- a/features/flow/pay-card-transactions/src/logic/categoryOf.ts
+++ b/features/flow/pay-card-transactions/src/logic/categoryOf.ts
@@ -1,0 +1,13 @@
+import type { PayCardTransaction, PayCardTransactionCategory } from "@domain/api-card-management";
+
+/** The provider classifies each charge itself, so this reads its label rather than deriving one. */
+export function categoryOf(transaction: PayCardTransaction): PayCardTransactionCategory {
+  return transaction.mccCategory;
+}
+
+export function transactionHasCategory(
+  transaction: PayCardTransaction,
+  category: PayCardTransactionCategory,
+): boolean {
+  return categoryOf(transaction) === category;
+}

--- a/features/flow/pay-card-transactions/src/types.ts
+++ b/features/flow/pay-card-transactions/src/types.ts
@@ -1,0 +1,15 @@
+import type { PayCardTransaction, PayCardTransactionCategory } from "@domain/api-card-management";
+
+export type CardTransactionItem = Readonly<{
+  transaction: PayCardTransaction;
+  category: PayCardTransactionCategory;
+  categoryLabel: string;
+}>;
+
+export type CardTransactionsViewModel = Readonly<{
+  transactions: readonly CardTransactionItem[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7050,6 +7050,16 @@ importers:
         version: 1.51.0
 
   features/flow/pay-card-transactions:
+    dependencies:
+      '@domain/api-card-management':
+        specifier: workspace:^
+        version: link:../../../domain/api/card-management
+      '@features/flow-pay-card-auth':
+        specifier: workspace:*
+        version: link:../pay-card-auth
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
@@ -7060,6 +7070,9 @@ importers:
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
+      '@support/msw-features-flow-pay-card':
+        specifier: workspace:*
+        version: link:../../../support/msw-features-flow-pay-card
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -7105,6 +7118,9 @@ importers:
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 30.5.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.67.0
@@ -7120,6 +7136,9 @@ importers:
       react-native:
         specifier: 'catalog:'
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer:
         specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)


### PR DESCRIPTION
### 📝 Description

Reads the first page of `GET /v1/card/transactions` and gives every transaction its spend category.

- `useCardTransactionsViewModel` queries while a card session is live, asks for nothing at all when nobody is signed in, and hands each transaction its category plus that category translated.
- `mccCategory` becomes the closed set the provider documents (`PayCardTransactionCategory`). A page is one array, so a grouping the provider never named reads as `MISC` instead of failing every other transaction on that page.
- `mockPayCardTransactions` answers a page covering all eight categories, served by the desktop and mobile MSW workers, so the list can be built without a live card.

Stacked on #21871: its tests import `@support/msw-features-flow-pay-card`, which lands there. Review and merge that one first — this PR targets its branch, so the diff shown here is only the transactions work.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34954](https://ledgerhq.atlassian.net/browse/LIVE-34954)

[LIVE-34954]: https://ledgerhq.atlassian.net/browse/LIVE-34954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ