### PR TITLE
[LWM] test(mobile): aggregate all in-flight dependency bumps (DO NOT MERGE)

### DIFF
--- a/.changeset/brave-otters-wander.md
+++ b/.changeset/brave-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Replace react-native-haptic-feedback with expo-haptics, already present as a Lumen peer

--- a/.changeset/bump-react-native-restart.md
+++ b/.changeset/bump-react-native-restart.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bump react-native-restart from 0.0.24 to 0.0.29 and migrate to the non-deprecated `restart()` API (LIVE-37285)

--- a/.changeset/bump-rn-config.md
+++ b/.changeset/bump-rn-config.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@features/platform-device-action-content": patch
+---
+
+Bump react-native-config from 1.5.3 to 1.7.2 (LIVE-37288)

--- a/.changeset/loud-bears-shout.md
+++ b/.changeset/loud-bears-shout.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bump react-native-tcp-socket from 6.0.6 to 6.4.2 (LIVE-37286)

--- a/.changeset/tame-lions-wave.md
+++ b/.changeset/tame-lions-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bump react-native-splash-screen from 3.2.0 to 3.3.0 (LIVE-37287)

--- a/.changeset/upgrade-url-polyfill-v4.md
+++ b/.changeset/upgrade-url-polyfill-v4.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Upgrade react-native-url-polyfill 1.3.0 → 4.0.0: 65% smaller bundle impact, 2–8× faster URL/URLSearchParams on Hermes, no transitive dependencies

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -114,12 +114,6 @@ jest.mock("react-native-gesture-handler", () => {
 
 jest.mock("react-native-gesture-handler/ReanimatedSwipeable");
 
-jest.mock("react-native-haptic-feedback", () => ({
-  default: {
-    trigger: jest.fn(),
-  },
-}));
-
 jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn().mockResolvedValue(undefined),
   notificationAsync: jest.fn().mockResolvedValue(undefined),

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -7,8 +7,7 @@ import "node-libs-react-native/globals";
 // https://github.com/kmagiera/react-native-gesture-handler/issues/320#issuecomment-443815828
 import "react-native-gesture-handler";
 
-/** URL polyfill */
-// URL object `intentionally` lightweight, does not support URLSearchParams features
+// Polyfill URL + URLSearchParams — React Native's native URL doesn't support URLSearchParams.
 // https://github.com/facebook/react-native/issues/23922
 import "react-native-url-polyfill/auto";
 

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2267,8 +2267,34 @@ PODS:
     - Yoga
   - react-native-randombytes (3.6.1):
     - React-Core
-  - react-native-restart (0.0.24):
+  - react-native-restart (0.0.29):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - react-native-safe-area-context (5.6.1):
     - boost
     - DoubleConversion
@@ -3686,7 +3712,7 @@ DEPENDENCIES:
   - "react-native-pager-view (from `../../../node_modules/.pnpm/react-native-pager-view@7.0.0_react-native@0.81_c0ff24837a45f8c2423b5ee7da79e1b6/node_modules/react-native-pager-view`)"
   - "react-native-performance (from `../../../node_modules/.pnpm/react-native-performance@5.1.2_react-native@0.8_ffdcfbc49b03201535a4e2607a2b1c42/node_modules/react-native-performance`)"
   - "react-native-randombytes (from `../../../node_modules/.pnpm/react-native-randombytes@3.6.1/node_modules/react-native-randombytes`)"
-  - "react-native-restart (from `../../../node_modules/.pnpm/react-native-restart@0.0.24_react-native@0.81.6_3490b89e86473c217d6f2b0593c9edc0/node_modules/react-native-restart`)"
+  - "react-native-restart (from `../../../node_modules/.pnpm/react-native-restart@0.0.29_react-native@0.81.6_f4e95484bb2762619f4b89d0ee00b582/node_modules/react-native-restart`)"
   - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.6.1_react-nati_dc140c40b533e12ecb3cd17960e9d3aa/node_modules/react-native-safe-area-context`)"
   - "react-native-slider (from `../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider`)"
   - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen`)"
@@ -3940,7 +3966,7 @@ EXTERNAL SOURCES:
   react-native-randombytes:
     :path: "../../../node_modules/.pnpm/react-native-randombytes@3.6.1/node_modules/react-native-randombytes"
   react-native-restart:
-    :path: "../../../node_modules/.pnpm/react-native-restart@0.0.24_react-native@0.81.6_3490b89e86473c217d6f2b0593c9edc0/node_modules/react-native-restart"
+    :path: "../../../node_modules/.pnpm/react-native-restart@0.0.29_react-native@0.81.6_f4e95484bb2762619f4b89d0ee00b582/node_modules/react-native-restart"
   react-native-safe-area-context:
     :path: "../../../node_modules/.pnpm/react-native-safe-area-context@5.6.1_react-nati_dc140c40b533e12ecb3cd17960e9d3aa/node_modules/react-native-safe-area-context"
   react-native-slider:
@@ -4172,7 +4198,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 4046e20b89f9ec1d29155668eb06c76a5f464951
   react-native-performance: 05f3b3d4418866a72dff821412160f96adc7460e
   react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
-  react-native-restart: df7caae89026a8ab2ecdd82839978f657701f51d
+  react-native-restart: b195f3ec6628c041e52753fe84a4851240267957
   react-native-safe-area-context: ee1e8e2a7abf737a8d4d9d1a5686a7f2e7466236
   react-native-slider: 05e7080478df08489251c2a6739a0d5628b7c198
   react-native-splash-screen: a43276f9cf4b2e65d7ce30efe372ffc528064293

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2439,8 +2439,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-splash-screen (3.2.0):
-    - React
+  - react-native-splash-screen (3.3.0):
+    - React-Core
   - react-native-startup-time (2.1.0):
     - React-Core
   - react-native-tcp-socket (6.4.2):
@@ -3715,7 +3715,7 @@ DEPENDENCIES:
   - "react-native-restart (from `../../../node_modules/.pnpm/react-native-restart@0.0.29_react-native@0.81.6_f4e95484bb2762619f4b89d0ee00b582/node_modules/react-native-restart`)"
   - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.6.1_react-nati_dc140c40b533e12ecb3cd17960e9d3aa/node_modules/react-native-safe-area-context`)"
   - "react-native-slider (from `../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider`)"
-  - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen`)"
+  - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.3.0_react-native@0_aab91b328bf357ade659c0bedf41097a/node_modules/react-native-splash-screen`)"
   - "react-native-startup-time (from `../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time`)"
   - "react-native-tcp-socket (from `../../../node_modules/.pnpm/react-native-tcp-socket@6.4.2_react-native@0.81_327f68c7b97e83fdd9f586e1781ec795/node_modules/react-native-tcp-socket`)"
   - "react-native-version-number (from `../../../node_modules/.pnpm/react-native-version-number@0.3.6/node_modules/react-native-version-number`)"
@@ -3972,7 +3972,7 @@ EXTERNAL SOURCES:
   react-native-slider:
     :path: "../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider"
   react-native-splash-screen:
-    :path: "../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen"
+    :path: "../../../node_modules/.pnpm/react-native-splash-screen@3.3.0_react-native@0_aab91b328bf357ade659c0bedf41097a/node_modules/react-native-splash-screen"
   react-native-startup-time:
     :path: "../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time"
   react-native-tcp-socket:
@@ -4201,7 +4201,7 @@ SPEC CHECKSUMS:
   react-native-restart: b195f3ec6628c041e52753fe84a4851240267957
   react-native-safe-area-context: ee1e8e2a7abf737a8d4d9d1a5686a7f2e7466236
   react-native-slider: 05e7080478df08489251c2a6739a0d5628b7c198
-  react-native-splash-screen: a43276f9cf4b2e65d7ce30efe372ffc528064293
+  react-native-splash-screen: 95994222cc95c236bd3cdc59fe45ed5f27969594
   react-native-startup-time: c7297d8a7892400239e6828bb94a3721c1a1a9df
   react-native-tcp-socket: 83a30b5da1deed4c720ee25595737ee851c23339
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -3286,34 +3286,6 @@ PODS:
     - Yoga
   - RNLocalize (2.2.6):
     - React-Core
-  - RNReactNativeHapticFeedback (2.3.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RNReanimated (4.3.0):
     - boost
     - DoubleConversion
@@ -3791,7 +3763,6 @@ DEPENDENCIES:
   - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.28.0_react-nativ_0a7cb677e518f2e9f30a24dde608028e/node_modules/react-native-gesture-handler`)"
   - "RNKeychain (from `../../../node_modules/.pnpm/react-native-keychain@10.0.0/node_modules/react-native-keychain`)"
   - "RNLocalize (from `../../../node_modules/.pnpm/react-native-localize@2.2.6_react-native@0.81.6_22b59121ec847ba53fb2e7d8aec6c181/node_modules/react-native-localize`)"
-  - "RNReactNativeHapticFeedback (from `../../../node_modules/.pnpm/react-native-haptic-feedback@2.3.3_react-native_4be985a7c9ac5a85953ef361e5810bbb/node_modules/react-native-haptic-feedback`)"
   - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.0_react-native-work_428dfbb78210a4eccefe4ea5b615ab19/node_modules/react-native-reanimated`)"
   - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.15.4_react-native@0.81.6_d34209bb2ab45ed965aa2e8d5e51931e/node_modules/react-native-screens`)"
   - "RNShare (from `../../../node_modules/.pnpm/react-native-share@12.2.0/node_modules/react-native-share`)"
@@ -4097,8 +4068,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/.pnpm/react-native-keychain@10.0.0/node_modules/react-native-keychain"
   RNLocalize:
     :path: "../../../node_modules/.pnpm/react-native-localize@2.2.6_react-native@0.81.6_22b59121ec847ba53fb2e7d8aec6c181/node_modules/react-native-localize"
-  RNReactNativeHapticFeedback:
-    :path: "../../../node_modules/.pnpm/react-native-haptic-feedback@2.3.3_react-native_4be985a7c9ac5a85953ef361e5810bbb/node_modules/react-native-haptic-feedback"
   RNReanimated:
     :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.0_react-native-work_428dfbb78210a4eccefe4ea5b615ab19/node_modules/react-native-reanimated"
   RNScreens:
@@ -4277,7 +4246,6 @@ SPEC CHECKSUMS:
   RNGestureHandler: b8d2e75c2e88fc2a1f6be3b3beeeed80b88fa37d
   RNKeychain: 76d042fc1dfba47f3945920bc82e0bce9ad1ff55
   RNLocalize: 8bf466de4c92d4721b254aabe1ff0a1456e7b9f4
-  RNReactNativeHapticFeedback: 5f1542065f0b24c9252bd8cf3e83bc9c548182e4
   RNReanimated: c74d47574d33045e2129b2a192be1deac616c3a0
   RNScreens: 4f2aed147a2775017923789d8a0a2d377712ec2e
   RNShare: 81b8cfb58b1460c4a197d5379934bdf70980c124

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2164,10 +2164,36 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-config (1.5.3):
-    - react-native-config/App (= 1.5.3)
-  - react-native-config/App (1.5.3):
+  - react-native-config (1.7.2):
+    - react-native-config/App (= 1.7.2)
+  - react-native-config/App (1.7.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - react-native-fast-crypto (3.0.0):
     - React-Core
   - react-native-fast-pbkdf2 (0.3.1):
@@ -3701,7 +3727,7 @@ DEPENDENCIES:
   - "React-microtasksnativemodule (from `../../../node_modules/.pnpm/react-native@0.81.6_patch_hash=fbb22f6ab81c7336_40b065189c08febd012a31e10dcb1091/node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)"
   - "react-native-biometrics (from `../../../node_modules/.pnpm/react-native-biometrics@3.0.1_react-native@0.81_6107268f132f753441abdb0f4a753a27/node_modules/react-native-biometrics`)"
   - "react-native-ble-plx (from `../../../node_modules/.pnpm/react-native-ble-plx@3.5.1_react-native@0.81.6__754cd35e9c22570bd4ae3f51b32245ed/node_modules/react-native-ble-plx`)"
-  - "react-native-config (from `../../../node_modules/.pnpm/react-native-config@1.5.3_react-native@0.81.6_p_91b8471f5fa8329e21ee06a26a59f0d8/node_modules/react-native-config`)"
+  - "react-native-config (from `../../../node_modules/.pnpm/react-native-config@1.7.2_react-native@0.81.6_p_f2da349b4c9c5d38d61c2169cbc760d2/node_modules/react-native-config`)"
   - "react-native-fast-crypto (from `../../../node_modules/.pnpm/react-native-fast-crypto@3.0.0_react-native@0.8_c964805093320a1bef0eac9f7f7988e2/node_modules/react-native-fast-crypto`)"
   - "react-native-fast-pbkdf2 (from `../../../node_modules/.pnpm/react-native-fast-pbkdf2@0.3.1_patch_hash=9dfb8_82077b482b4e45a2986abf061e25f0ca/node_modules/react-native-fast-pbkdf2`)"
   - "react-native-get-random-values (from `../../../node_modules/.pnpm/react-native-get-random-values@1.11.0_react-nat_f6c2cc36e39b20a87b2c98ebcaeb6c82/node_modules/react-native-get-random-values`)"
@@ -3944,7 +3970,7 @@ EXTERNAL SOURCES:
   react-native-ble-plx:
     :path: "../../../node_modules/.pnpm/react-native-ble-plx@3.5.1_react-native@0.81.6__754cd35e9c22570bd4ae3f51b32245ed/node_modules/react-native-ble-plx"
   react-native-config:
-    :path: "../../../node_modules/.pnpm/react-native-config@1.5.3_react-native@0.81.6_p_91b8471f5fa8329e21ee06a26a59f0d8/node_modules/react-native-config"
+    :path: "../../../node_modules/.pnpm/react-native-config@1.7.2_react-native@0.81.6_p_f2da349b4c9c5d38d61c2169cbc760d2/node_modules/react-native-config"
   react-native-fast-crypto:
     :path: "../../../node_modules/.pnpm/react-native-fast-crypto@3.0.0_react-native@0.8_c964805093320a1bef0eac9f7f7988e2/node_modules/react-native-fast-crypto"
   react-native-fast-pbkdf2:
@@ -4187,7 +4213,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: f4762eb5cc8d2287f2513c9e404e48b30bf9fc69
   react-native-biometrics: 43ed5b828646a7862dbc7945556446be00798e7d
   react-native-ble-plx: 3badd256b90d238ff01addaa12c7a05b4ea62cda
-  react-native-config: ea75335a7cca1d3326de1da384227e580a7c082e
+  react-native-config: 713a638bfc2b359f4606a9a161bb16e6a5068568
   react-native-fast-crypto: ad4845c4dd1314c9c6e7272b91c09ff60439c6aa
   react-native-fast-pbkdf2: 329e89b9929a51ed4d9ba88bf355a266f13d9d93
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2443,7 +2443,7 @@ PODS:
     - React
   - react-native-startup-time (2.1.0):
     - React-Core
-  - react-native-tcp-socket (6.0.6):
+  - react-native-tcp-socket (6.4.2):
     - CocoaAsyncSocket
     - React-Core
   - react-native-version-number (0.3.6):
@@ -3717,7 +3717,7 @@ DEPENDENCIES:
   - "react-native-slider (from `../../../node_modules/.pnpm/@react-native-community+slider@5.1.1/node_modules/@react-native-community/slider`)"
   - "react-native-splash-screen (from `../../../node_modules/.pnpm/react-native-splash-screen@3.2.0_react-native@0_7fb3b50c4a313d239ce4fdf88b5162e5/node_modules/react-native-splash-screen`)"
   - "react-native-startup-time (from `../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time`)"
-  - "react-native-tcp-socket (from `../../../node_modules/.pnpm/react-native-tcp-socket@6.0.6_react-native@0.81_34ca5ceafa440bcbde428f36b080d61a/node_modules/react-native-tcp-socket`)"
+  - "react-native-tcp-socket (from `../../../node_modules/.pnpm/react-native-tcp-socket@6.4.2_react-native@0.81_327f68c7b97e83fdd9f586e1781ec795/node_modules/react-native-tcp-socket`)"
   - "react-native-version-number (from `../../../node_modules/.pnpm/react-native-version-number@0.3.6/node_modules/react-native-version-number`)"
   - "react-native-video (from `../../../node_modules/.pnpm/react-native-video@6.16.1_react-native@0.81.6_p_f6cee87bac56333e1bcaa7ed5e65d1cc/node_modules/react-native-video`)"
   - "react-native-view-shot (from `../../../node_modules/.pnpm/react-native-view-shot@5.1.1_react-native@0.81._83e6766540172c22b2f788432d1311fb/node_modules/react-native-view-shot`)"
@@ -3976,7 +3976,7 @@ EXTERNAL SOURCES:
   react-native-startup-time:
     :path: "../../../node_modules/.pnpm/react-native-startup-time@2.1.0_react-native@0._9046ca1eb6173c89565c2a34b7da3918/node_modules/react-native-startup-time"
   react-native-tcp-socket:
-    :path: "../../../node_modules/.pnpm/react-native-tcp-socket@6.0.6_react-native@0.81_34ca5ceafa440bcbde428f36b080d61a/node_modules/react-native-tcp-socket"
+    :path: "../../../node_modules/.pnpm/react-native-tcp-socket@6.4.2_react-native@0.81_327f68c7b97e83fdd9f586e1781ec795/node_modules/react-native-tcp-socket"
   react-native-version-number:
     :path: "../../../node_modules/.pnpm/react-native-version-number@0.3.6/node_modules/react-native-version-number"
   react-native-video:
@@ -4203,7 +4203,7 @@ SPEC CHECKSUMS:
   react-native-slider: 05e7080478df08489251c2a6739a0d5628b7c198
   react-native-splash-screen: a43276f9cf4b2e65d7ce30efe372ffc528064293
   react-native-startup-time: c7297d8a7892400239e6828bb94a3721c1a1a9df
-  react-native-tcp-socket: ae8abcfebc071216302a09d9ed1e375d4e877484
+  react-native-tcp-socket: 83a30b5da1deed4c720ee25595737ee851c23339
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
   react-native-video: 6ed94120c73e29c8fbea89ec4e3cedf3528751d6
   react-native-view-shot: 5ed55de8892be2746074c2f8066e6abc21dd6fd3

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -285,7 +285,7 @@
     "react-native-qrcode-svg": "6.1.1",
     "react-native-randombytes": "3.6.1",
     "react-native-reanimated": "catalog:",
-    "react-native-restart": "0.0.24",
+    "react-native-restart": "0.0.29",
     "react-native-safe-area-context": "catalog:",
     "react-native-screens": "catalog:",
     "react-native-share": "12.2.0",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -271,7 +271,6 @@
     "react-native-fast-shadow": "0.1.1",
     "react-native-gesture-handler": "2.28.0",
     "react-native-get-random-values": "1.11.0",
-    "react-native-haptic-feedback": "2.3.3",
     "react-native-image-crop-tools": "1.6.4",
     "react-native-image-picker": "8.2.0",
     "react-native-keychain": "catalog:",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -292,7 +292,7 @@
     "react-native-splash-screen": "3.2.0",
     "react-native-startup-time": "2.1.0",
     "react-native-svg": "catalog:",
-    "react-native-tcp-socket": "6.0.6",
+    "react-native-tcp-socket": "6.4.2",
     "react-native-url-polyfill": "1.3.0",
     "react-native-version-number": "0.3.6",
     "react-native-video": "6.16.1",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -289,7 +289,7 @@
     "react-native-safe-area-context": "catalog:",
     "react-native-screens": "catalog:",
     "react-native-share": "12.2.0",
-    "react-native-splash-screen": "3.2.0",
+    "react-native-splash-screen": "3.3.0",
     "react-native-startup-time": "2.1.0",
     "react-native-svg": "catalog:",
     "react-native-tcp-socket": "6.4.2",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -292,7 +292,7 @@
     "react-native-startup-time": "2.1.0",
     "react-native-svg": "catalog:",
     "react-native-tcp-socket": "6.4.2",
-    "react-native-url-polyfill": "1.3.0",
+    "react-native-url-polyfill": "4.0.0",
     "react-native-version-number": "0.3.6",
     "react-native-video": "6.16.1",
     "react-native-view-shot": "5.1.1",

--- a/apps/ledger-live-mobile/src/context/Locale.tsx
+++ b/apps/ledger-live-mobile/src/context/Locale.tsx
@@ -111,7 +111,7 @@ export default function LocaleProvider({ children }: Props) {
   // To be removed the day we want to support arabic again.
   if (I18nManager.isRTL) {
     I18nManager.forceRTL(false);
-    RNRestart.Restart();
+    RNRestart.restart();
   }
 
   const value: LocaleState = useMemo(

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
@@ -97,7 +97,7 @@ function OnboardingStepLanguage({ navigation }: NavigationProps) {
       dispatch(setLanguage(selectedLanguage)),
       updateIdentify(),
     ]);
-    setTimeout(() => RNRestart.Restart(), 0);
+    setTimeout(() => RNRestart.restart(), 0);
   };
 
   const changeLanguage = useCallback(

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -3,7 +3,7 @@ import { Dimensions, Linking, Platform, Share, View } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import QRCode from "react-native-qrcode-svg";
 import { useTranslation } from "~/context/Locale";
-import ReactNativeHapticFeedback from "react-native-haptic-feedback";
+import * as Haptics from "expo-haptics";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { TokenCurrency } from "@domain/entity-currency-token";
@@ -216,16 +216,11 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
         button: eventName,
         page: "Receive Account Qr Code",
       });
-      const options = {
-        enableVibrateFallback: false,
-        ignoreAndroidSystemSettings: false,
-      };
-
       setTimeout(() => {
         setCopied(false);
       }, 3000);
 
-      ReactNativeHapticFeedback.trigger("soft", options);
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Soft);
       pushToast({
         id: `copy-receive`,
         type: "success",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2286,8 +2286,8 @@ importers:
         specifier: 6.4.2
         version: 6.4.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-url-polyfill:
-        specifier: 1.3.0
-        version: 1.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        specifier: 4.0.0
+        version: 4.0.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-version-number:
         specifier: 0.3.6
         version: 0.3.6
@@ -37816,8 +37816,8 @@ packages:
     peerDependencies:
       react-native: '>=0.60.0'
 
-  react-native-url-polyfill@1.3.0:
-    resolution: {integrity: sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==}
+  react-native-url-polyfill@4.0.0:
+    resolution: {integrity: sha512-eqYM3wBAA0eL1sPYbBAoNfbES3+NkgcxUdelQ7QzmoVtqKB5qGG0U13MPTRUroAWK+y2EoJFS3MZUK0fwTf0pA==}
     peerDependencies:
       react-native: '*'
 
@@ -68919,10 +68919,9 @@ snapshots:
       eventemitter3: 4.0.7
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  react-native-url-polyfill@1.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
+  react-native-url-polyfill@4.0.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
     dependencies:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-      whatwg-url-without-unicode: 8.0.0-3
 
   react-native-version-number@0.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2265,8 +2265,8 @@ importers:
         specifier: 'catalog:'
         version: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(@babel/core@7.28.5)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-restart:
-        specifier: 0.0.24
-        version: 0.0.24(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        specifier: 0.0.29
+        version: 0.0.29(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-safe-area-context:
         specifier: 'catalog:'
         version: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -37767,11 +37767,15 @@ packages:
       react-native: 0.81 - 0.85
       react-native-worklets: 0.8.x
 
-  react-native-restart@0.0.24:
-    resolution: {integrity: sha512-pvJNU3NwQk6bCG2gOWcQpZ4IxhtELB0K9gzmtixfsaTFbW1UXXHkJNjk1kHazcbH5hrD7QbUkR63fsAVh8X4VQ==}
+  react-native-restart@0.0.29:
+    resolution: {integrity: sha512-AJDAww9cW7F6d4g9TABhuFR1E0j00p5ktv0Rls0BA6Ymz/8J+HwMxeR6KPZmHfkMtAguH4H2kw2xhqXjjSiUlg==}
     peerDependencies:
       react: 19.1.4
       react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      react-native-windows:
+        optional: true
 
   react-native-safe-area-context@5.6.1:
     resolution: {integrity: sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==}
@@ -68833,7 +68837,7 @@ snapshots:
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       semver: 7.8.1
 
-  react-native-restart@0.0.24(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+  react-native-restart@0.0.29(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,8 +451,8 @@ catalogs:
       specifier: 0.81.6
       version: 0.81.6
     react-native-config:
-      specifier: 1.5.3
-      version: 1.5.3
+      specifier: 1.7.2
+      version: 1.7.2
     react-native-keychain:
       specifier: 10.0.0
       version: 10.0.0
@@ -2197,7 +2197,7 @@ importers:
         version: 3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-config:
         specifier: 'catalog:'
-        version: 1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        version: 1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-device-info:
         specifier: 11.1.0
         version: 11.1.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
@@ -8154,7 +8154,7 @@ importers:
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
       react-native-config:
         specifier: 'catalog:'
-        version: 1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))
+        version: 1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-test-renderer:
         specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)
@@ -37601,14 +37601,13 @@ packages:
       react: 19.1.4
       react-native: '*'
 
-  react-native-config@1.5.3:
-    resolution: {integrity: sha512-3D05Abgk5DfDw9w258EzXvX5AkU7eqj3u9H0H0L4gUga4nYg/zuupcrpGbpF4QeXBcJ84jjs6g8JaEP6VBT7Pg==}
+  react-native-config@1.7.2:
+    resolution: {integrity: sha512-sOzjs2oGPqlgJu7WjlYa/zA8/uShebQeQVYumgPd8pO+l/TrHWhOZPWrDAphxrshpnFVgPgQeXXT3eVSTNQGpg==}
     peerDependencies:
+      react: 19.1.4
       react-native: '*'
       react-native-windows: '>=0.61'
     peerDependenciesMeta:
-      react-native:
-        optional: true
       react-native-windows:
         optional: true
 
@@ -68643,12 +68642,14 @@ snapshots:
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4)
 
-  react-native-config@1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
-    optionalDependencies:
+  react-native-config@1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  react-native-config@1.5.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)):
-    optionalDependencies:
+  react-native-config@1.7.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
 
   react-native-crypto@2.2.0(react-native-randombytes@3.6.1):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2222,9 +2222,6 @@ importers:
       react-native-get-random-values:
         specifier: 1.11.0
         version: 1.11.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
-      react-native-haptic-feedback:
-        specifier: 2.3.3
-        version: 2.3.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-image-crop-tools:
         specifier: 1.6.4
         version: 1.6.4(patch_hash=8dc28ff513f78de4133eb71abe17699348337c4354a1e7fa23aeb5083009e0b2)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -37664,11 +37661,6 @@ packages:
     peerDependencies:
       react-native: '>=0.56'
 
-  react-native-haptic-feedback@2.3.3:
-    resolution: {integrity: sha512-svS4D5PxfNv8o68m9ahWfwje5NqukM3qLS48+WTdhbDkNUkOhP9rDfDSRHzlhk4zq+ISjyw95EhLeh8NkKX5vQ==}
-    peerDependencies:
-      react-native: '>=0.60.0'
-
   react-native-image-crop-tools@1.6.4:
     resolution: {integrity: sha512-GhI76SlKAI7vfUfg/UnG/MrPTe7ffwjsOowBnYYAB2npJ2ij/iAG4LRXOPlQygoY+yiCy158sYo4wmKDc0RfLQ==}
     peerDependencies:
@@ -68719,10 +68711,6 @@ snapshots:
     dependencies:
       fast-base64-decode: 1.0.0
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
-
-  react-native-haptic-feedback@2.3.3(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
-    dependencies:
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
   react-native-image-crop-tools@1.6.4(patch_hash=8dc28ff513f78de4133eb71abe17699348337c4354a1e7fa23aeb5083009e0b2)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2286,8 +2286,8 @@ importers:
         specifier: 'catalog:'
         version: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-tcp-socket:
-        specifier: 6.0.6
-        version: 6.0.6(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        specifier: 6.4.2
+        version: 6.4.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-url-polyfill:
         specifier: 1.3.0
         version: 1.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
@@ -37820,8 +37820,8 @@ packages:
       react-native: '*'
       react-native-pager-view: '>= 6.0.0'
 
-  react-native-tcp-socket@6.0.6:
-    resolution: {integrity: sha512-FIFSP+3S5OnJRjl7ddD7G9NfVbVEiQ4WROEmOBei1cKE0pDz2R/Kcm4XkFlnMd5sdoG6Wbv830Yd/ZsmOjkEKw==}
+  react-native-tcp-socket@6.4.2:
+    resolution: {integrity: sha512-x3piN60BLaVA7or3n6HKhsa15QDpb1hu+X7Mh99ldV+ZXUGDVKymsLLyu7vzEybTzF3sC17ubpCEgjik5aXfcA==}
     peerDependencies:
       react-native: '>=0.60.0'
 
@@ -68924,7 +68924,7 @@ snapshots:
       react-native-pager-view: 7.0.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       use-latest-callback: 0.1.9(react@19.1.4)
 
-  react-native-tcp-socket@6.0.6(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
+  react-native-tcp-socket@6.4.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
     dependencies:
       buffer: 5.7.1
       eventemitter3: 4.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2277,8 +2277,8 @@ importers:
         specifier: 12.2.0
         version: 12.2.0
       react-native-splash-screen:
-        specifier: 3.2.0
-        version: 3.2.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
+        specifier: 3.3.0
+        version: 3.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-startup-time:
         specifier: 2.1.0
         version: 2.1.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -37793,8 +37793,8 @@ packages:
     resolution: {integrity: sha512-f6MB9BsKa9xVvu0DKbxq5jw4IyYHqQeqUlCNkD8eAFoJx6SD31ObPAn7SQ6NG9AOuhCy6aYuSJYJvx25DaoMZQ==}
     engines: {node: '>=16'}
 
-  react-native-splash-screen@3.2.0:
-    resolution: {integrity: sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==}
+  react-native-splash-screen@3.3.0:
+    resolution: {integrity: sha512-rGjt6HkoSXxMqH4SQUJ1gnPQlPJV8+J47+4yhgTIan4bVvAwJhEeJH7wWt9hXSdH4+VfwTS0GTaflj1Tw83IhA==}
     peerDependencies:
       react-native: '>=0.57.0'
 
@@ -68875,7 +68875,7 @@ snapshots:
 
   react-native-share@12.2.0: {}
 
-  react-native-splash-screen@3.2.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
+  react-native-splash-screen@3.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
     dependencies:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -159,7 +159,7 @@ catalog:
   react: 19.1.4
   react-dom: 19.1.4
   react-i18next: 16.5.0
-  react-native-config: 1.5.3
+  react-native-config: 1.7.2
   react-native-keychain: 10.0.0
   react-native-reanimated: 4.3.0
   react-native-worklets: 0.8.1


### PR DESCRIPTION
> [!WARNING]
> **Test aggregate — not for merge.** This branch exists to run E2E and produce builds against all in-flight mobile dependency changes at once. Each change ships in its own PR; review happens there.

### 📝 Description

Cherry-picks the six open mobile dependency PRs onto `develop`, so QA gets one APK / one iOS build with every change combined rather than six separate ones.

| Change | Ticket | PR |
|---|---|---|
| react-native-restart 0.0.24 → 0.0.29 | [LIVE-37285](https://ledgerhq.atlassian.net/browse/LIVE-37285) | #21859 |
| react-native-tcp-socket 6.0.6 → 6.4.2 | [LIVE-37286](https://ledgerhq.atlassian.net/browse/LIVE-37286) | #21857 |
| react-native-splash-screen 3.2.0 → 3.3.0 | [LIVE-37287](https://ledgerhq.atlassian.net/browse/LIVE-37287) | #21856 |
| react-native-config 1.5.3 → 1.7.2 | [LIVE-37288](https://ledgerhq.atlassian.net/browse/LIVE-37288) | #21858 |
| react-native-haptic-feedback → expo-haptics | [LIVE-37290](https://ledgerhq.atlassian.net/browse/LIVE-37290) | #21860 |
| react-native-url-polyfill 1.3.0 → 4.0.0 | [LIVE-37282](https://ledgerhq.atlassian.net/browse/LIVE-37282) | #21850 |

Four of the six are native pods, so the combined `Podfile.lock` carries all of them at once — which is the part no individual PR exercises. `pnpm-lock.yaml` validated with `pnpm install --frozen-lockfile` (exit 0, no drift).

Where to look during QA: app startup and splash, locale change and onboarding language switch (restart), address-copy haptic on Android in silent mode (expo-haptics no longer honours the ringer-mode check), deep links and URL parsing (url-polyfill v4), and anything env-driven (react-native-config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-37285]: https://ledgerhq.atlassian.net/browse/LIVE-37285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37286]: https://ledgerhq.atlassian.net/browse/LIVE-37286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37287]: https://ledgerhq.atlassian.net/browse/LIVE-37287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37288]: https://ledgerhq.atlassian.net/browse/LIVE-37288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37290]: https://ledgerhq.atlassian.net/browse/LIVE-37290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-37282]: https://ledgerhq.atlassian.net/browse/LIVE-37282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ