### PR TITLE
fix(e2e): scroll the portfolio hero into view (QAA-1571)

### DIFF
--- a/.changeset/qaa-1571-portfolio-hero-scroll.md
+++ b/.changeset/qaa-1571-portfolio-hero-scroll.md
@@ -1,0 +1,19 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Scroll the portfolio hero back into view before asserting on it (QAA-1571)
+
+Android detaches off-screen FlatList rows from the native view hierarchy, so once
+the portfolio list is scrolled past its first row the balance and the quick-action
+CTAs are absent rather than under-visible, and no wait recovers them. The nightly
+hierarchy dumps show the list arriving ~1194px down — the exact height of that row
+— with `market-banner-container` as the first attached child at y=54 instead of
+y=1248, which is why `quick-actions-ctas` and `portfolio-balance-normal` timed out
+on Android while iOS stayed green.
+
+Every portfolio accessor that targets the balance or the quick actions now scrolls
+the list up to its own target first, via `scrollToId(target, list, undefined, "up")`.
+Visibility thresholds and timeouts are unchanged. Detox's `scrollTo("top")` is not
+usable here: the list's pull-to-refresh control means the action never reports a top
+edge and force-breaks its loop.

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -19,6 +19,9 @@ export default class PortfolioPage {
   portfolioSettingsId = "topbar-settings";
   myWalletHeaderSettingsButtonId = "my-wallet-header-settings-button";
   portfolioListIdRegex = new RegExp(`portfolio-screen|${this.readOnlyItemsId}`);
+  portfolioScrollableListIdRegex = new RegExp(
+    `^(${this.accountsListView}|${this.emptyPortfolioListId})$`,
+  );
   addAccountCta = "add-account-cta";
   transactionHistorySectionTitleId = "portfolio-transaction-history-section";
   showAllAssetsButton = "assets-button";
@@ -108,6 +111,18 @@ export default class PortfolioPage {
     }
   }
 
+  /**
+   * The balance and the quick-action row live in the portfolio list's first row, which Android
+   * detaches from the view hierarchy once the list is scrolled past it — the target is then absent,
+   * not merely under-visible, and no wait recovers it.
+   *
+   * Detox's `scrollTo("top")` force-breaks on this list: its pull-to-refresh control means the
+   * action never reports a top edge.
+   */
+  private async ensureHeroVisible(targetId: string) {
+    await scrollToId(targetId, this.portfolioScrollableListIdRegex, undefined, "up");
+  }
+
   @Step("Expect balance to be visible")
   async expectBalanceToBeVisible() {
     await detoxExpect(getElementById(this.analyticsBalanceAmountId)).toBeVisible();
@@ -115,6 +130,7 @@ export default class PortfolioPage {
 
   @Step("Expect total balance value {{{0}}}")
   async expectTotalBalanceCounterValue(counterValue: string) {
+    await this.ensureHeroVisible(this.portfolioBalanceNormal);
     await waitForElementById(this.portfolioBalanceNormal);
     const label = await getLabelOfElement(this.portfolioBalanceAmount);
     jestExpect(label).toContain(counterValue);
@@ -125,6 +141,7 @@ export default class PortfolioPage {
     if (await isAggregatedAssetsEnabled()) {
       return;
     } else {
+      await this.ensureHeroVisible(this.portfolioBalanceAnalyticsPill);
       await waitForElementById(this.portfolioBalanceAnalyticsPill);
     }
   }
@@ -195,6 +212,7 @@ export default class PortfolioPage {
 
   @Step("Check quick action buttons visibility")
   async checkQuickActionButtonsVisibility() {
+    await this.ensureHeroVisible(this.quickActionsCtasContainerId);
     await waitForElementById(this.quickActionTransferButtonV4);
     await waitForElementById(this.quickActionSwapButtonV4);
     await waitForElementById(this.quickActionBuyButtonV4);
@@ -344,21 +362,24 @@ export default class PortfolioPage {
 
   @Step("Check quick action transfer button visibility")
   async checkQuickActionTransferButtonVisibility() {
+    await this.ensureHeroVisible(this.quickActionTransferButtonV4);
     await waitForElementById(this.quickActionTransferButtonV4);
   }
 
   @Step("Check quick action swap button visibility")
   async checkQuickActionSwapButtonVisibility() {
+    await this.ensureHeroVisible(this.quickActionSwapButtonV4);
     await waitForElementById(this.quickActionSwapButtonV4);
   }
 
   @Step("Check quick action buy button visibility")
   async checkQuickActionBuyButtonVisibility() {
+    await this.ensureHeroVisible(this.quickActionBuyButtonV4);
     await waitForElementById(this.quickActionBuyButtonV4);
   }
 
-  // The row mounts only after portfolio data resolves (QAA-1524).
   private async waitForQuickActionsSettled() {
+    await this.ensureHeroVisible(this.quickActionsCtasContainerId);
     await waitForFullyVisibleById(this.quickActionsCtasContainerId);
   }
 
@@ -381,21 +402,25 @@ export default class PortfolioPage {
   }
   @Step("Check no balance title visibility")
   async checkNoBalanceTitleVisibility() {
+    await this.ensureHeroVisible(this.portfolioBalanceNoAccount);
     await waitForElementById(this.portfolioBalanceNoAccount);
   }
 
   @Step("Check normal balance title visibility")
   async checkNormalBalanceTitleVisibility() {
+    await this.ensureHeroVisible(this.portfolioBalanceNormal);
     await waitForElementById(this.portfolioBalanceNormal);
   }
 
   @Step("Check portfolio balance analytics pill visibility")
   async checkPortfolioBalanceAnalyticsPillVisibility() {
+    await this.ensureHeroVisible(this.portfolioBalanceAnalyticsPill);
     await waitForElementById(this.portfolioBalanceAnalyticsPill);
   }
 
   @Step("Tap on portfolio balance analytics pill")
   async tapPortfolioBalanceAnalyticsPill() {
+    await this.ensureHeroVisible(this.portfolioBalanceAnalyticsPill);
     await tapById(this.portfolioBalanceAnalyticsPill);
   }
 


### PR DESCRIPTION
### 📝 Description

Two Android tests failed every attempt in the nightly mobile E2E — `[BTC] - Buy from portfolio page` on `quick-actions-ctas` and `Select a counter value to display amounts` on `portfolio-balance-normal`, both 60s visibility timeouts, both green on iOS.

**Previous behaviour.** The targets were not under-visible, they were **absent from the native view hierarchy**. The nightly *Native View Hierarchy at failure* attachment shows the portfolio list present with `market-banner-container` as its first attached child at `y=54`; on a healthy run that node sits at `y=1248`. The list therefore arrived ~1194px scrolled down — the exact height of the hero block (`portfolio-balance-normal` `y=450`, `quick-actions-ctas` `y=960-1176`) — which puts the whole hero above the viewport. The hero is the first row of the portfolio's `RefreshableCollapsibleHeaderFlatList`, and Android detaches off-screen FlatList rows from the native tree, so no wait could ever recover it. iOS keeps them attached, hence green. This is also why the two earlier fixes (QAA-1524, QAA-1523) only changed the error message.

**Fix.** `PortfolioPage.ensureHeroVisible(targetId)` scrolls the list back up to the caller's own target before the existing assertion, using the repo's `scrollToId(target, list, undefined, "up")`. It is applied to the 10 accessors that target the balance or the quick actions, and no-ops when the target is already visible. Visibility thresholds and timeouts are untouched — nothing was relaxed to make this pass.

Detox's `element(by.id(list)).scrollTo("top")` was the first approach and is not usable on this list: the pull-to-refresh control means the action never reports a top edge and it dies with `Scrolling a lot without reaching the edge: force-breaking the loop`.

`expectBalanceToBeVisible` is deliberately not guarded — `analytics-balance-amount` belongs to the Analytics screen, not the portfolio list. The guard resolves `/^(PortfolioAccountsList|PortfolioEmptyList)$/` so it also works on the no-accounts portfolio.

**Automated check preventing regression.** The four affected spec files run on both platforms in the E2E run linked below.

<details>
<summary>Local verification (android.emu.release, CI screen geometry)</summary>

| Check | Result |
| --- | --- |
| Failure reproduced by scrolling the list down 1200px first, guard off | ✗ identical 60s / 100%-visibility timeout, `quick-actions-ctas` absent |
| Same scenario, guard on | ✓ passes in 33s |
| buy + counter-value + portfolioWithAccount + portfolioWithoutAccount | ✓ 3 consecutive runs, 8/8 tests each |

The two specs also pass unpatched locally — the scrolled state does not occur on this host, so the failure was reproduced deliberately rather than claimed as a local red-to-green.
</details>

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1571](https://ledgerhq.atlassian.net/browse/QAA-1571)
- **E2E run**: [34606089904](https://github.com/LedgerHQ/ledger-live/actions/runs/34606089904) — iOS & Android, filtered to the four affected specs, all E2E jobs green
- **ADR** (if any): n/a

Open question left to the product side: on CI the portfolio lands ~1194px scrolled with no test input, so a real user would open Home mid-page. This PR only makes the tests resilient to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1571]: https://ledgerhq.atlassian.net/browse/QAA-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ