### PR TITLE
[LWM] chore(mobile): remove unused react-native-performance (LIVE-37307)

### DIFF
--- a/.changeset/remove-rn-performance.md
+++ b/.changeset/remove-rn-performance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove unused react-native-performance dependency (LIVE-37307)

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -2237,34 +2237,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-performance (5.1.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - react-native-randombytes (3.6.1):
     - React-Core
   - react-native-restart (0.0.24):
@@ -3684,7 +3656,6 @@ DEPENDENCIES:
   - "react-native-launch-arguments (from `../../../node_modules/.pnpm/react-native-launch-arguments@4.0.2_react-nativ_c4bbb6fd9a1925e903fa616a647715a9/node_modules/react-native-launch-arguments`)"
   - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@11.4.1_react-na_86e92b27cfbc2cc37825bfe76bb15e23/node_modules/@react-native-community/netinfo`)"
   - "react-native-pager-view (from `../../../node_modules/.pnpm/react-native-pager-view@7.0.0_react-native@0.81_c0ff24837a45f8c2423b5ee7da79e1b6/node_modules/react-native-pager-view`)"
-  - "react-native-performance (from `../../../node_modules/.pnpm/react-native-performance@5.1.2_react-native@0.8_ffdcfbc49b03201535a4e2607a2b1c42/node_modules/react-native-performance`)"
   - "react-native-randombytes (from `../../../node_modules/.pnpm/react-native-randombytes@3.6.1/node_modules/react-native-randombytes`)"
   - "react-native-restart (from `../../../node_modules/.pnpm/react-native-restart@0.0.24_react-native@0.81.6_3490b89e86473c217d6f2b0593c9edc0/node_modules/react-native-restart`)"
   - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.6.1_react-nati_dc140c40b533e12ecb3cd17960e9d3aa/node_modules/react-native-safe-area-context`)"
@@ -3935,8 +3906,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@11.4.1_react-na_86e92b27cfbc2cc37825bfe76bb15e23/node_modules/@react-native-community/netinfo"
   react-native-pager-view:
     :path: "../../../node_modules/.pnpm/react-native-pager-view@7.0.0_react-native@0.81_c0ff24837a45f8c2423b5ee7da79e1b6/node_modules/react-native-pager-view"
-  react-native-performance:
-    :path: "../../../node_modules/.pnpm/react-native-performance@5.1.2_react-native@0.8_ffdcfbc49b03201535a4e2607a2b1c42/node_modules/react-native-performance"
   react-native-randombytes:
     :path: "../../../node_modules/.pnpm/react-native-randombytes@3.6.1/node_modules/react-native-randombytes"
   react-native-restart:
@@ -4170,7 +4139,6 @@ SPEC CHECKSUMS:
   react-native-launch-arguments: d4759f7591e2766e6c5ec746b7032429edaf7058
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-pager-view: 4046e20b89f9ec1d29155668eb06c76a5f464951
-  react-native-performance: 05f3b3d4418866a72dff821412160f96adc7460e
   react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
   react-native-restart: df7caae89026a8ab2ecdd82839978f657701f51d
   react-native-safe-area-context: ee1e8e2a7abf737a8d4d9d1a5686a7f2e7466236

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -397,7 +397,6 @@
     "metro-transform-plugins": "0.83.3",
     "msw": "catalog:",
     "react-native-launch-arguments": "4.0.2",
-    "react-native-performance": "5.1.2",
     "react-test-renderer": "catalog:",
     "react-native-sse": "1.2.1",
     "strip-ansi": "6.0.1",

--- a/apps/ledger-live-mobile/src/devTools/useDevTools.ts
+++ b/apps/ledger-live-mobile/src/devTools/useDevTools.ts
@@ -27,15 +27,3 @@ const HookDevTools = () => {
 };
 
 export default HookDevTools;
-
-/**
- * For performance monitoring, we can use the following metrics:
- *
- * 0. import performance from 'react-native-performance';
- *
- * 1. performance.mark('app-start');
- * 2. performance.mark('data-loaded');
- * 3. performance.measure('app-initialization', 'app-start', 'data-loaded');
- * 4. performance.metric('custom-metric', 42, { detail: 'Additional info' });
- *
- */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2598,9 +2598,6 @@ importers:
       react-native-launch-arguments:
         specifier: 4.0.2
         version: 4.0.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-performance:
-        specifier: 5.1.2
-        version: 5.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))
       react-native-sse:
         specifier: 1.2.1
         version: 1.2.1
@@ -37795,11 +37792,6 @@ packages:
       react: 19.1.4
       react-native: '*'
 
-  react-native-performance@5.1.2:
-    resolution: {integrity: sha512-l5JOJphNzox9a9icL3T6O/gEqZuqWqcbejW04WPa10m0UanBdIYrNkPFl48B3ivWw3MabpjB6GiDYv7old9/fw==}
-    peerDependencies:
-      react-native: '*'
-
   react-native-qrcode-svg@6.1.1:
     resolution: {integrity: sha512-98cc8fkl61g2V5cesmxjlMr1WaJZcB6dyeN8T9d/shIWtJxU8KRCinNCZNBlIvO9fxbIpo5SgK+pqSItK0+vow==}
     peerDependencies:
@@ -68834,10 +68826,6 @@ snapshots:
   react-native-pager-view@7.0.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       react: 19.1.4
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-
-  react-native-performance@5.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)):
-    dependencies:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
   react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):


### PR DESCRIPTION
### 📝 Description

Removes the unused `react-native-performance` dependency from `apps/ledger-live-mobile`.

No code imported it anywhere (JS, devtools, e2e, Android or iOS sources) — the only mention was a comment in `useDevTools.ts` demonstrating how one could use it, now deleted along with the `package.json` entry, lockfile, and Podfile.lock pod entry.

`react-native-startup-time` is unrelated and stays — it's genuinely used via `getTimeSinceStartup()`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37307](https://ledgerhq.atlassian.net/browse/LIVE-37307)
- **ADR** (if any): N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-37307]: https://ledgerhq.atlassian.net/browse/LIVE-37307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ