### PR TITLE
fix(contacts): add DialogFooter to LedgerSync intro modal (LIVE-37003)

### DIFF
--- a/.changeset/LIVE-37003-contacts-ledger-sync-bottom-padding.md
+++ b/.changeset/LIVE-37003-contacts-ledger-sync-bottom-padding.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts-introduction": patch
+"ledger-live-desktop": patch
+---
+
+fix bottom padding missing on the Ledger Sync intro modal in the Add Contact flow

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogBody,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   Spot,
 } from "@ledgerhq/lumen-ui-react";
@@ -40,7 +41,7 @@ export function ContactsLedgerSyncIntroductionDialog({
           className="pointer-events-none absolute inset-x-0 top-0 h-full bg-gradient-muted"
         />
         <DialogHeader density="compact" onClose={dismiss} />
-        <DialogBody className="flex flex-col gap-32 px-24 pb-24">
+        <DialogBody className="flex flex-col gap-32 px-24">
           <div className="flex flex-col items-center gap-24">
             <Spot appearance="icon" size={72} icon={Refresh} />
             <div className="flex flex-col items-center gap-8 text-center">
@@ -48,27 +49,27 @@ export function ContactsLedgerSyncIntroductionDialog({
               <p className="body-2 text-muted">{description}</p>
             </div>
           </div>
-          <div className="flex flex-col gap-16">
-            <Button
-              appearance="base"
-              size="lg"
-              isFull
-              onClick={onActivate}
-              data-testid="contacts-ledger-sync-introduction-activate"
-            >
-              {activateLabel}
-            </Button>
-            <Button
-              appearance="gray"
-              size="lg"
-              isFull
-              onClick={dismiss}
-              data-testid="contacts-ledger-sync-introduction-dismiss"
-            >
-              {dismissLabel}
-            </Button>
-          </div>
         </DialogBody>
+        <DialogFooter className="flex flex-col gap-16 pb-24">
+          <Button
+            appearance="base"
+            size="lg"
+            isFull
+            onClick={onActivate}
+            data-testid="contacts-ledger-sync-introduction-activate"
+          >
+            {activateLabel}
+          </Button>
+          <Button
+            appearance="gray"
+            size="lg"
+            isFull
+            onClick={dismiss}
+            data-testid="contacts-ledger-sync-introduction-dismiss"
+          >
+            {dismissLabel}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

Fixes **[LIVE-37003](https://ledgerhq.atlassian.net/browse/LIVE-37003)** — no bottom padding on the Ledger Sync modal when opening the Add Contact flow on LWD.

**Root cause:** action buttons placed inside `DialogBody` bypass Lumen UI's built-in footer spacing. `DialogBody` padding alone (`pb-24`) is not enough — the correct fix is to move buttons to `DialogFooter`.

**Fix:** move the activate + dismiss buttons out of `DialogBody` and into `DialogFooter` with `pb-24`.

<img width="1493" height="840" alt="Screenshot 2026-09-11 at 4 32 09 PM" src="https://github.com/user-attachments/assets/a8930786-8eec-4c85-bbfa-cbcec9aa1730" />

## Test plan

- [x] Open Contacts on LWD
- [x] Click "Add contact" without Ledger Sync active → Ledger Sync intro modal appears
- [x] Verify 24px bottom padding below the buttons

[LIVE-37003]: https://ledgerhq.atlassian.net/browse/LIVE-37003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ