### PR TITLE
[LWDM] chore(coin-celo): move `stakingSupported` to `BridgeApi`

### DIFF
--- a/.changeset/modern-rats-bake.md
+++ b/.changeset/modern-rats-bake.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-celo": patch
+"@ledgerhq/live-common": patch
+---
+
+chore(coin-celo): move `stakingSupported` to `BridgeApi`

--- a/libs/coin-modules/coin-celo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-celo/src/api/index.test.ts
@@ -22,9 +22,6 @@ jest.mock("@ledgerhq/coin-evm/api/index", () => {
   const evmApiStub: Record<string, unknown> = Object.fromEntries(
     methods.map(name => [name, jest.fn()]),
   );
-  // coin-evm advertises EVM-staking support for Celo; the Celo api now implements
-  // its own (LockedGold + Election) staking and advertises stakingSupported: true.
-  evmApiStub.stakingSupported = true;
   return { createApi: jest.fn(() => evmApiStub) };
 });
 
@@ -103,7 +100,6 @@ describe("createApi", () => {
     const api = createApi("celo");
     const evmApi = (createEvmApi as jest.Mock).mock.results[0].value;
 
-    expect((api as { stakingSupported?: boolean }).stakingSupported).toBe(true);
     expect(typeof api.getStakes).toBe("function");
     expect(typeof api.getValidators).toBe("function");
     expect(typeof api.getRewards).toBe("function");

--- a/libs/coin-modules/coin-celo/src/api/index.ts
+++ b/libs/coin-modules/coin-celo/src/api/index.ts
@@ -45,7 +45,7 @@ const prefixHex = (hex: string): `0x${string}` =>
  * `validateIntent` handles staking then delegates the rest to coin-evm.
  */
 // Checked against CoinModuleImpl with `satisfies` rather than annotated as it, so the precise shape
-// survives — including `stakingSupported`, which is not part of the API surface.
+// survives
 //
 // `craftRawTransaction` is the one capability neither this module nor the EVM api it composes
 // provides, so it is absent here; the consumer resolver applies `withDefaults`, which answers
@@ -66,7 +66,7 @@ export function createApi(currencyId = "celo") {
   > &
     Required<Pick<CoinModuleApi<EvmConfigInfo, MemoNotSupported, BufferTxData>, "validateIntent">>;
 
-  const api = {
+  return {
     ...typedEvmApi,
     craftTransaction: (
       _context: CeloContext,
@@ -98,7 +98,6 @@ export function createApi(currencyId = "celo") {
       _context: CeloContext,
       _options?: { cursor?: Cursor },
     ): Promise<Page<Validator>> => getValidators(),
-    stakingSupported: true,
     validateIntent: (
       context: CeloContext,
       intent: TransactionIntent<MemoNotSupported, BufferTxData>,
@@ -108,11 +107,7 @@ export function createApi(currencyId = "celo") {
       isCeloStakingIntent(intent)
         ? validateStakingIntent(intent, balances, options?.customFees)
         : typedEvmApi.validateIntent(context, intent, balances, options),
-  } satisfies CoinModuleImpl<EvmConfigInfo, MemoNotSupported, BufferTxData> & {
-    stakingSupported?: boolean;
-  };
-
-  return api;
+  } satisfies CoinModuleImpl<EvmConfigInfo, MemoNotSupported, BufferTxData>;
 }
 
 export default createApi;

--- a/libs/ledger-live-common/src/families/celo/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/celo/bridge/api.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
-import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { CryptoCurrency, getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
-import { computeIntentType, getAssetFromToken, getTokenFromAsset } from "./api";
+import celoBridge, { computeIntentType, getAssetFromToken, getTokenFromAsset } from "./api";
 
 jest.mock("@ledgerhq/ledger-wallet-framework/cryptoAssetsStore");
 
@@ -100,6 +100,15 @@ describe("celo bridge", () => {
         assetOwner: owner,
         name: "Celo Dollar",
         unit: mockToken.units[0],
+      });
+    });
+  });
+
+  describe("staking", () => {
+    it("includes staking configuration", () => {
+      expect(celoBridge({} as unknown as CryptoCurrency)).toMatchObject({
+        stakingSupported: true,
+        usesStakingPositions: true,
       });
     });
   });

--- a/libs/ledger-live-common/src/families/celo/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/celo/bridge/api.ts
@@ -80,6 +80,7 @@ export default function celoBridge(currency: CryptoCurrency): BridgeApi {
     getAssetFromToken: (token: TokenCurrency, owner: string) => getAssetFromToken(token, owner),
     computeIntentType: (transaction: Record<string, unknown>) => computeIntentType(transaction),
     balanceOptions: getBalanceOptions(currency),
+    stakingSupported: true,
     // Celo votes + pending withdrawals are surfaced per-position (via Balance.stake),
     // not as the EVM-style aggregate; see coin-celo src/api/getBalance.ts.
     usesStakingPositions: true,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Property belongs to `BridgeApi`, not `CoinModuleApi`.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
