### PR TITLE
feat(analytics): add screenRefs to shared analytics package (LIVE-37162)

### DIFF
--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -99,5 +99,7 @@ import {
 
 Tracking routes are used in analytics to provide props like `page` and `source`. They are **ref objects** (similar to React refs) e.g. `currentRouteNameRef.current`.
 
+`track()` adds `page` from `getCurrentTrackingPage()` when a current page is set. Callers can still pass their own `page`.
+
 - Exporting the raw refs is **interim** – [LIVE-36002](https://ledgerhq.atlassian.net/browse/LIVE-36002) narrows this to a function-only API
 - Names are overly-varied (`screenRef`, `routeName` and `trackingSource`) – [LIVE-37304](https://ledgerhq.atlassian.net/browse/LIVE-37304) addresses ambigious names and duplicate logic

--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]
 >
-> **Status: WIP** — New package for LIVE-37157. Delete this note once the work is complete.
+> **Status: UNSTABLE** — New package for LIVE-37157. Delete this note once the work is complete.
 
 Shared `track` for Ledger Wallet apps. Each app registers its own analytics client (e.g. Segment), consent check, and extra props.
 
@@ -86,3 +86,18 @@ analyticsEvents$.subscribe((event) => {
 
 // { appVersion: "1.2.3", theme: "light" },
 ```
+
+### Screen refs
+
+```ts
+import {
+  currentRouteNameRef,
+  getCurrentTrackingPage,
+  setTrackingSource,
+} from "@shared/analytics";
+```
+
+Tracking routes are used in analytics to provide props like `page` and `source`. They are **ref objects** (similar to React refs) e.g. `currentRouteNameRef.current`.
+
+- Exporting the raw refs is **interim** – [LIVE-36002](https://ledgerhq.atlassian.net/browse/LIVE-36002) narrows this to a function-only API
+- Names are overly-varied (`screenRef`, `routeName` and `trackingSource`) – [LIVE-37304](https://ledgerhq.atlassian.net/browse/LIVE-37304) addresses ambigious names and duplicate logic

--- a/shared/analytics/src/index.ts
+++ b/shared/analytics/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./analyticsEvents";
 export * from "./registry";
+export * from "./screenRefs";
 export * from "./track";
 export type * from "./types";

--- a/shared/analytics/src/screenRefs.test.ts
+++ b/shared/analytics/src/screenRefs.test.ts
@@ -1,0 +1,47 @@
+import {
+  currentRouteNameRef,
+  getCurrentTrackingPage,
+  getPreviousTrackingPage,
+  previousRouteNameRef,
+  setTrackingSource,
+} from "./screenRefs";
+
+beforeEach(() => {
+  currentRouteNameRef.current = undefined;
+  previousRouteNameRef.current = undefined;
+});
+
+describe("screenRefs", () => {
+  it("normalizes an unknown page to an empty string", () => {
+    expect(getCurrentTrackingPage()).toBe("");
+    expect(getPreviousTrackingPage()).toBe("");
+  });
+
+  it("normalizes a null page to an empty string", () => {
+    currentRouteNameRef.current = null;
+
+    expect(getCurrentTrackingPage()).toBe("");
+  });
+
+  it("reads the refs through the getters", () => {
+    currentRouteNameRef.current = "Market";
+    previousRouteNameRef.current = "Portfolio";
+
+    expect(getCurrentTrackingPage()).toBe("Market");
+    expect(getPreviousTrackingPage()).toBe("Portfolio");
+  });
+
+  it("overrides the current page through setTrackingSource", () => {
+    setTrackingSource("Send Flow");
+
+    expect(currentRouteNameRef.current).toBe("Send Flow");
+  });
+
+  it("clears the current page when setTrackingSource is called without a source", () => {
+    currentRouteNameRef.current = "Send Flow";
+
+    setTrackingSource();
+
+    expect(getCurrentTrackingPage()).toBe("");
+  });
+});

--- a/shared/analytics/src/screenRefs.ts
+++ b/shared/analytics/src/screenRefs.ts
@@ -1,0 +1,13 @@
+import type { TrackingRouteRef } from "./types";
+
+export const previousRouteNameRef: TrackingRouteRef = { current: undefined };
+export const currentRouteNameRef: TrackingRouteRef = { current: undefined };
+
+/** Route names for analytics, normalized to "" when unknown. */
+export const getCurrentTrackingPage = (): string => currentRouteNameRef.current ?? "";
+export const getPreviousTrackingPage = (): string => previousRouteNameRef.current ?? "";
+
+/** Override the page name further screen events will report as their `source`. */
+export const setTrackingSource = (source?: string): void => {
+  currentRouteNameRef.current = source;
+};

--- a/shared/analytics/src/track.test.ts
+++ b/shared/analytics/src/track.test.ts
@@ -3,6 +3,7 @@ jest.mock("./internals/trackEvent", () => ({
 }));
 
 import { setEnabledFn } from "./registry";
+import { currentRouteNameRef } from "./screenRefs";
 import { trackEvent } from "./internals/trackEvent";
 import { track } from "./track";
 
@@ -13,6 +14,7 @@ const register = () => {
 beforeEach(() => {
   jest.mocked(trackEvent).mockReset();
   setEnabledFn(() => true);
+  currentRouteNameRef.current = undefined;
 });
 
 describe("track", () => {
@@ -85,5 +87,33 @@ describe("track", () => {
 
     expect(result).toBeUndefined();
     expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("injects the current tracking page if it has been set", () => {
+    register();
+    currentRouteNameRef.current = "Page Market";
+
+    track("Analytics Event", { event: "props" });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "track",
+      "Analytics Event",
+      { page: "Page Market", event: "props" },
+      { mandatory: false },
+    );
+  });
+
+  it("allows caller to override page prop", () => {
+    register();
+    currentRouteNameRef.current = "Page from ref";
+
+    track("Analytics Event", { page: "Page from event", event: "props" });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "track",
+      "Analytics Event",
+      { page: "Page from event", event: "props" },
+      { mandatory: false },
+    );
   });
 });

--- a/shared/analytics/src/track.ts
+++ b/shared/analytics/src/track.ts
@@ -14,6 +14,7 @@
 
 import { normalizeProps } from "./internals/normalizeProps";
 import { isEnabled } from "./registry";
+import { getCurrentTrackingPage } from "./screenRefs";
 import { trackEvent } from "./internals/trackEvent";
 import type { Props, TrackOptions } from "./types";
 
@@ -23,6 +24,11 @@ export function track(
   { mandatory = false }: TrackOptions = {},
 ): void | Promise<void> {
   if (mandatory || isEnabled()) {
-    return trackEvent("track", event, normalizeProps(props), { mandatory });
+    const normalizedProps = normalizeProps(props);
+    const page = getCurrentTrackingPage();
+
+    return trackEvent("track", event, page ? { page, ...normalizedProps } : normalizedProps, {
+      mandatory,
+    });
   }
 }

--- a/shared/analytics/src/types.ts
+++ b/shared/analytics/src/types.ts
@@ -35,3 +35,5 @@ export type PropsFilter = (props: Props) => Props;
 export type TrackOptions = {
   mandatory?: boolean;
 };
+
+export type TrackingRouteRef = { current: string | null | undefined };


### PR DESCRIPTION
### 📝 Description

- Desktop and Mobile currently maintain a set of "screen refs" for tracking the route used by analytics
- These changes add a replacement for that duplicate code to the shared package
- The value of the current page is added to the tracking payload if it is set – this matches existing in-app behaviour

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-37162](https://ledgerhq.atlassian.net/browse/LIVE-37162)


[LIVE-37162]: https://ledgerhq.atlassian.net/browse/LIVE-37162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ