### PR TITLE
feat(device-onboarding): add the five actors

### DIFF
--- a/.changeset/LIVE-36060-device-onboarding-actors.md
+++ b/.changeset/LIVE-36060-device-onboarding-actors.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-onboarding": minor
+---
+
+Add the device state, genuine check, firmware check, early check toggle and seed polling actors

--- a/libs/device-onboarding/README.md
+++ b/libs/device-onboarding/README.md
@@ -24,6 +24,42 @@ session open when the machine exits.
   used by the future state machine.
 - `DeviceOnboardingOutput` identifies the connected device and the reason the machine exited.
 - `sessionListener` maps DMK session status changes to onboarding events.
+- `readDeviceState`, `genuineCheck`, `firmwareCheck`, `toggleEarlyCheck`, and `seedPolling` are the
+  actors the machine invokes to interrogate the device. Each reports through events only.
+- `withRetries` and `createRetryPolicy` back the retries of the first three, so a failure event
+  from them means the retries are exhausted. An actor accepts a `retryPolicy` to override them.
+- `ToggleEarlyCheckCommand` carries the `e0 03` APDU. DMK exposes no such command and the ticket
+  that was to add one was abandoned, so this is the one piece of device knowledge the package
+  holds on its own. It is meant to be deleted, not built on: import DMK's the day it ships one.
+
+`readDeviceState` reports `DEVICE_STATE_UNREADABLE` rather than a failure when the onboarding step
+is missing, since `isOnboarded` stays usable, and `seedPolling` stays quiet in that case. The
+catalogue version of DMK decodes no step, so that is the answer for every device until it does.
+
+The step names in `OnboardingStep` are DMK's own, so reading one is a membership check and this
+package holds no copy of the decoding. The seed word count is validated the same way, against the
+three lengths the product supports.
+
+Every genuine check failure carries the raw failure DMK returned, as `FIRMWARE_UPDATE_AVAILABLE`
+carries `update`. The machine never reads it: `genuineFailed` is one state but not one screen, and
+an unreachable backend and a forced My Ledger provider both arrive as an `HttpFetchApiError`, so
+only the app, which holds the provider setting, can resolve which drawer to open.
+
+`toggleEarlyCheck` never fails: the on-device screen is a courtesy, so a device that left the
+welcome step, a firmware that does not know the APDU and a transport error all report
+`EARLY_CHECK_UNAVAILABLE` and leave the checks themselves still to run.
+
+## What `src/device/` holds
+
+Four files, none of them onboarding policy, each of them shared by two actors so that inlining one
+would mean writing it twice. `onboardingState.ts` sends `GetOsVersion` and reads the answer as a
+`DeviceOnboardingState`, answering `null` for as long as the onboarding step and the seed progress
+are absent from DMK's response type, and compares two of them for the poller. `deviceAction.ts`
+turns a device action, an observable of intermediate states, into the promise the retry helper can
+wrap. `errors.ts` tells a refusal, a lost secure channel and an unreachable catalogue apart by tag,
+since `HttpFetchApiError` and `WebSocketConnectionError` are not on DMK's barrel.
+`toggleEarlyCheckCommand.ts` is the `e0 03` command itself. Keeping them here is what lets
+`src/actors/` read as onboarding policy alone.
 
 ## Validation
 

--- a/libs/device-onboarding/README.md
+++ b/libs/device-onboarding/README.md
@@ -30,7 +30,7 @@ session open when the machine exits.
   from them means the retries are exhausted. An actor accepts a `retryPolicy` to override them.
 - `ToggleEarlyCheckCommand` carries the `e0 03` APDU. DMK exposes no such command and the ticket
   that was to add one was abandoned, so this is the one piece of device knowledge the package
-  holds on its own. It is meant to be deleted, not built on: import DMK's the day it ships one.
+  holds on its own. It is meant to be deleted, not built on: import DMK's command once it ships.
 
 `readDeviceState` reports `DEVICE_STATE_UNREADABLE` rather than a failure when the onboarding step
 is missing, since `isOnboarded` stays usable, and `seedPolling` stays quiet in that case. The

--- a/libs/device-onboarding/src/actors/firmwareCheck.test.ts
+++ b/libs/device-onboarding/src/actors/firmwareCheck.test.ts
@@ -1,0 +1,189 @@
+import {
+  DeviceActionStatus,
+  GetDeviceMetadataDeviceAction,
+  UnknownDAError,
+  type GetDeviceMetadataDAError,
+  type GetDeviceMetadataDAIntermediateValue,
+  type GetDeviceMetadataDAOutput,
+} from "@ledgerhq/device-management-kit";
+import { isCatalogueUnreachable } from "../device/errors";
+import { createRetryPolicy } from "../retry";
+import { runActor, settle } from "../tests/actorHarness";
+import { createFakeDeviceActionDmk, type FakeDeviceActionDmk } from "../tests/fakeDmk";
+import type { AvailableFirmwareUpdate } from "../types";
+import { firmwareCheck, mapFirmwareMetadata, type FirmwareCheckEvent } from "./firmwareCheck";
+
+type FakeFirmwareCheckDmk = FakeDeviceActionDmk<
+  GetDeviceMetadataDAOutput,
+  GetDeviceMetadataDAError,
+  GetDeviceMetadataDAIntermediateValue
+>;
+
+const availableUpdate = {
+  mcuUpdateRequired: false,
+  finalFirmware: { version: "1.5.0" },
+} as unknown as AvailableFirmwareUpdate;
+const catalogueUnreachable = { _tag: "FetchError" } as GetDeviceMetadataDAError;
+
+describe("mapFirmwareMetadata", () => {
+  it("reports an available update", () => {
+    expect(mapFirmwareMetadata(metadata(availableUpdate))).toEqual({
+      type: "FIRMWARE_UPDATE_AVAILABLE",
+      update: availableUpdate,
+    });
+  });
+
+  it("reports a device already up to date", () => {
+    expect(mapFirmwareMetadata(metadata(undefined))).toEqual({ type: "FIRMWARE_UP_TO_DATE" });
+  });
+});
+
+describe("firmwareCheck", () => {
+  it("reads the metadata of a device that is not onboarded yet", () => {
+    const fake = createFake();
+    const { stop } = start(fake);
+
+    expect(fake.executeDeviceAction).toHaveBeenCalledWith({
+      sessionId: "session",
+      deviceAction: expect.any(GetDeviceMetadataDeviceAction),
+    });
+    expect(fake.executeDeviceAction.mock.calls[0][0].deviceAction.input).toEqual({
+      useSecureChannel: true,
+      forceUpdate: false,
+      allowNonOnboardedDevice: true,
+    });
+    stop();
+  });
+
+  it("reports the available update of an outdated device", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    complete(fake, availableUpdate);
+    await settle();
+
+    expect(received).toEqual([{ type: "FIRMWARE_UPDATE_AVAILABLE", update: availableUpdate }]);
+    stop();
+  });
+
+  it("reports a device already up to date", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    complete(fake, undefined);
+    await settle();
+
+    expect(received).toEqual([{ type: "FIRMWARE_UP_TO_DATE" }]);
+    stop();
+  });
+
+  it("reports a failed metadata read as a failed check", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fail(fake, new UnknownDAError());
+    await settle();
+
+    expect(fake.executions).toHaveLength(1);
+    expect(received).toEqual([{ type: "FIRMWARE_CHECK_FAILED" }]);
+    stop();
+  });
+
+  it("reports a stopped device action as a failed check", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fake.lastExecution().states.next({ status: DeviceActionStatus.Stopped });
+    await settle();
+
+    expect(received).toEqual([{ type: "FIRMWARE_CHECK_FAILED" }]);
+    stop();
+  });
+
+  it("retries an unreachable catalogue until it answers", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fail(fake, catalogueUnreachable);
+    await settle();
+    complete(fake, undefined);
+    await settle();
+
+    expect(fake.executions).toHaveLength(2);
+    expect(received).toEqual([{ type: "FIRMWARE_UP_TO_DATE" }]);
+    stop();
+  });
+
+  it("fails only once the retries are exhausted", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      fail(fake, catalogueUnreachable);
+      await settle();
+    }
+
+    expect(fake.executions).toHaveLength(3);
+    expect(received).toEqual([{ type: "FIRMWARE_CHECK_FAILED" }]);
+    stop();
+  });
+
+  it("cancels the device action and unsubscribes when the actor stops", () => {
+    const fake = createFake();
+    const { stop } = start(fake);
+    const { states, cancel } = fake.lastExecution();
+
+    expect(states.observed).toBe(true);
+
+    stop();
+
+    expect(states.observed).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports nothing once the actor is stopped", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+    const execution = fake.lastExecution();
+
+    stop();
+    execution.states.next({
+      status: DeviceActionStatus.Completed,
+      output: metadata(undefined),
+    });
+    await settle();
+
+    expect(received).toEqual([]);
+  });
+});
+
+function metadata(update: AvailableFirmwareUpdate | undefined): GetDeviceMetadataDAOutput {
+  return { firmwareUpdateContext: { availableUpdate: update } } as GetDeviceMetadataDAOutput;
+}
+
+function createFake(): FakeFirmwareCheckDmk {
+  return createFakeDeviceActionDmk<
+    GetDeviceMetadataDAOutput,
+    GetDeviceMetadataDAError,
+    GetDeviceMetadataDAIntermediateValue
+  >();
+}
+
+function start(fake: FakeFirmwareCheckDmk) {
+  return runActor<FirmwareCheckEvent>(firmwareCheck, {
+    dmk: fake.dmk,
+    sessionId: "session",
+    retryPolicy: { ...createRetryPolicy(isCatalogueUnreachable), delaysMs: [0, 0] },
+  });
+}
+
+function complete(fake: FakeFirmwareCheckDmk, update: AvailableFirmwareUpdate | undefined) {
+  fake.lastExecution().states.next({
+    status: DeviceActionStatus.Completed,
+    output: metadata(update),
+  });
+}
+
+function fail(fake: FakeFirmwareCheckDmk, error: GetDeviceMetadataDAError) {
+  fake.lastExecution().states.next({ status: DeviceActionStatus.Error, error });
+}

--- a/libs/device-onboarding/src/actors/firmwareCheck.ts
+++ b/libs/device-onboarding/src/actors/firmwareCheck.ts
@@ -1,0 +1,70 @@
+import {
+  GetDeviceMetadataDeviceAction,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type GetDeviceMetadataDAError,
+  type GetDeviceMetadataDAIntermediateValue,
+  type GetDeviceMetadataDAOutput,
+} from "@ledgerhq/device-management-kit";
+import { fromCallback } from "xstate";
+import { createDeviceActionRunner } from "../device/deviceAction";
+import { isCatalogueUnreachable } from "../device/errors";
+import { createRetryPolicy, withRetries, type RetryPolicy } from "../retry";
+import type { OnboardingEvent } from "../types";
+
+export type FirmwareCheckEvent = Extract<
+  OnboardingEvent,
+  { type: "FIRMWARE_UP_TO_DATE" | "FIRMWARE_UPDATE_AVAILABLE" | "FIRMWARE_CHECK_FAILED" }
+>;
+
+export type FirmwareCheckInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  retryPolicy?: RetryPolicy;
+};
+
+export function mapFirmwareMetadata(metadata: GetDeviceMetadataDAOutput): FirmwareCheckEvent {
+  const { availableUpdate } = metadata.firmwareUpdateContext;
+
+  return availableUpdate === undefined
+    ? { type: "FIRMWARE_UP_TO_DATE" }
+    : { type: "FIRMWARE_UPDATE_AVAILABLE", update: availableUpdate };
+}
+
+export const firmwareCheck = fromCallback<FirmwareCheckEvent, FirmwareCheckInput>(
+  ({ input, sendBack }) => {
+    let stopped = false;
+
+    const runner = createDeviceActionRunner<
+      GetDeviceMetadataDAOutput,
+      GetDeviceMetadataDAError,
+      GetDeviceMetadataDAIntermediateValue
+    >(() =>
+      input.dmk.executeDeviceAction({
+        sessionId: input.sessionId,
+        deviceAction: new GetDeviceMetadataDeviceAction({
+          input: { useSecureChannel: true, forceUpdate: false, allowNonOnboardedDevice: true },
+        }),
+      }),
+    );
+
+    const policy = input.retryPolicy ?? createRetryPolicy(isCatalogueUnreachable);
+
+    withRetries(runner.run, policy, { isCancelled: () => stopped })
+      .then(metadata => {
+        if (!stopped) {
+          sendBack(mapFirmwareMetadata(metadata));
+        }
+      })
+      .catch(() => {
+        if (!stopped) {
+          sendBack({ type: "FIRMWARE_CHECK_FAILED" });
+        }
+      });
+
+    return () => {
+      stopped = true;
+      runner.stop();
+    };
+  },
+);

--- a/libs/device-onboarding/src/actors/genuineCheck.test.ts
+++ b/libs/device-onboarding/src/actors/genuineCheck.test.ts
@@ -1,0 +1,251 @@
+import {
+  DeviceActionStatus,
+  GenuineCheckDeviceAction,
+  RefusedByUserDAError,
+  SecureChannelError,
+  UnknownDAError,
+  UserInteractionRequired,
+  type GenuineCheckDAError,
+  type GenuineCheckDAIntermediateValue,
+  type GenuineCheckDAOutput,
+} from "@ledgerhq/device-management-kit";
+import { DeviceActionStoppedError } from "../device/deviceAction";
+import { isCatalogueUnreachable } from "../device/errors";
+import { createRetryPolicy } from "../retry";
+import { runActor, settle } from "../tests/actorHarness";
+import { createFakeDeviceActionDmk, type FakeDeviceActionDmk } from "../tests/fakeDmk";
+import { genuineCheck, mapGenuineCheckFailure, type GenuineCheckEvent } from "./genuineCheck";
+
+type FakeGenuineCheckDmk = FakeDeviceActionDmk<
+  GenuineCheckDAOutput,
+  GenuineCheckDAError,
+  GenuineCheckDAIntermediateValue
+>;
+
+const webSocketConnectionError = { _tag: "WebSocketConnectionError" } as GenuineCheckDAError;
+const catalogueUnreachable = { _tag: "FetchError" } as GenuineCheckDAError;
+
+describe("mapGenuineCheckFailure", () => {
+  it("reports a refusal on the device as a refusal", () => {
+    const error = new RefusedByUserDAError();
+
+    expect(mapGenuineCheckFailure(error)).toEqual({
+      type: "GENUINE_CHECK_REFUSED",
+      failure: error,
+    });
+  });
+
+  it.each([
+    ["a secure channel error", new SecureChannelError(new Error("closed"))],
+    ["a websocket error", webSocketConnectionError],
+  ])("reports %s as a lost secure channel", (_, error) => {
+    expect(mapGenuineCheckFailure(error)).toEqual({ type: "SECURE_CHANNEL_LOST", failure: error });
+  });
+
+  it.each([
+    ["an unknown device action error", new UnknownDAError()],
+    ["an unreachable catalogue", catalogueUnreachable],
+    ["an error without a tag", new Error("boom")],
+  ])("reports %s as a failure", (_, error) => {
+    expect(mapGenuineCheckFailure(error)).toEqual({ type: "GENUINE_CHECK_FAILED", failure: error });
+  });
+
+  it.each([
+    ["a refusal", new RefusedByUserDAError()],
+    ["a lost secure channel", new SecureChannelError(new Error("closed"))],
+    ["an unreachable catalogue", catalogueUnreachable],
+  ])("hands the app %s untouched rather than a copy of it", (_, error) => {
+    expect(mapGenuineCheckFailure(error).failure).toBe(error);
+  });
+});
+
+describe("genuineCheck", () => {
+  it("checks a device that is not onboarded yet", () => {
+    const fake = createFake();
+    const { stop } = start(fake);
+
+    expect(fake.executeDeviceAction).toHaveBeenCalledWith({
+      sessionId: "session",
+      deviceAction: expect.any(GenuineCheckDeviceAction),
+    });
+    expect(fake.executeDeviceAction.mock.calls[0][0].deviceAction.input).toEqual({
+      allowNonOnboardedDevice: true,
+    });
+    stop();
+  });
+
+  it("reports a genuine device as passed", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    complete(fake, true);
+    await settle();
+
+    expect(received).toEqual([{ type: "GENUINE_CHECK_PASSED" }]);
+    stop();
+  });
+
+  it("reports a device that is not genuine, carrying the verdict it was given", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    complete(fake, false);
+    await settle();
+
+    expect(received).toEqual([{ type: "DEVICE_NOT_GENUINE", failure: { isGenuine: false } }]);
+    stop();
+  });
+
+  it("asks the user to allow the secure connection", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    pending(fake, UserInteractionRequired.UnlockDevice);
+    pending(fake, UserInteractionRequired.AllowSecureConnection);
+    await settle();
+
+    expect(received).toEqual([{ type: "ALLOW_SECURE_CONNECTION_REQUESTED" }]);
+    stop();
+  });
+
+  it.each([
+    ["a refusal on the device", "GENUINE_CHECK_REFUSED", new RefusedByUserDAError()],
+    ["a lost secure channel", "SECURE_CHANNEL_LOST", new SecureChannelError(new Error("closed"))],
+    ["a lost websocket", "SECURE_CHANNEL_LOST", webSocketConnectionError],
+    ["an unknown error", "GENUINE_CHECK_FAILED", new UnknownDAError()],
+  ])("reports %s as %s", async (_, type, error) => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fail(fake, error as GenuineCheckDAError);
+    await settle();
+
+    expect(received).toEqual([{ type, failure: error }]);
+    stop();
+  });
+
+  it("reports a stopped device action as a failure", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fake.lastExecution().states.next({ status: DeviceActionStatus.Stopped });
+    await settle();
+
+    expect(received).toEqual([
+      { type: "GENUINE_CHECK_FAILED", failure: expect.any(DeviceActionStoppedError) },
+    ]);
+    stop();
+  });
+
+  it("retries an unreachable catalogue until it answers", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fail(fake, catalogueUnreachable);
+    await settle();
+    complete(fake, true);
+    await settle();
+
+    expect(fake.executions).toHaveLength(2);
+    expect(received).toEqual([{ type: "GENUINE_CHECK_PASSED" }]);
+    stop();
+  });
+
+  it("fails only once the retries are exhausted", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      fail(fake, catalogueUnreachable);
+      await settle();
+    }
+
+    expect(fake.executions).toHaveLength(3);
+    expect(received).toEqual([{ type: "GENUINE_CHECK_FAILED", failure: catalogueUnreachable }]);
+    stop();
+  });
+
+  it("does not start another device action when it is stopped during a retry delay", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+
+    fail(fake, catalogueUnreachable);
+    stop();
+    await settle();
+
+    expect(fake.executions).toHaveLength(1);
+    expect(received).toEqual([]);
+  });
+
+  it("does not retry an error the policy rejects", async () => {
+    const fake = createFake();
+    const { stop } = start(fake);
+
+    fail(fake, new UnknownDAError());
+    await settle();
+
+    expect(fake.executions).toHaveLength(1);
+    stop();
+  });
+
+  it("cancels the device action and unsubscribes when the actor stops", () => {
+    const fake = createFake();
+    const { stop } = start(fake);
+    const { states, cancel } = fake.lastExecution();
+
+    expect(states.observed).toBe(true);
+
+    stop();
+
+    expect(states.observed).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports nothing once the actor is stopped", async () => {
+    const fake = createFake();
+    const { received, stop } = start(fake);
+    const execution = fake.lastExecution();
+
+    stop();
+    execution.states.next({ status: DeviceActionStatus.Completed, output: { isGenuine: true } });
+    await settle();
+
+    expect(received).toEqual([]);
+  });
+});
+
+function createFake(): FakeGenuineCheckDmk {
+  return createFakeDeviceActionDmk<
+    GenuineCheckDAOutput,
+    GenuineCheckDAError,
+    GenuineCheckDAIntermediateValue
+  >();
+}
+
+function start(fake: FakeGenuineCheckDmk) {
+  return runActor<GenuineCheckEvent>(genuineCheck, {
+    dmk: fake.dmk,
+    sessionId: "session",
+    retryPolicy: { ...createRetryPolicy(isCatalogueUnreachable), delaysMs: [0, 0] },
+  });
+}
+
+function complete(fake: FakeGenuineCheckDmk, isGenuine: boolean) {
+  fake.lastExecution().states.next({
+    status: DeviceActionStatus.Completed,
+    output: { isGenuine },
+  });
+}
+
+function pending(fake: FakeGenuineCheckDmk, requiredUserInteraction: UserInteractionRequired) {
+  fake.lastExecution().states.next({
+    status: DeviceActionStatus.Pending,
+    intermediateValue: {
+      requiredUserInteraction,
+    } as GenuineCheckDAIntermediateValue,
+  });
+}
+
+function fail(fake: FakeGenuineCheckDmk, error: GenuineCheckDAError) {
+  fake.lastExecution().states.next({ status: DeviceActionStatus.Error, error });
+}

--- a/libs/device-onboarding/src/actors/genuineCheck.ts
+++ b/libs/device-onboarding/src/actors/genuineCheck.ts
@@ -1,0 +1,99 @@
+import {
+  GenuineCheckDeviceAction,
+  UserInteractionRequired,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type GenuineCheckDAError,
+  type GenuineCheckDAIntermediateValue,
+  type GenuineCheckDAOutput,
+} from "@ledgerhq/device-management-kit";
+import { fromCallback } from "xstate";
+import { createDeviceActionRunner } from "../device/deviceAction";
+import { isCatalogueUnreachable, isDeviceRefusal, isSecureChannelLost } from "../device/errors";
+import { createRetryPolicy, withRetries, type RetryPolicy } from "../retry";
+import type { GenuineCheckFailure, OnboardingEvent } from "../types";
+
+export type GenuineCheckEvent = Extract<
+  OnboardingEvent,
+  {
+    type:
+      | "ALLOW_SECURE_CONNECTION_REQUESTED"
+      | "GENUINE_CHECK_PASSED"
+      | "GENUINE_CHECK_REFUSED"
+      | "GENUINE_CHECK_FAILED"
+      | "DEVICE_NOT_GENUINE"
+      | "SECURE_CHANNEL_LOST";
+  }
+>;
+
+export type GenuineCheckFailureEvent = Extract<GenuineCheckEvent, { failure: GenuineCheckFailure }>;
+
+export type GenuineCheckInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  retryPolicy?: RetryPolicy;
+};
+
+export function mapGenuineCheckFailure(error: unknown): GenuineCheckFailureEvent {
+  if (isDeviceRefusal(error)) {
+    return { type: "GENUINE_CHECK_REFUSED", failure: error };
+  }
+
+  if (isSecureChannelLost(error)) {
+    return { type: "SECURE_CHANNEL_LOST", failure: error };
+  }
+
+  return { type: "GENUINE_CHECK_FAILED", failure: error };
+}
+
+export const genuineCheck = fromCallback<GenuineCheckEvent, GenuineCheckInput>(
+  ({ input, sendBack }) => {
+    let stopped = false;
+
+    const runner = createDeviceActionRunner<
+      GenuineCheckDAOutput,
+      GenuineCheckDAError,
+      GenuineCheckDAIntermediateValue
+    >(
+      () =>
+        input.dmk.executeDeviceAction({
+          sessionId: input.sessionId,
+          // The devices being onboarded are exactly the ones the default input rejects.
+          deviceAction: new GenuineCheckDeviceAction({
+            input: { allowNonOnboardedDevice: true },
+          }),
+        }),
+      ({ requiredUserInteraction }) => {
+        const awaitsSecureConnectionApproval =
+          requiredUserInteraction === UserInteractionRequired.AllowSecureConnection;
+
+        if (!stopped && awaitsSecureConnectionApproval) {
+          sendBack({ type: "ALLOW_SECURE_CONNECTION_REQUESTED" });
+        }
+      },
+    );
+
+    const policy = input.retryPolicy ?? createRetryPolicy(isCatalogueUnreachable);
+
+    withRetries(runner.run, policy, { isCancelled: () => stopped })
+      .then(output => {
+        if (!stopped) {
+          sendBack(
+            output.isGenuine
+              ? { type: "GENUINE_CHECK_PASSED" }
+              : { type: "DEVICE_NOT_GENUINE", failure: output },
+          );
+        }
+      })
+      .catch(error => {
+        if (!stopped) {
+          sendBack(mapGenuineCheckFailure(error));
+        }
+      });
+
+    return () => {
+      stopped = true;
+      runner.stop();
+    };
+  },
+);

--- a/libs/device-onboarding/src/actors/readDeviceState.test.ts
+++ b/libs/device-onboarding/src/actors/readDeviceState.test.ts
@@ -1,0 +1,193 @@
+import {
+  CommandResultFactory,
+  GetOsVersionCommand,
+  InvalidStatusWordError,
+  type DeviceManagementKit,
+  type GetOsVersionResponse,
+} from "@ledgerhq/device-management-kit";
+import { createRetryPolicy } from "../retry";
+import { runActor, settle } from "../tests/actorHarness";
+import { createFakeCommandDmk, type ScriptedCommand } from "../tests/fakeDmk";
+import { createOsVersionResponse, type OsVersionResponseOptions } from "../tests/osVersionResponse";
+import { OnboardingStep, type DeviceOnboardingState } from "../types";
+import { mapDeviceState, readDeviceState, type ReadDeviceStateEvent } from "./readDeviceState";
+
+const onboardedDevice: OsVersionResponseOptions = {
+  onboardingState: "device-is-ready",
+  numberOfWords: 24,
+  currentWordIndex: 0,
+  isOnboarded: true,
+  isSecureConnectionAllowed: true,
+};
+
+const onboardedDeviceState: DeviceOnboardingState = {
+  isOnboarded: true,
+  isInRecoveryMode: false,
+  managerAllowed: true,
+  currentOnboardingStep: OnboardingStep.Ready,
+  seedWordIndex: 0,
+  seedPhraseWordCount: 24,
+};
+
+describe("mapDeviceState", () => {
+  it("reports a decoded device as read", () => {
+    expect(mapDeviceState(createOsVersionResponse(onboardedDevice))).toEqual({
+      type: "DEVICE_STATE_READ",
+      state: onboardedDeviceState,
+    });
+  });
+
+  it("takes the manager approval from the secure connection flag", () => {
+    const event = mapDeviceState(
+      createOsVersionResponse({ ...onboardedDevice, isSecureConnectionAllowed: false }),
+    );
+
+    expect(event).toMatchObject({ state: { managerAllowed: false } });
+  });
+
+  it("reports the recovery mode of a device restoring its seed", () => {
+    const event = mapDeviceState(
+      createOsVersionResponse({
+        onboardingState: "restore-recovery-phrase",
+        numberOfWords: 18,
+        currentWordIndex: 5,
+        isInRecoveryMode: true,
+      }),
+    );
+
+    expect(event).toEqual({
+      type: "DEVICE_STATE_READ",
+      state: {
+        isOnboarded: false,
+        isInRecoveryMode: true,
+        managerAllowed: false,
+        currentOnboardingStep: OnboardingStep.RestoreSeed,
+        seedWordIndex: 5,
+        seedPhraseWordCount: 18,
+      },
+    });
+  });
+
+  it("reports a bootloader before anything else", () => {
+    expect(
+      mapDeviceState(createOsVersionResponse({ ...onboardedDevice, isBootloader: true })),
+    ).toEqual({ type: "DEVICE_IN_BOOTLOADER" });
+  });
+
+  it("reports an OS updater before anything else", () => {
+    expect(mapDeviceState(createOsVersionResponse({ ...onboardedDevice, isOsu: true }))).toEqual({
+      type: "DEVICE_IN_OSU",
+    });
+  });
+
+  it("keeps the onboarding flag when the step is not recognised", () => {
+    expect(
+      mapDeviceState(
+        createOsVersionResponse({
+          ...onboardedDevice,
+          onboardingState: "a-state-we-do-not-know",
+        }),
+      ),
+    ).toEqual({
+      type: "DEVICE_STATE_UNREADABLE",
+      isOnboarded: true,
+      isInRecoveryMode: false,
+    });
+  });
+
+  it("is unreadable on the catalogue version, which decodes no step", () => {
+    expect(mapDeviceState(createOsVersionResponse())).toEqual({
+      type: "DEVICE_STATE_UNREADABLE",
+      isOnboarded: false,
+      isInRecoveryMode: false,
+    });
+  });
+});
+
+describe("readDeviceState", () => {
+  it("reports the state read from the OS version command", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([success(onboardedDevice)]);
+    const { received, stop } = start(dmk);
+
+    await settle();
+
+    expect(sendCommand).toHaveBeenCalledWith({
+      sessionId: "session",
+      command: expect.any(GetOsVersionCommand),
+    });
+    expect(received).toEqual([{ type: "DEVICE_STATE_READ", state: onboardedDeviceState }]);
+    stop();
+  });
+
+  it("retries a failed command until it answers", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([
+      { throws: new Error("transport failed") },
+      success(onboardedDevice),
+    ]);
+    const { received, stop } = start(dmk);
+
+    await settle();
+
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+    expect(received).toEqual([{ type: "DEVICE_STATE_READ", state: onboardedDeviceState }]);
+    stop();
+  });
+
+  it("fails only once the retries are exhausted", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([{ throws: new Error("transport failed") }]);
+    const { received, stop } = start(dmk);
+
+    await settle();
+
+    expect(sendCommand).toHaveBeenCalledTimes(3);
+    expect(received).toEqual([{ type: "DEVICE_STATE_FAILED" }]);
+    stop();
+  });
+
+  it("does not send the command again when it is stopped during a retry delay", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([{ throws: new Error("transport failed") }]);
+    const { received, stop } = start(dmk);
+
+    stop();
+    await settle();
+
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+    expect(received).toEqual([]);
+  });
+
+  it("fails when the device answers with an error status word", async () => {
+    const { dmk } = createFakeCommandDmk([
+      CommandResultFactory({ error: new InvalidStatusWordError("6a80") }),
+    ]);
+    const { received, stop } = start(dmk);
+
+    await settle();
+
+    expect(received).toEqual([{ type: "DEVICE_STATE_FAILED" }]);
+    stop();
+  });
+
+  it("reports nothing once the actor is stopped", async () => {
+    const { dmk } = createFakeCommandDmk([success(onboardedDevice)]);
+    const { received, stop } = start(dmk);
+
+    stop();
+    await settle();
+
+    expect(received).toEqual([]);
+  });
+});
+
+function success(
+  options: Parameters<typeof createOsVersionResponse>[0],
+): ScriptedCommand<GetOsVersionResponse> {
+  return CommandResultFactory({ data: createOsVersionResponse(options) });
+}
+
+function start(dmk: DeviceManagementKit) {
+  return runActor<ReadDeviceStateEvent>(readDeviceState, {
+    dmk,
+    sessionId: "session",
+    retryPolicy: { ...createRetryPolicy(() => true), delaysMs: [0, 0] },
+  });
+}

--- a/libs/device-onboarding/src/actors/readDeviceState.ts
+++ b/libs/device-onboarding/src/actors/readDeviceState.ts
@@ -1,0 +1,77 @@
+import type {
+  DeviceManagementKit,
+  DeviceSessionId,
+  GetOsVersionResponse,
+} from "@ledgerhq/device-management-kit";
+import { fromCallback } from "xstate";
+import { readOnboardingState, sendOsVersionCommand } from "../device/onboardingState";
+import { createRetryPolicy, withRetries, type RetryPolicy } from "../retry";
+import type { OnboardingEvent } from "../types";
+
+export type ReadDeviceStateEvent = Extract<
+  OnboardingEvent,
+  {
+    type:
+      | "DEVICE_STATE_READ"
+      | "DEVICE_STATE_UNREADABLE"
+      | "DEVICE_STATE_FAILED"
+      | "DEVICE_IN_BOOTLOADER"
+      | "DEVICE_IN_OSU";
+  }
+>;
+
+export type ReadDeviceStateInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  retryPolicy?: RetryPolicy;
+};
+
+export function mapDeviceState(response: GetOsVersionResponse): ReadDeviceStateEvent {
+  if (response.isBootloader) {
+    return { type: "DEVICE_IN_BOOTLOADER" };
+  }
+
+  if (response.isOsu) {
+    return { type: "DEVICE_IN_OSU" };
+  }
+
+  const state = readOnboardingState(response);
+
+  if (state === null) {
+    const flags = response.secureElementFlags;
+
+    return {
+      type: "DEVICE_STATE_UNREADABLE",
+      isOnboarded: flags.isOnboarded,
+      isInRecoveryMode: flags.isInRecoveryMode,
+    };
+  }
+
+  return { type: "DEVICE_STATE_READ", state };
+}
+
+export const readDeviceState = fromCallback<ReadDeviceStateEvent, ReadDeviceStateInput>(
+  ({ input, sendBack }) => {
+    let stopped = false;
+
+    const policy = input.retryPolicy ?? createRetryPolicy(() => true);
+
+    withRetries(() => sendOsVersionCommand(input.dmk, input.sessionId), policy, {
+      isCancelled: () => stopped,
+    })
+      .then(response => {
+        if (!stopped) {
+          sendBack(mapDeviceState(response));
+        }
+      })
+      .catch(() => {
+        if (!stopped) {
+          sendBack({ type: "DEVICE_STATE_FAILED" });
+        }
+      });
+
+    return () => {
+      stopped = true;
+    };
+  },
+);

--- a/libs/device-onboarding/src/actors/seedPolling.test.ts
+++ b/libs/device-onboarding/src/actors/seedPolling.test.ts
@@ -1,0 +1,179 @@
+import { CommandResultFactory, type DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import { runActor } from "../tests/actorHarness";
+import { createFakeCommandDmk, type ScriptedCommand } from "../tests/fakeDmk";
+import { createOsVersionResponse, type OsVersionResponseOptions } from "../tests/osVersionResponse";
+import { OnboardingStep } from "../types";
+import { defaultSeedPollingIntervalMs, seedPolling, type SeedPollingEvent } from "./seedPolling";
+
+const restoringWord = (currentWordIndex: number): OsVersionResponseOptions => ({
+  onboardingState: "restore-recovery-phrase",
+  numberOfWords: 24,
+  currentWordIndex,
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("seedPolling", () => {
+  it("reports the state read on the first poll", async () => {
+    const { dmk } = createFakeCommandDmk([reads(restoringWord(0))]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(received).toEqual([
+      {
+        type: "STEP_CHANGED",
+        state: {
+          isOnboarded: false,
+          isInRecoveryMode: false,
+          managerAllowed: false,
+          currentOnboardingStep: OnboardingStep.RestoreSeed,
+          seedWordIndex: 0,
+          seedPhraseWordCount: 24,
+        },
+      },
+    ]);
+    stop();
+  });
+
+  it("polls again after a second", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([reads(restoringWord(0))]);
+    const { stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(defaultSeedPollingIntervalMs);
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+    stop();
+  });
+
+  it("stays quiet while the state does not change", async () => {
+    const { dmk } = createFakeCommandDmk([reads(restoringWord(3))]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(3 * defaultSeedPollingIntervalMs);
+
+    expect(received).toHaveLength(1);
+    stop();
+  });
+
+  it("reports each step the user reaches", async () => {
+    const { dmk } = createFakeCommandDmk([
+      reads(restoringWord(0)),
+      reads(restoringWord(1)),
+      reads({ onboardingState: "device-is-ready", numberOfWords: 24, currentWordIndex: 23 }),
+    ]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(3 * defaultSeedPollingIntervalMs);
+
+    expect(received.map(event => event.type)).toEqual([
+      "STEP_CHANGED",
+      "STEP_CHANGED",
+      "STEP_CHANGED",
+    ]);
+    expect(received.at(-1)).toMatchObject({
+      state: { currentOnboardingStep: OnboardingStep.Ready, seedWordIndex: 23 },
+    });
+    stop();
+  });
+
+  it("stays quiet while the state cannot be decoded", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([reads({ isOnboarded: false })]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(3 * defaultSeedPollingIntervalMs);
+
+    expect(received).toEqual([]);
+    expect(sendCommand).toHaveBeenCalledTimes(4);
+    stop();
+  });
+
+  it("absorbs the failures a device being set up is expected to produce", async () => {
+    const { dmk } = createFakeCommandDmk([
+      { throws: new Error("device is locked") },
+      { throws: new Error("transport race") },
+      reads(restoringWord(2)),
+    ]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(3 * defaultSeedPollingIntervalMs);
+
+    expect(received).toEqual([expect.objectContaining({ type: "STEP_CHANGED" })]);
+    stop();
+  });
+
+  it("forgets the earlier failures once a poll answers", async () => {
+    const { dmk } = createFakeCommandDmk([
+      { throws: new Error("device is locked") },
+      { throws: new Error("device is locked") },
+      reads(restoringWord(2)),
+      { throws: new Error("device is locked") },
+      { throws: new Error("device is locked") },
+      reads(restoringWord(3)),
+    ]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(6 * defaultSeedPollingIntervalMs);
+
+    expect(received.map(event => event.type)).toEqual(["STEP_CHANGED", "STEP_CHANGED"]);
+    stop();
+  });
+
+  it("gives up on a run of consecutive failures", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([{ throws: new Error("disconnected") }]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(3 * defaultSeedPollingIntervalMs);
+
+    expect(received).toEqual([{ type: "TRANSPORT_LOST" }]);
+    expect(sendCommand).toHaveBeenCalledTimes(3);
+
+    await jest.advanceTimersByTimeAsync(5 * defaultSeedPollingIntervalMs);
+
+    expect(sendCommand).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it("never has two commands in flight", async () => {
+    const sendCommand = jest.fn(() => new Promise(() => {}));
+    const dmk = { sendCommand } as unknown as DeviceManagementKit;
+    const { stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(5 * defaultSeedPollingIntervalMs);
+
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("stops polling once the actor is stopped", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([reads(restoringWord(0))]);
+    const { received, stop } = start(dmk);
+
+    await jest.advanceTimersByTimeAsync(0);
+    stop();
+    await jest.advanceTimersByTimeAsync(5 * defaultSeedPollingIntervalMs);
+
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+    expect(received).toHaveLength(1);
+  });
+});
+
+function reads(options: OsVersionResponseOptions): ScriptedCommand<unknown> {
+  return CommandResultFactory({ data: createOsVersionResponse(options) });
+}
+
+function start(dmk: DeviceManagementKit) {
+  return runActor<SeedPollingEvent>(seedPolling, {
+    dmk,
+    sessionId: "session",
+    failureThreshold: 3,
+  });
+}

--- a/libs/device-onboarding/src/actors/seedPolling.ts
+++ b/libs/device-onboarding/src/actors/seedPolling.ts
@@ -1,0 +1,87 @@
+import type { DeviceManagementKit, DeviceSessionId } from "@ledgerhq/device-management-kit";
+import { fromCallback } from "xstate";
+import {
+  isSameOnboardingState,
+  readOnboardingState,
+  sendOsVersionCommand,
+} from "../device/onboardingState";
+import type { DeviceOnboardingState, OnboardingEvent } from "../types";
+
+export type SeedPollingEvent = Extract<
+  OnboardingEvent,
+  { type: "STEP_CHANGED" | "TRANSPORT_LOST" }
+>;
+
+export type SeedPollingInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  intervalMs?: number;
+  failureThreshold?: number;
+};
+
+export const defaultSeedPollingIntervalMs = 1000;
+export const defaultSeedPollingFailureThreshold = 3;
+
+/**
+ * The loop is chained rather than scheduled on an interval so two APDUs can never overlap, and a
+ * locked device or a disconnection is expected here: only a run of consecutive failures is worth
+ * reporting as a lost transport.
+ */
+export const seedPolling = fromCallback<SeedPollingEvent, SeedPollingInput>(
+  ({ input, sendBack }) => {
+    const intervalMs = input.intervalMs ?? defaultSeedPollingIntervalMs;
+    const failureThreshold = input.failureThreshold ?? defaultSeedPollingFailureThreshold;
+
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let lastState: DeviceOnboardingState | undefined;
+    let consecutiveFailures = 0;
+
+    const waitForNextPoll = () =>
+      new Promise<void>(resolve => {
+        timer = setTimeout(resolve, intervalMs);
+      });
+
+    const reportStateChanges = async () => {
+      const response = await sendOsVersionCommand(input.dmk, input.sessionId);
+      const state = readOnboardingState(response);
+
+      consecutiveFailures = 0;
+
+      if (state !== null && !isSameOnboardingState(lastState, state)) {
+        lastState = state;
+
+        if (!stopped) {
+          sendBack({ type: "STEP_CHANGED", state });
+        }
+      }
+    };
+
+    const poll = async () => {
+      while (!stopped) {
+        try {
+          await reportStateChanges();
+        } catch {
+          consecutiveFailures++;
+
+          if (consecutiveFailures >= failureThreshold) {
+            if (!stopped) {
+              sendBack({ type: "TRANSPORT_LOST" });
+            }
+
+            return;
+          }
+        }
+
+        await waitForNextPoll();
+      }
+    };
+
+    void poll();
+
+    return () => {
+      stopped = true;
+      clearTimeout(timer);
+    };
+  },
+);

--- a/libs/device-onboarding/src/actors/toggleEarlyCheck.test.ts
+++ b/libs/device-onboarding/src/actors/toggleEarlyCheck.test.ts
@@ -1,0 +1,83 @@
+import {
+  ApduResponse,
+  CommandResultFactory,
+  type DeviceManagementKit,
+} from "@ledgerhq/device-management-kit";
+import {
+  EarlyCheckToggle,
+  ToggleEarlyCheckCommand,
+  type ToggleEarlyCheckErrorCode,
+} from "../device/toggleEarlyCheckCommand";
+import { runActor, settle } from "../tests/actorHarness";
+import { createFakeCommandDmk, type ScriptedCommand } from "../tests/fakeDmk";
+import { toggleEarlyCheck, type ToggleEarlyCheckEvent } from "./toggleEarlyCheck";
+
+describe("toggleEarlyCheck", () => {
+  it.each([
+    ["entering", EarlyCheckToggle.Enter, 0x00],
+    ["leaving", EarlyCheckToggle.Exit, 0x01],
+  ])("sends the %s command", async (_, toggle, expectedP2) => {
+    const { dmk, sendCommand } = createFakeCommandDmk([CommandResultFactory({ data: undefined })]);
+    const { received, stop } = start(dmk, toggle);
+
+    await settle();
+
+    expect(sendCommand.mock.calls[0][0].command.getApdu().p2).toBe(expectedP2);
+    expect(received).toEqual([{ type: "EARLY_CHECK_TOGGLED" }]);
+    stop();
+  });
+
+  it.each([
+    ["the device left the welcome step", 0x69, 0x82],
+    ["the firmware does not know the APDU", 0x67, 0x00],
+    ["the status code is unexpected", 0x6e, 0x00],
+  ])("carries on when %s", async (_, first, second) => {
+    const { dmk } = createFakeCommandDmk([deviceRefuses(first, second)]);
+    const { received, stop } = start(dmk);
+
+    await settle();
+
+    expect(received).toEqual([{ type: "EARLY_CHECK_UNAVAILABLE" }]);
+    stop();
+  });
+
+  it("carries on when the transport fails", async () => {
+    const { dmk } = createFakeCommandDmk([{ throws: new Error("transport failed") }]);
+    const { received, stop } = start(dmk);
+
+    await settle();
+
+    expect(received).toEqual([{ type: "EARLY_CHECK_UNAVAILABLE" }]);
+    stop();
+  });
+
+  it("does not retry a failure", async () => {
+    const { dmk, sendCommand } = createFakeCommandDmk([{ throws: new Error("transport failed") }]);
+    const { stop } = start(dmk);
+
+    await settle();
+
+    expect(sendCommand).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("reports nothing once the actor is stopped", async () => {
+    const { dmk } = createFakeCommandDmk([CommandResultFactory({ data: undefined })]);
+    const { received, stop } = start(dmk);
+
+    stop();
+    await settle();
+
+    expect(received).toEqual([]);
+  });
+});
+
+function deviceRefuses(...statusCode: number[]): ScriptedCommand<void, ToggleEarlyCheckErrorCode> {
+  return new ToggleEarlyCheckCommand(EarlyCheckToggle.Enter).parseResponse(
+    new ApduResponse({ statusCode: Uint8Array.from(statusCode), data: new Uint8Array() }),
+  );
+}
+
+function start(dmk: DeviceManagementKit, toggle: EarlyCheckToggle = EarlyCheckToggle.Enter) {
+  return runActor<ToggleEarlyCheckEvent>(toggleEarlyCheck, { dmk, sessionId: "session", toggle });
+}

--- a/libs/device-onboarding/src/actors/toggleEarlyCheck.ts
+++ b/libs/device-onboarding/src/actors/toggleEarlyCheck.ts
@@ -1,0 +1,49 @@
+import {
+  isSuccessCommandResult,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+import { fromCallback } from "xstate";
+import { ToggleEarlyCheckCommand, type EarlyCheckToggle } from "../device/toggleEarlyCheckCommand";
+import type { OnboardingEvent } from "../types";
+
+export type ToggleEarlyCheckEvent = Extract<
+  OnboardingEvent,
+  { type: "EARLY_CHECK_TOGGLED" | "EARLY_CHECK_UNAVAILABLE" }
+>;
+
+export type ToggleEarlyCheckInput = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+  toggle: EarlyCheckToggle;
+};
+
+export const toggleEarlyCheck = fromCallback<ToggleEarlyCheckEvent, ToggleEarlyCheckInput>(
+  ({ input, sendBack }) => {
+    let stopped = false;
+
+    input.dmk
+      .sendCommand({
+        sessionId: input.sessionId,
+        command: new ToggleEarlyCheckCommand(input.toggle),
+      })
+      .then(result => {
+        if (!stopped) {
+          sendBack(
+            isSuccessCommandResult(result)
+              ? { type: "EARLY_CHECK_TOGGLED" }
+              : { type: "EARLY_CHECK_UNAVAILABLE" },
+          );
+        }
+      })
+      .catch(() => {
+        if (!stopped) {
+          sendBack({ type: "EARLY_CHECK_UNAVAILABLE" });
+        }
+      });
+
+    return () => {
+      stopped = true;
+    };
+  },
+);

--- a/libs/device-onboarding/src/device/deviceAction.test.ts
+++ b/libs/device-onboarding/src/device/deviceAction.test.ts
@@ -1,0 +1,42 @@
+import {
+  DeviceActionStatus,
+  type DeviceActionIntermediateValue,
+  type DeviceActionState,
+} from "@ledgerhq/device-management-kit";
+import { Subject } from "rxjs";
+import { createDeviceActionRunner, DeviceActionStoppedError } from "./deviceAction";
+
+type Verdict = { isGenuine: boolean };
+type States = DeviceActionState<Verdict, Error, DeviceActionIntermediateValue>;
+
+describe("createDeviceActionRunner", () => {
+  it("settles the run in flight when it is stopped", async () => {
+    const { runner } = start();
+    const run = runner.run();
+
+    runner.stop();
+
+    await expect(run).rejects.toBeInstanceOf(DeviceActionStoppedError);
+  });
+
+  it("settles the run when the device action ends without a verdict", async () => {
+    const { states, runner } = start();
+    const run = runner.run();
+
+    states.complete();
+
+    await expect(run).rejects.toBeInstanceOf(DeviceActionStoppedError);
+  });
+});
+
+function start() {
+  const states = new Subject<States>();
+
+  const runner = createDeviceActionRunner<Verdict, Error, DeviceActionIntermediateValue>(() => ({
+    observable: states.asObservable(),
+    // DMK pushes the stopped state from `cancel` itself, which the shared fake does not reproduce.
+    cancel: () => states.next({ status: DeviceActionStatus.Stopped }),
+  }));
+
+  return { states, runner };
+}

--- a/libs/device-onboarding/src/device/deviceAction.ts
+++ b/libs/device-onboarding/src/device/deviceAction.ts
@@ -20,8 +20,8 @@ export type DeviceActionRunner<Output> = {
 
 /**
  * Turns a device action, an observable of intermediate states, into the promise the retry helper
- * can wrap. `stop` cancels the execution itself, not only the subscription, and is what a retry
- * calls before the next attempt.
+ * can wrap. `stop` cancels before it unsubscribes, since DMK reports the stop from `cancel` and an
+ * unsubscribed run would never settle, and is what a retry calls before the next attempt.
  */
 export function createDeviceActionRunner<
   Output,
@@ -35,8 +35,8 @@ export function createDeviceActionRunner<
   let subscription: Subscription | undefined;
 
   const stop = () => {
-    subscription?.unsubscribe();
     execution?.cancel();
+    subscription?.unsubscribe();
     subscription = undefined;
     execution = undefined;
   };
@@ -63,6 +63,7 @@ export function createDeviceActionRunner<
           }
         },
         error: reject,
+        complete: () => reject(new DeviceActionStoppedError()),
       });
     });
 

--- a/libs/device-onboarding/src/device/deviceAction.ts
+++ b/libs/device-onboarding/src/device/deviceAction.ts
@@ -1,0 +1,70 @@
+import {
+  DeviceActionStatus,
+  type DeviceActionIntermediateValue,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import type { Subscription } from "rxjs";
+
+export class DeviceActionStoppedError extends Error {
+  readonly _tag = "DeviceActionStoppedError";
+
+  constructor() {
+    super("The device action stopped before producing an output");
+  }
+}
+
+export type DeviceActionRunner<Output> = {
+  run(): Promise<Output>;
+  stop(): void;
+};
+
+/**
+ * Turns a device action, an observable of intermediate states, into the promise the retry helper
+ * can wrap. `stop` cancels the execution itself, not only the subscription, and is what a retry
+ * calls before the next attempt.
+ */
+export function createDeviceActionRunner<
+  Output,
+  Error,
+  IntermediateValue extends DeviceActionIntermediateValue,
+>(
+  start: () => ExecuteDeviceActionReturnType<Output, Error, IntermediateValue>,
+  onIntermediateValue?: (value: IntermediateValue) => void,
+): DeviceActionRunner<Output> {
+  let execution: ExecuteDeviceActionReturnType<Output, Error, IntermediateValue> | undefined;
+  let subscription: Subscription | undefined;
+
+  const stop = () => {
+    subscription?.unsubscribe();
+    execution?.cancel();
+    subscription = undefined;
+    execution = undefined;
+  };
+
+  const run = () =>
+    new Promise<Output>((resolve, reject) => {
+      stop();
+      execution = start();
+      subscription = execution.observable.subscribe({
+        next: state => {
+          switch (state.status) {
+            case DeviceActionStatus.Pending:
+              onIntermediateValue?.(state.intermediateValue);
+              break;
+            case DeviceActionStatus.Completed:
+              resolve(state.output);
+              break;
+            case DeviceActionStatus.Error:
+              reject(state.error);
+              break;
+            case DeviceActionStatus.Stopped:
+              reject(new DeviceActionStoppedError());
+              break;
+          }
+        },
+        error: reject,
+      });
+    });
+
+  return { run, stop };
+}

--- a/libs/device-onboarding/src/device/errors.ts
+++ b/libs/device-onboarding/src/device/errors.ts
@@ -1,0 +1,28 @@
+const refusedByUserTag = "RefusedByUserDAError";
+const secureChannelTags = new Set(["SecureChannelError", "WebSocketConnectionError"]);
+/** DMK's `HttpFetchApiError`, which every manager catalogue call rejects with, is tagged `FetchError`. */
+const catalogueTag = "FetchError";
+
+export function isDeviceRefusal(error: unknown): boolean {
+  return errorTag(error) === refusedByUserTag;
+}
+
+export function isSecureChannelLost(error: unknown): boolean {
+  const tag = errorTag(error);
+
+  return tag !== undefined && secureChannelTags.has(tag);
+}
+
+export function isCatalogueUnreachable(error: unknown): boolean {
+  return errorTag(error) === catalogueTag;
+}
+
+function errorTag(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("_tag" in error)) {
+    return undefined;
+  }
+
+  const { _tag } = error as { _tag: unknown };
+
+  return typeof _tag === "string" ? _tag : undefined;
+}

--- a/libs/device-onboarding/src/device/onboardingState.test.ts
+++ b/libs/device-onboarding/src/device/onboardingState.test.ts
@@ -1,0 +1,70 @@
+import { createOsVersionResponse } from "../tests/osVersionResponse";
+import { OnboardingStep } from "../types";
+import { readOnboardingState, readOnboardingStep, readWordsInformation } from "./onboardingState";
+
+describe("readOnboardingStep", () => {
+  it.each(Object.values(OnboardingStep))("reads the %s step", step => {
+    expect(readOnboardingStep(createOsVersionResponse({ onboardingState: step }))).toBe(step);
+  });
+
+  it("has no step when the catalogue does not decode it", () => {
+    expect(readOnboardingStep(createOsVersionResponse())).toBeNull();
+  });
+
+  it.each(["unknown", "a-state-we-do-not-know"])("has no step for %s", onboardingState => {
+    expect(readOnboardingStep(createOsVersionResponse({ onboardingState }))).toBeNull();
+  });
+});
+
+describe("readWordsInformation", () => {
+  it.each([12, 18, 24])("reads a %s words recovery phrase", numberOfWords => {
+    expect(
+      readWordsInformation(createOsVersionResponse({ numberOfWords, currentWordIndex: 3 })),
+    ).toEqual({ seedWordIndex: 3, seedPhraseWordCount: numberOfWords });
+  });
+
+  it("reads the first word index", () => {
+    expect(
+      readWordsInformation(createOsVersionResponse({ numberOfWords: 24, currentWordIndex: 0 })),
+    ).toEqual({ seedWordIndex: 0, seedPhraseWordCount: 24 });
+  });
+
+  it("has no seed progress when the catalogue does not decode it", () => {
+    expect(readWordsInformation(createOsVersionResponse())).toBeNull();
+  });
+
+  it("has no seed progress without a word index", () => {
+    expect(readWordsInformation(createOsVersionResponse({ numberOfWords: 24 }))).toBeNull();
+  });
+
+  it("has no seed progress for a recovery phrase length we do not support", () => {
+    expect(
+      readWordsInformation(createOsVersionResponse({ numberOfWords: 25, currentWordIndex: 0 })),
+    ).toBeNull();
+  });
+});
+
+describe("readOnboardingState", () => {
+  it("reads a device waiting for the fourth word of a restore", () => {
+    const response = createOsVersionResponse({
+      isInRecoveryMode: true,
+      isSecureConnectionAllowed: true,
+      onboardingState: "restore-recovery-phrase",
+      numberOfWords: 18,
+      currentWordIndex: 3,
+    });
+
+    expect(readOnboardingState(response)).toEqual({
+      isOnboarded: false,
+      isInRecoveryMode: true,
+      managerAllowed: true,
+      currentOnboardingStep: OnboardingStep.RestoreSeed,
+      seedWordIndex: 3,
+      seedPhraseWordCount: 18,
+    });
+  });
+
+  it("has no state on the catalogue version, which decodes neither field", () => {
+    expect(readOnboardingState(createOsVersionResponse({ isOnboarded: true }))).toBeNull();
+  });
+});

--- a/libs/device-onboarding/src/device/onboardingState.ts
+++ b/libs/device-onboarding/src/device/onboardingState.ts
@@ -1,0 +1,98 @@
+import {
+  GetOsVersionCommand,
+  isSuccessCommandResult,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type GetOsVersionResponse,
+} from "@ledgerhq/device-management-kit";
+import { OnboardingStep, type DeviceOnboardingState, type SeedPhraseWordCount } from "../types";
+
+export type SeedProgress = {
+  seedWordIndex: number;
+  seedPhraseWordCount: SeedPhraseWordCount;
+};
+
+export async function sendOsVersionCommand(
+  dmk: DeviceManagementKit,
+  sessionId: DeviceSessionId,
+): Promise<GetOsVersionResponse> {
+  const result = await dmk.sendCommand({ sessionId, command: new GetOsVersionCommand() });
+
+  if (!isSuccessCommandResult(result)) {
+    throw result.error;
+  }
+
+  return result.data;
+}
+
+/** DMK decodes only the first secure element flag byte, so these three are absent from its response type. */
+type OnboardingFlags = {
+  onboardingState?: string;
+  numberOfWords?: number;
+  currentWordIndex?: number;
+};
+
+const onboardingSteps = new Set<string>(Object.values(OnboardingStep));
+const seedPhraseWordCounts = new Set([12, 18, 24]);
+
+export function readOnboardingState(response: GetOsVersionResponse): DeviceOnboardingState | null {
+  const currentOnboardingStep = readOnboardingStep(response);
+  const seedProgress = readWordsInformation(response);
+
+  if (currentOnboardingStep === null || seedProgress === null) {
+    return null;
+  }
+
+  const flags = response.secureElementFlags;
+
+  return {
+    isOnboarded: flags.isOnboarded,
+    isInRecoveryMode: flags.isInRecoveryMode,
+    managerAllowed: flags.isSecureConnectionAllowed,
+    currentOnboardingStep,
+    ...seedProgress,
+  };
+}
+
+export function isSameOnboardingState(
+  previous: DeviceOnboardingState | undefined,
+  next: DeviceOnboardingState,
+): boolean {
+  return (
+    previous !== undefined &&
+    previous.isOnboarded === next.isOnboarded &&
+    previous.isInRecoveryMode === next.isInRecoveryMode &&
+    previous.managerAllowed === next.managerAllowed &&
+    previous.currentOnboardingStep === next.currentOnboardingStep &&
+    previous.seedWordIndex === next.seedWordIndex &&
+    previous.seedPhraseWordCount === next.seedPhraseWordCount
+  );
+}
+
+export function readOnboardingStep(response: GetOsVersionResponse): OnboardingStep | null {
+  const { onboardingState } = onboardingFlags(response);
+
+  if (onboardingState === undefined || !onboardingSteps.has(onboardingState)) {
+    return null;
+  }
+
+  return onboardingState as OnboardingStep;
+}
+
+export function readWordsInformation(response: GetOsVersionResponse): SeedProgress | null {
+  const { numberOfWords, currentWordIndex } = onboardingFlags(response);
+
+  if (typeof currentWordIndex !== "number" || !isSeedPhraseWordCount(numberOfWords)) {
+    return null;
+  }
+
+  return { seedWordIndex: currentWordIndex, seedPhraseWordCount: numberOfWords };
+}
+
+function onboardingFlags(response: GetOsVersionResponse): OnboardingFlags {
+  return response.secureElementFlags as OnboardingFlags;
+}
+
+function isSeedPhraseWordCount(value: number | undefined): value is SeedPhraseWordCount {
+  return value !== undefined && seedPhraseWordCounts.has(value);
+}

--- a/libs/device-onboarding/src/device/toggleEarlyCheckCommand.test.ts
+++ b/libs/device-onboarding/src/device/toggleEarlyCheckCommand.test.ts
@@ -1,0 +1,50 @@
+import { ApduResponse, isSuccessCommandResult } from "@ledgerhq/device-management-kit";
+import { EarlyCheckToggle, ToggleEarlyCheckCommand } from "./toggleEarlyCheckCommand";
+
+describe("ToggleEarlyCheckCommand", () => {
+  it.each([
+    ["entering", EarlyCheckToggle.Enter, 0x00],
+    ["leaving", EarlyCheckToggle.Exit, 0x01],
+  ])("builds the %s APDU", (_, toggle, expectedP2) => {
+    const apdu = new ToggleEarlyCheckCommand(toggle).getApdu();
+
+    expect([apdu.cla, apdu.ins, apdu.p1, apdu.p2]).toEqual([0xe0, 0x03, 0x00, expectedP2]);
+    expect(apdu.data).toHaveLength(0);
+  });
+
+  it("succeeds on a 9000 response", () => {
+    const result = new ToggleEarlyCheckCommand(EarlyCheckToggle.Enter).parseResponse(
+      apduResponse(0x90, 0x00),
+    );
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+  });
+
+  it.each([
+    ["6982", 0x69, 0x82, "The device is no longer on a welcome step"],
+    ["6700", 0x67, 0x00, "The firmware does not know the early check command"],
+  ])("names the %s failure", (errorCode, first, second, message) => {
+    const result = new ToggleEarlyCheckCommand(EarlyCheckToggle.Enter).parseResponse(
+      apduResponse(first, second),
+    );
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(result).toMatchObject({ error: { errorCode, message } });
+  });
+
+  it("falls back to the global handler on an unlisted status code", () => {
+    const result = new ToggleEarlyCheckCommand(EarlyCheckToggle.Enter).parseResponse(
+      apduResponse(0x6e, 0x00),
+    );
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(result).toMatchObject({ error: { errorCode: "6e00" } });
+  });
+});
+
+function apduResponse(...statusCode: number[]): ApduResponse {
+  return new ApduResponse({
+    statusCode: Uint8Array.from(statusCode),
+    data: new Uint8Array(),
+  });
+}

--- a/libs/device-onboarding/src/device/toggleEarlyCheckCommand.ts
+++ b/libs/device-onboarding/src/device/toggleEarlyCheckCommand.ts
@@ -1,0 +1,71 @@
+import {
+  ApduBuilder,
+  bufferToHexaString,
+  CommandResultFactory,
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
+  isCommandErrorCode,
+  type Apdu,
+  type ApduResponse,
+  type Command,
+  type CommandErrorArgs,
+  type CommandErrors,
+  type CommandResult,
+} from "@ledgerhq/device-management-kit";
+
+export const EarlyCheckToggle = {
+  Enter: 0x00,
+  Exit: 0x01,
+} as const;
+
+export type EarlyCheckToggle = (typeof EarlyCheckToggle)[keyof typeof EarlyCheckToggle];
+
+export type ToggleEarlyCheckErrorCode = "6982" | "6700";
+
+export const toggleEarlyCheckErrors: CommandErrors<ToggleEarlyCheckErrorCode> = {
+  "6982": { message: "The device is no longer on a welcome step" },
+  "6700": { message: "The firmware does not know the early check command" },
+};
+
+export class ToggleEarlyCheckCommandError extends DeviceExchangeError<ToggleEarlyCheckErrorCode> {
+  constructor(args: CommandErrorArgs<ToggleEarlyCheckErrorCode>) {
+    super({ tag: "ToggleEarlyCheckCommandError", ...args });
+  }
+}
+
+/**
+ * Moves the device in or out of the early security check step, without running any check. The
+ * firmware only accepts it on the two welcome steps. DMK carries no command for this APDU, so it
+ * is declared here, identical to `deviceSDK/commands/toggleOnboardingEarlyCheck` of
+ * ledger-live-common, and this file is what goes away once DMK ships one.
+ */
+export class ToggleEarlyCheckCommand implements Command<void, void, ToggleEarlyCheckErrorCode> {
+  readonly name = "toggleOnboardingEarlyCheck";
+  readonly args = undefined;
+
+  constructor(private readonly toggle: EarlyCheckToggle) {}
+
+  getApdu(): Apdu {
+    return new ApduBuilder({ cla: 0xe0, ins: 0x03, p1: 0x00, p2: this.toggle }).build();
+  }
+
+  parseResponse(apduResponse: ApduResponse): CommandResult<void, ToggleEarlyCheckErrorCode> {
+    if (CommandUtils.isSuccessResponse(apduResponse)) {
+      return CommandResultFactory({ data: undefined });
+    }
+
+    const errorCode = bufferToHexaString(apduResponse.statusCode).replace("0x", "");
+
+    if (isCommandErrorCode(errorCode, toggleEarlyCheckErrors)) {
+      return CommandResultFactory({
+        error: new ToggleEarlyCheckCommandError({
+          ...toggleEarlyCheckErrors[errorCode],
+          errorCode,
+        }),
+      });
+    }
+
+    return CommandResultFactory({ error: GlobalCommandErrorHandler.handle(apduResponse) });
+  }
+}

--- a/libs/device-onboarding/src/index.ts
+++ b/libs/device-onboarding/src/index.ts
@@ -15,12 +15,57 @@ export {
   type DeviceOnboardingInput,
   type DeviceOnboardingOutput,
   type DeviceOnboardingState,
+  type GenuineCheckFailure,
   type OnboardingEvent,
   type SeedPhraseWordCount,
 } from "./types";
+export {
+  createRetryPolicy,
+  withRetries,
+  defaultRetryAttempts,
+  defaultRetryDelaysMs,
+  type RetryPolicy,
+} from "./retry";
 export {
   mapSession,
   sessionListener,
   type SessionEvent,
   type SessionListenerInput,
 } from "./actors/session";
+export {
+  mapDeviceState,
+  readDeviceState,
+  type ReadDeviceStateEvent,
+  type ReadDeviceStateInput,
+} from "./actors/readDeviceState";
+export {
+  genuineCheck,
+  mapGenuineCheckFailure,
+  type GenuineCheckEvent,
+  type GenuineCheckFailureEvent,
+  type GenuineCheckInput,
+} from "./actors/genuineCheck";
+export {
+  firmwareCheck,
+  mapFirmwareMetadata,
+  type FirmwareCheckEvent,
+  type FirmwareCheckInput,
+} from "./actors/firmwareCheck";
+export {
+  toggleEarlyCheck,
+  type ToggleEarlyCheckEvent,
+  type ToggleEarlyCheckInput,
+} from "./actors/toggleEarlyCheck";
+export {
+  EarlyCheckToggle,
+  ToggleEarlyCheckCommand,
+  ToggleEarlyCheckCommandError,
+  type ToggleEarlyCheckErrorCode,
+} from "./device/toggleEarlyCheckCommand";
+export {
+  defaultSeedPollingFailureThreshold,
+  defaultSeedPollingIntervalMs,
+  seedPolling,
+  type SeedPollingEvent,
+  type SeedPollingInput,
+} from "./actors/seedPolling";

--- a/libs/device-onboarding/src/ports.ts
+++ b/libs/device-onboarding/src/ports.ts
@@ -47,9 +47,8 @@ export type FirmwareUpdateResult =
 /**
  * Implemented by each app without exposing its live-dmk transport types to this package.
  *
- * The app owns the session lifecycle. The machine reads the current id but never opens or closes
- * a session. `openSession` is the composition boundary that supplies the app's existing DMK
- * instance. `applyFirmwareUpdate` must resolve on a refusal event without waiting for the updater
+ * The app owns the session lifecycle: the machine reads the current id but never opens or closes a
+ * session. `applyFirmwareUpdate` must resolve on a refusal event without waiting for the updater
  * observable to complete.
  */
 export type DeviceOnboardingPorts = {

--- a/libs/device-onboarding/src/retry.test.ts
+++ b/libs/device-onboarding/src/retry.test.ts
@@ -1,0 +1,127 @@
+import { createRetryPolicy, withRetries, type RetryPolicy } from "./retry";
+
+const immediateRetries = (isRetryable: (error: unknown) => boolean): RetryPolicy => ({
+  attempts: 3,
+  delaysMs: [0, 0],
+  isRetryable,
+});
+
+describe("withRetries", () => {
+  it("returns the first result without retrying", async () => {
+    const run = jest.fn().mockResolvedValue("read");
+
+    await expect(
+      withRetries(
+        run,
+        immediateRetries(() => true),
+      ),
+    ).resolves.toBe("read");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a retryable failure until it succeeds", async () => {
+    const run = jest.fn().mockRejectedValueOnce(new Error("flaky")).mockResolvedValue("read");
+
+    await expect(
+      withRetries(
+        run,
+        immediateRetries(() => true),
+      ),
+    ).resolves.toBe("read");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws the last failure once the attempts are exhausted", async () => {
+    const lastError = new Error("third");
+    const run = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("second"))
+      .mockRejectedValue(lastError);
+
+    await expect(
+      withRetries(
+        run,
+        immediateRetries(() => true),
+      ),
+    ).rejects.toBe(lastError);
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws a failure the policy rejects without retrying", async () => {
+    const error = new Error("permanent");
+    const run = jest.fn().mockRejectedValue(error);
+
+    await expect(
+      withRetries(
+        run,
+        immediateRetries(() => false),
+      ),
+    ).rejects.toBe(error);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs a single attempt when the policy allows none", async () => {
+    const run = jest.fn().mockRejectedValue(new Error("failed"));
+
+    await expect(
+      withRetries(run, { attempts: 0, delaysMs: [], isRetryable: () => true }),
+    ).rejects.toThrow("failed");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up rather than reaching the device again once the caller cancelled", async () => {
+    const run = jest.fn().mockRejectedValue(new Error("flaky"));
+    const policy: RetryPolicy = { attempts: 3, delaysMs: [0], isRetryable: () => true };
+    let cancelled = false;
+
+    const result = withRetries(run, policy, { isCancelled: () => cancelled });
+    cancelled = true;
+
+    await expect(result).rejects.toThrow("flaky");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits the configured delay between attempts", async () => {
+    jest.useFakeTimers();
+    const run = jest.fn().mockRejectedValueOnce(new Error("flaky")).mockResolvedValue("read");
+    const policy = createRetryPolicy(() => true);
+
+    const result = withRetries(run, policy);
+    await Promise.resolve();
+
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(299);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBe("read");
+    expect(run).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
+  it("reuses the last delay when there are more attempts than delays", async () => {
+    jest.useFakeTimers();
+    const run = jest.fn().mockRejectedValue(new Error("flaky"));
+    const policy: RetryPolicy = { attempts: 4, delaysMs: [10], isRetryable: () => true };
+
+    const result = withRetries(run, policy).catch(() => "failed");
+
+    await jest.advanceTimersByTimeAsync(30);
+    await expect(result).resolves.toBe("failed");
+    expect(run).toHaveBeenCalledTimes(4);
+
+    jest.useRealTimers();
+  });
+});
+
+describe("createRetryPolicy", () => {
+  it("allows three attempts with an increasing delay", () => {
+    const policy = createRetryPolicy(() => true);
+
+    expect(policy.attempts).toBe(3);
+    expect(policy.delaysMs).toEqual([300, 900]);
+  });
+});

--- a/libs/device-onboarding/src/retry.ts
+++ b/libs/device-onboarding/src/retry.ts
@@ -1,0 +1,60 @@
+export type RetryPolicy = {
+  attempts: number;
+  delaysMs: number[];
+  isRetryable(error: unknown): boolean;
+};
+
+export const defaultRetryAttempts = 3;
+export const defaultRetryDelaysMs = [300, 900];
+
+export function createRetryPolicy(isRetryable: (error: unknown) => boolean): RetryPolicy {
+  return {
+    attempts: defaultRetryAttempts,
+    delaysMs: [...defaultRetryDelaysMs],
+    isRetryable,
+  };
+}
+
+export type RetryOptions = {
+  /**
+   * Consulted after each delay: an actor stopped during a backoff must not reach the device again.
+   */
+  isCancelled?: () => boolean;
+};
+
+/** Only the failure of the last attempt is thrown, so a transient error never reaches the machine. */
+export async function withRetries<T>(
+  run: () => Promise<T>,
+  policy: RetryPolicy,
+  { isCancelled }: RetryOptions = {},
+): Promise<T> {
+  const attempts = Math.max(1, policy.attempts);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      const isLastAttempt = attempt >= attempts;
+
+      if (isLastAttempt || !policy.isRetryable(error)) {
+        throw error;
+      }
+
+      await delay(delayForAttempt(policy.delaysMs, attempt));
+
+      if (isCancelled?.()) {
+        throw error;
+      }
+    }
+  }
+}
+
+function delayForAttempt(delaysMs: number[], attempt: number): number {
+  return delaysMs[attempt - 1] ?? delaysMs.at(-1) ?? 0;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/libs/device-onboarding/src/tests/actorHarness.ts
+++ b/libs/device-onboarding/src/tests/actorHarness.ts
@@ -1,0 +1,48 @@
+import { createActor, setup, type AnyActorLogic, type EventObject } from "xstate";
+
+export type RunningActor<TEvent> = {
+  received: TEvent[];
+  stop(): void;
+};
+
+/**
+ * Invokes an actor from a machine that captures whatever it sends back, since a callback actor only
+ * reports through its parent.
+ */
+export function runActor<TEvent extends EventObject>(
+  actor: AnyActorLogic,
+  input: unknown,
+): RunningActor<TEvent> {
+  const received: TEvent[] = [];
+
+  const machine = setup({
+    types: { events: {} as TEvent },
+    actors: { actor },
+    actions: {
+      capture: ({ event }) => {
+        if (!event.type.startsWith("xstate.")) {
+          received.push(event);
+        }
+      },
+    },
+  }).createMachine({
+    invoke: { src: "actor", input },
+    on: { "*": { actions: "capture" } },
+  });
+
+  const running = createActor(machine).start();
+
+  return { received, stop: () => running.stop() };
+}
+
+/**
+ * Drains the pending promises and zero-delay timers, one cycle per attempt an actor under a retry
+ * policy can make.
+ */
+export async function settle(cycles = 4): Promise<void> {
+  for (let cycle = 0; cycle < cycles; cycle++) {
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+  }
+}

--- a/libs/device-onboarding/src/tests/fakeDmk.ts
+++ b/libs/device-onboarding/src/tests/fakeDmk.ts
@@ -1,0 +1,95 @@
+import type {
+  CommandResult,
+  DeviceActionIntermediateValue,
+  DeviceActionState,
+  DeviceManagementKit,
+} from "@ledgerhq/device-management-kit";
+import { Subject } from "rxjs";
+
+export type ScriptedCommand<Data, ErrorCodes = void> =
+  | CommandResult<Data, ErrorCodes>
+  | { throws: unknown };
+
+export type FakeCommandDmk = {
+  dmk: DeviceManagementKit;
+  sendCommand: jest.Mock;
+};
+
+/**
+ * Serves the scripted results in order, then repeats the last one, so that a script of one entry
+ * answers every retry the same way.
+ */
+export function createFakeCommandDmk<Data, ErrorCodes = void>(
+  script: ScriptedCommand<Data, ErrorCodes>[],
+): FakeCommandDmk {
+  const remaining = [...script];
+
+  const sendCommand = jest.fn(async () => {
+    const next = remaining.length > 1 ? remaining.shift() : remaining[0];
+
+    if (next === undefined) {
+      throw new Error("the command script is empty");
+    }
+
+    if ("throws" in next) {
+      throw next.throws;
+    }
+
+    return next;
+  });
+
+  return { dmk: { sendCommand } as unknown as DeviceManagementKit, sendCommand };
+}
+
+export type FakeDeviceActionExecution<
+  Output,
+  Error,
+  IntermediateValue extends DeviceActionIntermediateValue,
+> = {
+  states: Subject<DeviceActionState<Output, Error, IntermediateValue>>;
+  cancel: jest.Mock;
+};
+
+export type FakeDeviceActionDmk<
+  Output,
+  Error,
+  IntermediateValue extends DeviceActionIntermediateValue,
+> = {
+  dmk: DeviceManagementKit;
+  executeDeviceAction: jest.Mock;
+  executions: FakeDeviceActionExecution<Output, Error, IntermediateValue>[];
+  lastExecution(): FakeDeviceActionExecution<Output, Error, IntermediateValue>;
+};
+
+/** Hands one subject per execution, so that a retry is observable as a second execution. */
+export function createFakeDeviceActionDmk<
+  Output,
+  Error,
+  IntermediateValue extends DeviceActionIntermediateValue,
+>(): FakeDeviceActionDmk<Output, Error, IntermediateValue> {
+  const executions: FakeDeviceActionExecution<Output, Error, IntermediateValue>[] = [];
+
+  const executeDeviceAction = jest.fn(() => {
+    const states = new Subject<DeviceActionState<Output, Error, IntermediateValue>>();
+    const cancel = jest.fn();
+
+    executions.push({ states, cancel });
+
+    return { observable: states.asObservable(), cancel };
+  });
+
+  return {
+    dmk: { executeDeviceAction } as unknown as DeviceManagementKit,
+    executeDeviceAction,
+    executions,
+    lastExecution: () => {
+      const execution = executions.at(-1);
+
+      if (execution === undefined) {
+        throw new Error("no device action was executed");
+      }
+
+      return execution;
+    },
+  };
+}

--- a/libs/device-onboarding/src/tests/osVersionResponse.ts
+++ b/libs/device-onboarding/src/tests/osVersionResponse.ts
@@ -1,0 +1,37 @@
+import type { GetOsVersionResponse } from "@ledgerhq/device-management-kit";
+
+export type OsVersionResponseOptions = {
+  isBootloader?: boolean;
+  isOsu?: boolean;
+  isOnboarded?: boolean;
+  isInRecoveryMode?: boolean;
+  isSecureConnectionAllowed?: boolean;
+  onboardingState?: string;
+  numberOfWords?: number;
+  currentWordIndex?: number;
+};
+
+/**
+ * Builds a `GetOsVersionCommand` response holding only the fields the actors read. The onboarding
+ * step and seed progress are set outside the catalogue type on purpose: that is how a DMK decoding
+ * them delivers them.
+ */
+export function createOsVersionResponse({
+  isBootloader = false,
+  isOsu = false,
+  isOnboarded = false,
+  isInRecoveryMode = false,
+  isSecureConnectionAllowed = false,
+  ...onboardingFlags
+}: OsVersionResponseOptions = {}): GetOsVersionResponse {
+  return {
+    isBootloader,
+    isOsu,
+    secureElementFlags: {
+      isOnboarded,
+      isInRecoveryMode,
+      isSecureConnectionAllowed,
+      ...onboardingFlags,
+    },
+  } as unknown as GetOsVersionResponse;
+}

--- a/libs/device-onboarding/src/types.ts
+++ b/libs/device-onboarding/src/types.ts
@@ -5,29 +5,37 @@ import type {
   FirmwareUpdateContext,
 } from "@ledgerhq/device-management-kit";
 
+/** Named with the values DMK's decoding returns, so reading one is a membership check and not a translation. */
 export const OnboardingStep = {
-  WelcomeScreen1: "WELCOME_SCREEN_1",
-  WelcomeScreen2: "WELCOME_SCREEN_2",
-  WelcomeScreen3: "WELCOME_SCREEN_3",
-  WelcomeScreen4: "WELCOME_SCREEN_4",
-  WelcomeScreenReminder: "WELCOME_SCREEN_REMINDER",
-  OnboardingEarlyCheck: "ONBOARDING_EARLY_CHECK",
-  ChooseName: "CHOOSE_NAME",
-  Pin: "PIN",
-  SetupChoice: "SETUP_CHOICE",
-  SetupChoiceRestore: "SETUP_CHOICE_RESTORE",
-  NewDevice: "NEW_DEVICE",
-  NewDeviceConfirming: "NEW_DEVICE_CONFIRMING",
-  RestoreSeed: "RESTORE_SEED",
-  RecoverRestore: "RECOVER_RESTORE",
-  RestoreCharon: "RESTORE_CHARON",
-  SafetyWarning: "SAFETY_WARNING",
-  Ready: "READY",
+  WelcomeScreen1: "welcome-screen-1",
+  WelcomeScreen2: "welcome-screen-2",
+  WelcomeScreen3: "welcome-screen-3",
+  WelcomeScreen4: "welcome-screen-4",
+  WelcomeScreenReminder: "welcome-screen-reminder",
+  OnboardingEarlyCheck: "onboarding-status-check",
+  ChooseName: "choose-name",
+  Pin: "pin",
+  SetupChoice: "setup-choice",
+  SetupChoiceRestore: "setup-restore-choice",
+  NewDevice: "new-device",
+  NewDeviceConfirming: "confirm-new-device",
+  RestoreSeed: "restore-recovery-phrase",
+  RecoverRestore: "restore-recover-backup",
+  RestoreCharon: "restore-with-rk",
+  SafetyWarning: "safety-warning",
+  Ready: "device-is-ready",
 } as const;
 
 export type OnboardingStep = (typeof OnboardingStep)[keyof typeof OnboardingStep];
 
 export type SeedPhraseWordCount = 12 | 18 | 24;
+
+/**
+ * Carried untouched so the app can pick a drawer the machine knows nothing about: an unreachable
+ * backend and a forced My Ledger provider both arrive as an `HttpFetchApiError`, and only the app
+ * holds the provider setting that tells them apart.
+ */
+export type GenuineCheckFailure = unknown;
 
 export type DeviceOnboardingState = {
   isOnboarded: boolean;
@@ -44,6 +52,22 @@ export type OnboardingEvent =
   | { type: "UNLOCKED" }
   | { type: "TRANSPORT_LOST" }
   | { type: "STEP_CHANGED"; state: DeviceOnboardingState }
+  | { type: "DEVICE_STATE_READ"; state: DeviceOnboardingState }
+  | { type: "DEVICE_STATE_UNREADABLE"; isOnboarded: boolean; isInRecoveryMode: boolean }
+  | { type: "DEVICE_STATE_FAILED" }
+  | { type: "DEVICE_IN_BOOTLOADER" }
+  | { type: "DEVICE_IN_OSU" }
+  | { type: "EARLY_CHECK_TOGGLED" }
+  | { type: "EARLY_CHECK_UNAVAILABLE" }
+  | { type: "ALLOW_SECURE_CONNECTION_REQUESTED" }
+  | { type: "GENUINE_CHECK_PASSED" }
+  | { type: "GENUINE_CHECK_REFUSED"; failure: GenuineCheckFailure }
+  | { type: "GENUINE_CHECK_FAILED"; failure: GenuineCheckFailure }
+  | { type: "DEVICE_NOT_GENUINE"; failure: GenuineCheckFailure }
+  | { type: "SECURE_CHANNEL_LOST"; failure: GenuineCheckFailure }
+  | { type: "FIRMWARE_UP_TO_DATE" }
+  | { type: "FIRMWARE_UPDATE_AVAILABLE"; update: AvailableFirmwareUpdate }
+  | { type: "FIRMWARE_CHECK_FAILED" }
   | { type: "START" }
   | { type: "RETRY" }
   | { type: "SKIP" }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The five XState actors the onboarding flow reads the device through, in the new
`@ledgerhq/device-onboarding` package: `readDeviceState`, `genuineCheck`, `firmwareCheck`,
`toggleEarlyCheck` and `seedPolling`. They are the only code that talks to the device, and they
report through events rather than return values. No app consumes them yet — the machine that
invokes them is LIVE-36066.


<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36060]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36060]: https://ledgerhq.atlassian.net/browse/LIVE-36060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ