### PR TITLE
feat(web-tools): add the Firmware App Deployments tool

### DIFF
--- a/.changeset/web-tools-firmware-app-deployments.md
+++ b/.changeset/web-tools-firmware-app-deployments.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/web-tools": patch
+---
+
+Add the Firmware App Deployments tool: a matrix of which device app version is published on each device, provider and OS track, read from the Manager API.

--- a/apps/web-tools/README.md
+++ b/apps/web-tools/README.md
@@ -14,6 +14,7 @@ Today we have:
 - **Domain TLV Parser**: allows to parse a domain APDU (TLV) returned by the Ledger NFT Metadata service. This is useful to test the parsing done in the Ethereum app.
 - **SVG Icons**: helper to facilitate the creation of currency SVG icons for the Ledger Live application. This will validate icons correctly matches Ledger Live expectations and will prefill a PR creation.
 - **Derivation Paths**: Get a simple list of supported derivation paths for a given currency
+- **Firmware App Deployments**: a matrix of which device app version is published on each device, provider (P1 production, P4 pre-production) and OS track (current stable, and the next prerelease when one exists). Reads the Manager API directly from the browser, so it answers "is this app rebuilt for the upcoming OS yet?" without a device.
 
 ---
 

--- a/apps/web-tools/src/pages/firmware-app-deployments/FirmwareAppDeploymentsView.tsx
+++ b/apps/web-tools/src/pages/firmware-app-deployments/FirmwareAppDeploymentsView.tsx
@@ -1,0 +1,422 @@
+import { memo } from "react";
+import {
+  Banner,
+  Button,
+  Checkbox,
+  SearchInput,
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRoot,
+} from "@ledgerhq/lumen-ui-react";
+import { formatInstant, isStale } from "./logic";
+import type { MatrixApp, MatrixColumn, ShownDevice } from "./types";
+import type {
+  FirmwareAppDeploymentsViewModel,
+  VisibleColumn,
+} from "./useFirmwareAppDeploymentsViewModel";
+
+const MONO = "font-mono tabular-nums";
+
+/*
+ * Lumen's colour tokens are var() indirections, so Tailwind's /opacity modifiers are
+ * dropped from them silently — `bg-muted/50` compiles to plain `bg-muted`. These two mix
+ * against the canvas explicitly, which keeps them theme-aware and actually lighter.
+ *
+ * The tint marks the next-OS track. At full strength bg-muted is #f1f1f1, heavy enough to
+ * read as a filled slab down the page; the hairline is the rule between rows, which wants
+ * to be lighter than the rule under the header.
+ */
+const TRACK_TINT = "bg-[color-mix(in_srgb,var(--background-muted)_45%,var(--background-canvas))]";
+const HAIRLINE =
+  "border-[color-mix(in_srgb,var(--border-muted-subtle)_55%,var(--background-canvas))]";
+
+/**
+ * Micro-caps for column labels and chips: it separates them from the data at a glance
+ * without spending a second colour on the distinction.
+ */
+const MICRO = "body-4 uppercase tracking-wider";
+
+/*
+ * Lumen checks a box with bg-active, the Ledger purple — the only saturated colour on the
+ * page, spent on a secondary control. Checked becomes an ink tick in an ink-bordered box,
+ * the language the device chips use. Lumen merges className with tailwind-merge, so these
+ * replace its own.
+ */
+const CHECKBOX_INK = [
+  "data-[state=checked]:border data-[state=checked]:border-base",
+  "data-[state=checked]:bg-base data-[state=checked]:text-base",
+  "data-[state=checked]:hover:bg-base-hover",
+  "data-[state=checked]:active:bg-base-pressed",
+].join(" ");
+
+// A stable identity, so a null matrix does not defeat AppRow's memoisation.
+const EMPTY_COLUMNS: Record<string, MatrixColumn[]> = {};
+
+/*
+ * The next-OS track is a different axis from the provider, so it is separated by tone
+ * rather than by colour — nothing here should read as a status.
+ */
+const trackClasses = (column: MatrixColumn, startsGroup: boolean) =>
+  [column.track === "next" ? TRACK_TINT : "", startsGroup ? "border-l border-muted-subtle" : ""]
+    .filter(Boolean)
+    .join(" ");
+
+/** The header slot: collection status next to the control that changes it. */
+export const FirmwareAppDeploymentsActions = ({
+  matrix,
+  status,
+  refreshing,
+  onRefresh,
+}: Pick<FirmwareAppDeploymentsViewModel, "matrix" | "status" | "refreshing" | "onRefresh">) => {
+  const collectedAt = matrix?.collectedAt;
+
+  return (
+    <>
+      {status ? (
+        <p className="body-4 text-muted">{status}…</p>
+      ) : collectedAt ? (
+        <p className="body-4 text-muted">
+          Updated at{" "}
+          {/* Amber past the staleness threshold, so a stale cache shows without a
+              separate age readout. */}
+          <span className={`${MONO} ${isStale(collectedAt) ? "text-warning" : "text-base"}`}>
+            {formatInstant(collectedAt)}
+          </span>{" "}
+          UTC
+        </p>
+      ) : null}
+      <Button appearance="gray" size="sm" loading={refreshing} onClick={onRefresh}>
+        Refresh
+      </Button>
+    </>
+  );
+};
+
+/**
+ * A visible chip means the app is published on that device. Absent ones keep their layout
+ * box but are hidden, so the chip set stays a fixed-width ruler across every row.
+ *
+ * Plain spans rather than Lumen's Tag, which subscribes to a React context per instance
+ * and whose only filled appearance is the purple accent — repeated five times across a
+ * few hundred rows, that colour reads as a status the chips do not carry. Shown devices
+ * are marked with ink, the rest with a hairline.
+ */
+const CHIP = `rounded-xs border px-4 ${MICRO} whitespace-nowrap`;
+
+const DeviceChips = ({
+  app,
+  devices,
+  columns,
+  selectedKeys,
+}: {
+  app: MatrixApp;
+  devices: ShownDevice[];
+  columns: Record<string, MatrixColumn[]>;
+  selectedKeys: Set<string>;
+}) => (
+  <div className="flex flex-nowrap gap-2">
+    {devices.map(device => {
+      const published = columns[device.key].some(column => app.versions[column.key]);
+      const tone = selectedKeys.has(device.key)
+        ? "border-base text-base"
+        : "border-muted-subtle text-muted";
+
+      return (
+        <span key={device.key} className={`${CHIP} ${tone} ${published ? "" : "invisible"}`}>
+          {device.label}
+        </span>
+      );
+    })}
+  </div>
+);
+
+/*
+ * The body is plain <tr>/<td> rather than Lumen's TableRow/TableCell, and the cells are
+ * built by functions rather than components.
+ *
+ * A deliberate, measured exception to the design system: toggling a device re-renders the
+ * whole catalogue — 235 rows, ~1400 cells — and every Lumen cell runs cva plus
+ * tailwind-merge and wraps its children in another flex div. Profiled on a production
+ * build, a toggle costs 38ms with them and 30ms without. The header keeps its Lumen
+ * components; a dozen cells there cost nothing.
+ */
+const CELL = "h-48 px-12 py-8 body-3 text-base";
+
+const versionCell = (app: MatrixApp, column: MatrixColumn, startsGroup: boolean) => {
+  const entry = app.versions[column.key];
+  const classes = `${CELL} ${trackClasses(column, startsGroup)}`;
+
+  if (!entry) {
+    return (
+      <td key={column.key} className={`${classes} ${MONO} text-muted`}>
+        —
+      </td>
+    );
+  }
+
+  return (
+    <td key={column.key} className={classes}>
+      <div className="flex flex-col">
+        <span className={`${MONO} body-3 whitespace-nowrap`}>{entry.version}</span>
+        {/*
+          Matches the repository link, which is the same text-muted but rendered at 80%
+          by the global `a` rule in globals.css. Both are secondary to the version, so
+          they should sit at the same weight.
+        */}
+        <span className={`${MONO} body-4 text-muted whitespace-nowrap opacity-80`}>
+          {entry.modified}
+        </span>
+      </div>
+    </td>
+  );
+};
+
+/**
+ * Memoised because a filter keystroke rebuilds the visible list but leaves each surviving
+ * row's props untouched, so only the rows entering or leaving the list do any work.
+ */
+const AppRow = memo(function AppRow({
+  app,
+  visibleColumns,
+  devices,
+  columns,
+  selectedKeys,
+}: {
+  app: MatrixApp;
+  visibleColumns: VisibleColumn[];
+  devices: ShownDevice[];
+  columns: Record<string, MatrixColumn[]>;
+  selectedKeys: Set<string>;
+}) {
+  return (
+    <tr className={`${HAIRLINE} border-b`}>
+      <td className={`${CELL} whitespace-nowrap`}>{app.name}</td>
+      <td className={CELL}>
+        {app.repo ? (
+          <a
+            className={`${MONO} body-4 text-muted hover:text-interactive whitespace-nowrap hover:underline`}
+            href={`https://github.com/${app.repo}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {app.repo.split("/")[1]}
+          </a>
+        ) : (
+          <span className={`${MONO} text-muted`}>—</span>
+        )}
+      </td>
+      {visibleColumns.map(({ column, startsGroup }) => versionCell(app, column, startsGroup))}
+      <td className={`${CELL} w-1`}>
+        <DeviceChips app={app} devices={devices} columns={columns} selectedKeys={selectedKeys} />
+      </td>
+    </tr>
+  );
+});
+
+export const FirmwareAppDeploymentsView = ({
+  matrix,
+  deviceOptions,
+  devices,
+  shownDevices,
+  visibleColumns,
+  selectedKeys,
+  visibleApps,
+  visibleCount,
+  totalCount,
+  filter,
+  notice,
+  onFilterChange,
+  onToggleDevice,
+}: FirmwareAppDeploymentsViewModel) => {
+  const columns = matrix?.columns ?? EMPTY_COLUMNS;
+
+  return (
+    <div className="flex flex-col gap-16">
+      {notice ? (
+        <Banner
+          appearance={notice.appearance}
+          title={notice.title}
+          description={
+            notice.details ? (
+              <ul className="body-4 flex list-disc flex-col gap-2 pl-16">
+                {notice.details.map(detail => (
+                  <li key={detail}>{detail}</li>
+                ))}
+              </ul>
+            ) : undefined
+          }
+        />
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-between gap-12">
+        {/*
+          Checkboxes, not toggle buttons: a pressed pill reads as a filter chip, promising
+          a subset of the rows, which is exactly what this control does not do.
+        */}
+        <div className="flex flex-wrap items-center gap-16" role="group" aria-label="Devices shown">
+          <span className={`${MICRO} text-muted`}>Show</span>
+          {deviceOptions.map(device => (
+            <div key={device.key} className="flex items-center gap-8">
+              <Checkbox
+                id={`device-${device.key}`}
+                className={CHECKBOX_INK}
+                checked={device.selected}
+                disabled={device.disabled}
+                onCheckedChange={() => onToggleDevice(device.key)}
+              />
+              <label
+                htmlFor={`device-${device.key}`}
+                className={`body-3 ${device.disabled ? "text-disabled" : "text-base cursor-pointer"}`}
+              >
+                {device.label}
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-8">
+          {/*
+            SearchInput has no size prop and defaults to a 48px field with 16px text,
+            making it the tallest thing in a toolbar of 40px controls and leaving too
+            little room for the placeholder. containerClassName and inputClassName are
+            the hooks Lumen provides for this.
+          */}
+          <SearchInput
+            value={filter}
+            placeholder="Filter by app or repository…"
+            aria-label="Filter apps"
+            className="w-320"
+            containerClassName="h-40"
+            inputClassName="body-3"
+            onChange={event => onFilterChange(event.target.value)}
+          />
+          {/*
+            The row is space-between, so this sits at the right edge and its width pushes
+            the search field. A fixed width and tabular figures keep both still while the
+            count reflows on every keystroke.
+          */}
+          <span className={`${MONO} body-4 text-muted w-80 text-right whitespace-nowrap`}>
+            {visibleCount} / {totalCount}
+          </span>
+        </div>
+      </div>
+
+      {/*
+        The scroller is its own element rather than TableRoot, which carries Lumen's
+        `scrollbar-none`: it does scroll, but with no scrollbar and no hint that anything
+        lies beyond the right edge, a matrix this wide just reads as cropped. TableRoot
+        stays because it supplies the context the header rows need.
+      */}
+      <TableRoot>
+        <div className="overflow-x-auto">
+          {/*
+            Lumen's Table is `table-fixed max-w-full`, which sizes columns from the first
+            row and caps the table at its container: the matrix would be squeezed until
+            every cell truncated, with nothing to scroll. `table-auto` and `max-w-none`
+            let it take the width its content needs. Lumen merges className with
+            tailwind-merge, so these override rather than pile up.
+
+            border-collapse so the hairline under each row can live on the row itself: a
+            table defaults to border-separate, where a border on a <tr> never renders.
+          */}
+          <Table className="w-full max-w-none min-w-max table-auto border-collapse">
+            {/*
+              Lumen's own sticky header is switched off on both rows. The scroller above
+              sets overflow-x, which makes it a scroll container on both axes, so a sticky
+              thead would anchor to a box that never scrolls vertically and never move.
+            */}
+            <TableHeader className="bg-canvas">
+              {/*
+                With a single device selected its name is redundant — the selector above
+                already shows it — so the label is hidden from sight but kept for
+                assistive tech, which keeps the row geometry identical either way.
+              */}
+              {/*
+                The device groups own this row. App, Repository and Devices are peers of
+                the provider labels, not of the group above, so they sit on the next row:
+                spanning both rows centres them between the two lines, 11px off the
+                provider they read alongside.
+              */}
+              {shownDevices.length > 0 ? (
+                <TableHeaderRow stickyHeader={false}>
+                  <TableHeaderCell />
+                  <TableHeaderCell />
+                  {shownDevices.map((device, index) => (
+                    <TableHeaderCell
+                      key={device.key}
+                      scope="colgroup"
+                      colSpan={columns[device.key].length}
+                      className={`${MICRO} text-base ${index > 0 ? "border-l border-muted-subtle" : ""}`}
+                    >
+                      <span className={shownDevices.length === 1 ? "sr-only" : ""}>
+                        {device.label}
+                      </span>
+                    </TableHeaderCell>
+                  ))}
+                  <TableHeaderCell />
+                </TableHeaderRow>
+              ) : null}
+
+              <TableHeaderRow stickyHeader={false} className="border-muted-subtle border-b">
+                <TableHeaderCell className={`${MICRO} text-muted align-top`}>App</TableHeaderCell>
+                <TableHeaderCell className={`${MICRO} text-muted align-top`}>
+                  Repository
+                </TableHeaderCell>
+                {shownDevices.flatMap((device, deviceIndex) =>
+                  columns[device.key].map((column, columnIndex) => (
+                    <TableHeaderCell
+                      key={column.key}
+                      className={`${MICRO} text-muted align-top ${trackClasses(column, deviceIndex > 0 && columnIndex === 0)}`}
+                    >
+                      <span className="flex flex-col items-start gap-2">
+                        <span className="flex items-center gap-4">
+                          {column.provider}
+                          {column.track === "next" ? (
+                            <span className={`${CHIP} border-muted-subtle text-muted`}>Next</span>
+                          ) : null}
+                        </span>
+                        {/*
+                          The provider label above carries no unit, so the version needs
+                          one: without it the number reads as the app's, not the OS it
+                          was built against.
+                        */}
+                        <span className={`${MONO} body-4 text-muted normal-case`}>
+                          OS {column.firmware}
+                        </span>
+                      </span>
+                    </TableHeaderCell>
+                  )),
+                )}
+                <TableHeaderCell className={`${MICRO} text-muted align-top`}>
+                  Devices
+                </TableHeaderCell>
+              </TableHeaderRow>
+            </TableHeader>
+
+            <TableBody>
+              {visibleApps.map(app => (
+                <AppRow
+                  key={app.name}
+                  app={app}
+                  visibleColumns={visibleColumns}
+                  devices={devices}
+                  columns={columns}
+                  selectedKeys={selectedKeys}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </TableRoot>
+
+      {visibleApps.length === 0 ? (
+        <p className="body-3 text-muted py-56 text-center">
+          {matrix ? "No app matches this filter." : "Loading catalog…"}
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/web-tools/src/pages/firmware-app-deployments/PageShell.tsx
+++ b/apps/web-tools/src/pages/firmware-app-deployments/PageShell.tsx
@@ -1,0 +1,60 @@
+import { useEffect, type ReactNode } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { Link, ThemeProvider } from "@ledgerhq/lumen-ui-react";
+import { ArrowLeft } from "@ledgerhq/lumen-ui-react/symbols";
+
+/**
+ * A local shell rather than the shared ToolPage, because this page needs two things
+ * ToolPage does not offer and that the other tools have no use for: a container wide
+ * enough for the matrix, and a single-line header with the collection status beside the
+ * title. Everything else — theme, canvas, back link, heading — mirrors ToolPage, so the
+ * page still reads as part of the same site.
+ */
+export function PageShell({
+  title,
+  actions,
+  children,
+}: {
+  title: string;
+  /** Right-aligned content on the title line, for page-level status and actions. */
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  /*
+   * index.html gives every tool the same tab title, and the app has no per-route title
+   * handling. The previous title is captured rather than hardcoded, so leaving the page
+   * restores it.
+   */
+  useEffect(() => {
+    const previous = document.title;
+    document.title = `${title} · ${previous}`;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+
+  return (
+    <ThemeProvider colorScheme="system">
+      <main className="bg-canvas min-h-screen px-24 py-24 body-2 text-base">
+        <div className="mx-auto flex w-full min-w-0 max-w-[1280px] flex-col gap-16">
+          <header className="flex flex-wrap items-center justify-between gap-x-16 gap-y-8">
+            <div className="flex flex-wrap items-center gap-8">
+              <Link asChild appearance="accent" size="sm">
+                <RouterLink to="/" className="inline-flex items-center gap-4">
+                  <ArrowLeft size={16} />
+                  Back to tools
+                </RouterLink>
+              </Link>
+              <span className="text-muted-subtle" aria-hidden="true">
+                ·
+              </span>
+              <h1 className="heading-3 text-base">{title}</h1>
+            </div>
+            {actions ? <div className="flex flex-wrap items-center gap-12">{actions}</div> : null}
+          </header>
+          {children}
+        </div>
+      </main>
+    </ThemeProvider>
+  );
+}

--- a/apps/web-tools/src/pages/firmware-app-deployments/api.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/api.ts
@@ -1,0 +1,43 @@
+import { getEnv } from "@shared/env";
+import type { CatalogEntry, DeviceVersion, FinalFirmwareVersion } from "./types";
+
+/*
+ * The Manager API is read straight from the browser with `fetch`, rather than through
+ * live-common's HttpManagerApiRepository, for two reasons:
+ *
+ *   - `catalogForDevice` is wrapped in a 5-minute LRU cache. This page has an explicit
+ *     Refresh button, and a refresh that silently replays a cached response is not one.
+ *   - the repository is built for a plugged-in device, so it only exposes single-item
+ *     lookups. Enumerating every device and every published OS — which is the whole job
+ *     here — has no equivalent on it.
+ *
+ * The base URL still comes from the environment, so the staging switch works as it does
+ * everywhere else. Ledger Live also sends a `livecommonversion` query parameter; it is
+ * omitted deliberately, because every endpoint returns byte-identical responses with it,
+ * without it, and with a nonsense value.
+ */
+const fetchJson = async <T>(path: string): Promise<T> => {
+  const response = await fetch(`${getEnv("MANAGER_API_BASE")}${path}`);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText} on ${path}`);
+  }
+  return response.json() as Promise<T>;
+};
+
+export const fetchDeviceVersions = (): Promise<DeviceVersion[]> =>
+  fetchJson<DeviceVersion[]>("/device_versions");
+
+export const fetchFinalFirmwareVersions = (): Promise<FinalFirmwareVersion[]> =>
+  fetchJson<FinalFirmwareVersion[]>("/firmware_final_versions");
+
+export const fetchCatalog = (params: {
+  provider: number;
+  targetId: number;
+  firmwareVersionName: string;
+}): Promise<CatalogEntry[]> =>
+  fetchJson<CatalogEntry[]>(
+    "/v2/apps/by-target" +
+      `?provider=${params.provider}` +
+      `&target_id=${params.targetId}` +
+      `&firmware_version_name=${encodeURIComponent(params.firmwareVersionName)}`,
+  );

--- a/apps/web-tools/src/pages/firmware-app-deployments/cache.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/cache.ts
@@ -1,0 +1,24 @@
+import { CACHE_KEY } from "./constants";
+import { isUsableMatrix } from "./logic";
+import type { Matrix } from "./types";
+
+export const readCache = (): Matrix | null => {
+  try {
+    const cached = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "null") as Matrix | null;
+    return isUsableMatrix(cached) ? cached : null;
+  } catch {
+    // Denied storage or a corrupt entry — treat it as empty.
+    return null;
+  }
+};
+
+/** Returns an error message when the matrix could not be cached, `null` otherwise. */
+export const writeCache = (value: Matrix): string | null => {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(value));
+    return null;
+  } catch (error) {
+    const reason = error instanceof Error ? error.name : "unknown error";
+    return `Could not cache locally (${reason}). Data will be refetched next load.`;
+  }
+};

--- a/apps/web-tools/src/pages/firmware-app-deployments/collect.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/collect.ts
@@ -1,0 +1,104 @@
+import { fetchCatalog, fetchDeviceVersions, fetchFinalFirmwareVersions } from "./api";
+import { FIRMWARE_ATTEMPTS, REQUEST_CONCURRENCY } from "./constants";
+import { buildMatrix, errorMessage, planSlots } from "./logic";
+import type { CatalogEntry, Matrix, Slot } from "./types";
+
+/** Maps over items with a bounded number of requests in flight, keeping order. */
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  transform: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await transform(items[index]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+};
+
+/**
+ * Fetches a slot's catalog, trying firmware candidates newest-first until one returns
+ * apps. Judging a firmware by its name alone is unreliable — Stax has shipped a
+ * production entry named "2.0.2-tr1" whose catalog is empty — so the result decides
+ * rather than the name.
+ */
+const fetchSlotCatalog = async (
+  slot: Slot,
+  addWarning: (message: string) => void,
+): Promise<{ firmware: string; catalog: CatalogEntry[] } | null> => {
+  const attempts = slot.mayBeEmpty ? 1 : FIRMWARE_ATTEMPTS;
+  const tried: string[] = [];
+
+  for (const firmware of slot.candidates.slice(0, attempts)) {
+    tried.push(firmware.name);
+
+    let catalog: CatalogEntry[];
+    try {
+      catalog = await fetchCatalog({
+        provider: slot.provider.id,
+        targetId: slot.targetId,
+        firmwareVersionName: firmware.name,
+      });
+    } catch (error) {
+      addWarning(`${slot.key}: firmware ${firmware.name} failed — ${errorMessage(error)}`);
+      continue;
+    }
+
+    if (catalog.length > 0 || slot.mayBeEmpty) {
+      return { firmware: firmware.name, catalog };
+    }
+  }
+
+  addWarning(
+    `${slot.key}: no firmware yielded any apps (tried ${tried.join(", ") || "none"}) — skipped`,
+  );
+  return null;
+};
+
+/** Reads the whole matrix from the API. `onProgress` receives a short status line. */
+export const collectMatrix = async (onProgress: (status: string) => void): Promise<Matrix> => {
+  const warnings: string[] = [];
+  const addWarning = (message: string) => warnings.push(message);
+
+  onProgress("reading device and firmware lists");
+  const [deviceVersions, firmwareVersions] = await Promise.all([
+    fetchDeviceVersions(),
+    fetchFinalFirmwareVersions(),
+  ]);
+
+  const slots = planSlots(deviceVersions, firmwareVersions, addWarning);
+
+  let completed = 0;
+  const fetched = await mapWithConcurrency(slots, REQUEST_CONCURRENCY, async slot => {
+    const result = await fetchSlotCatalog(slot, addWarning);
+    onProgress(`fetching catalogs ${++completed}/${slots.length}`);
+    return { slot, result };
+  });
+
+  const matrix = buildMatrix(
+    fetched.filter(
+      (entry): entry is { slot: Slot; result: { firmware: string; catalog: CatalogEntry[] } } =>
+        entry.result !== null,
+    ),
+    warnings,
+  );
+
+  /*
+   * If the device and firmware lists arrive but every catalog request fails, the result
+   * is a structurally valid matrix describing nothing. Caching that would both hide the
+   * outage behind a fresh timestamp and leave the page with no device to select, so treat
+   * it as the failure it is and keep any existing cache.
+   */
+  if (Object.keys(matrix.columns).length === 0) {
+    throw new Error(`no catalog could be read for any of the ${slots.length} slots`);
+  }
+
+  return matrix;
+};

--- a/apps/web-tools/src/pages/firmware-app-deployments/constants.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/constants.ts
@@ -1,0 +1,46 @@
+import type { DeviceSpec, ProviderSpec } from "./types";
+
+/**
+ * Bump when the shape of the cached matrix changes, so stale caches are discarded rather
+ * than rendered by code that no longer understands them. Editing DEVICES is not such a
+ * change: the cache stores no device list, only columns keyed by device.
+ */
+export const CACHE_KEY = "firmware-app-deployments:v1";
+
+/** Deploys land weekly, so a cache older than this is missing at least one batch. */
+export const STALE_DAYS = 7;
+
+export const FIRMWARE_ATTEMPTS = 4;
+
+export const REQUEST_CONCURRENCY = 4;
+
+/**
+ * Provider ids and their internal names, per the FW-space "Providers management" page.
+ * These are not the key names live-common uses — see getProviderIdUseCase in device-core.
+ *
+ * Providers 80-83 are per-device firmware-upgrade test providers rather than app
+ * staging; 2 (das) and 5 (vault) have no documented owner. Neither is collected.
+ * P3 (club) is a genuine pre-production provider but holds only the swap set, so it is
+ * left out; adding it here is enough to bring its columns back.
+ */
+export const PROVIDERS: ProviderSpec[] = [
+  { id: 1, label: "P1" }, // vanilla — production
+  { id: 4, label: "P4" }, // test — pre-production
+];
+
+/**
+ * `label` is what the page shows, and deliberately not the API's own `name`: the catalog
+ * still carries internal codenames for devices that ship under another one. Device 136 is
+ * "Apex P" in the API and Gen5 in marketing material.
+ */
+export const DEVICES: DeviceSpec[] = [
+  { id: 16, key: "nanosp", label: "Nano S Plus" },
+  { id: 9, key: "nanox", label: "Nano X" },
+  { id: 17, key: "stax", label: "Stax" },
+  { id: 135, key: "flex", label: "Flex" },
+  { id: 136, key: "apex", label: "Gen5" },
+];
+
+/** The device selected on a first visit. Keep it first in DEVICES, so it also leads the
+ * controls and the chips. */
+export const DEFAULT_DEVICE = "nanosp";

--- a/apps/web-tools/src/pages/firmware-app-deployments/index.tsx
+++ b/apps/web-tools/src/pages/firmware-app-deployments/index.tsx
@@ -1,0 +1,26 @@
+import { PageShell } from "./PageShell";
+import {
+  FirmwareAppDeploymentsActions,
+  FirmwareAppDeploymentsView,
+} from "./FirmwareAppDeploymentsView";
+import { useFirmwareAppDeploymentsViewModel } from "./useFirmwareAppDeploymentsViewModel";
+
+export default function FirmwareAppDeployments() {
+  const viewModel = useFirmwareAppDeploymentsViewModel();
+
+  return (
+    <PageShell
+      title="Firmware App Deployments"
+      actions={
+        <FirmwareAppDeploymentsActions
+          matrix={viewModel.matrix}
+          status={viewModel.status}
+          refreshing={viewModel.refreshing}
+          onRefresh={viewModel.onRefresh}
+        />
+      }
+    >
+      <FirmwareAppDeploymentsView {...viewModel} />
+    </PageShell>
+  );
+}

--- a/apps/web-tools/src/pages/firmware-app-deployments/logic.test.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/logic.test.ts
@@ -1,0 +1,462 @@
+import {
+  buildMatrix,
+  devicesInMatrix,
+  errorMessage,
+  incompleteCollectionNotice,
+  isUsableMatrix,
+  parseDeviceSelection,
+  serialiseDeviceSelection,
+  isStale,
+  formatInstant,
+  matchesFilter,
+  pickFirmwareTracks,
+  planSlots,
+  rankFirmware,
+  repoFromSourceUrl,
+} from "./logic";
+import { STALE_DAYS } from "./constants";
+import type { CatalogEntry, DeviceVersion, FinalFirmwareVersion, Matrix, Slot } from "./types";
+
+const firmware = (
+  name: string,
+  device_versions: number[] = [16],
+  providers: number[] = [1],
+): FinalFirmwareVersion => ({ name, device_versions, providers });
+
+describe("isStale", () => {
+  it("accepts a timestamp inside the staleness window", () => {
+    const recent = new Date(Date.now() - (STALE_DAYS - 1) * 86_400_000).toISOString();
+    expect(isStale(recent)).toBe(false);
+  });
+
+  it("rejects a timestamp older than the staleness window", () => {
+    const old = new Date(Date.now() - (STALE_DAYS + 1) * 86_400_000).toISOString();
+    expect(isStale(old)).toBe(true);
+  });
+});
+
+describe("formatInstant", () => {
+  it("keeps the UTC date and minutes, dropping seconds and the T separator", () => {
+    expect(formatInstant("2026-09-11T08:34:57.123Z")).toBe("2026-09-11 08:34");
+  });
+});
+
+describe("rankFirmware", () => {
+  it("puts stable releases ahead of prereleases of a higher version", () => {
+    const ranked = rankFirmware([firmware("1.6.0-rc1"), firmware("1.5.0")]);
+    expect(ranked.map(version => version.name)).toEqual(["1.5.0", "1.6.0-rc1"]);
+  });
+
+  it("orders stable releases by version, newest first", () => {
+    const ranked = rankFirmware([firmware("1.5.0"), firmware("1.10.0"), firmware("1.6.0")]);
+    expect(ranked.map(version => version.name)).toEqual(["1.10.0", "1.6.0", "1.5.0"]);
+  });
+
+  it("orders prereleases naturally, so rc10 outranks rc2", () => {
+    const ranked = rankFirmware([firmware("1.6.0-rc2"), firmware("1.6.0-rc10")]);
+    expect(ranked.map(version => version.name)).toEqual(["1.6.0-rc10", "1.6.0-rc2"]);
+  });
+
+  it("drops entries with no parsable version core", () => {
+    const ranked = rankFirmware([firmware("nightly"), firmware("1.5.0")]);
+    expect(ranked.map(version => version.name)).toEqual(["1.5.0"]);
+  });
+});
+
+describe("pickFirmwareTracks", () => {
+  it("takes the newest stable as current and the prerelease above it as next", () => {
+    const ranked = rankFirmware([firmware("1.6.0-rc1"), firmware("1.5.0"), firmware("1.4.0")]);
+    const { current, next } = pickFirmwareTracks(ranked);
+
+    expect(current?.name).toBe("1.5.0");
+    expect(next?.name).toBe("1.6.0-rc1");
+  });
+
+  it("reports no next track when every prerelease is below the newest stable", () => {
+    const ranked = rankFirmware([firmware("1.5.0"), firmware("1.4.0-rc3")]);
+    const { current, next } = pickFirmwareTracks(ranked);
+
+    expect(current?.name).toBe("1.5.0");
+    expect(next).toBeNull();
+  });
+
+  it("reports no tracks at all when nothing stable is published", () => {
+    expect(pickFirmwareTracks(rankFirmware([firmware("1.6.0-rc1")]))).toEqual({
+      current: null,
+      next: null,
+    });
+  });
+});
+
+describe("repoFromSourceUrl", () => {
+  it.each([
+    ["https://github.com/LedgerHQ/app-concordium", "LedgerHQ/app-concordium"],
+    ["https://github.com/LedgerHQ/app-concordium.git", "LedgerHQ/app-concordium"],
+    ["https://github.com/LedgerHQ/app-concordium/tree/develop", "LedgerHQ/app-concordium"],
+  ])("reads %s as %s", (sourceUrl, expected) => {
+    expect(repoFromSourceUrl(sourceUrl)).toBe(expected);
+  });
+
+  it.each([undefined, "", "https://gitlab.com/LedgerHQ/app-concordium"])(
+    "returns null for %s",
+    sourceUrl => {
+      expect(repoFromSourceUrl(sourceUrl)).toBeNull();
+    },
+  );
+});
+
+describe("planSlots", () => {
+  const deviceVersions: DeviceVersion[] = [{ id: 16, target_id: 856686596, providers: [1, 4] }];
+
+  it("plans a current and a next slot per provider the device supports", () => {
+    const slots = planSlots(
+      deviceVersions,
+      [firmware("1.5.0", [16], [1, 4]), firmware("1.6.0-rc1", [16], [1, 4])],
+      () => {},
+    );
+
+    expect(slots.map(slot => slot.key)).toEqual([
+      "nanosp/P1/current",
+      "nanosp/P1/next",
+      "nanosp/P4/current",
+      "nanosp/P4/next",
+    ]);
+  });
+
+  it("gives the current slot every stable release as a fallback, newest first", () => {
+    const slots = planSlots(
+      deviceVersions,
+      [firmware("1.5.0"), firmware("1.4.0"), firmware("1.6.0-rc1")],
+      () => {},
+    );
+    const current = slots.find(slot => slot.track === "current")!;
+
+    expect(current.candidates.map(version => version.name)).toEqual(["1.5.0", "1.4.0"]);
+    expect(current.mayBeEmpty).toBe(false);
+  });
+
+  it("gives the next slot exactly one candidate and lets it come back empty", () => {
+    const slots = planSlots(deviceVersions, [firmware("1.5.0"), firmware("1.6.0-rc1")], () => {});
+    const next = slots.find(slot => slot.track === "next")!;
+
+    expect(next.candidates.map(version => version.name)).toEqual(["1.6.0-rc1"]);
+    expect(next.mayBeEmpty).toBe(true);
+  });
+
+  it("skips providers the device does not list", () => {
+    const slots = planSlots(
+      [{ id: 16, target_id: 856686596, providers: [1] }],
+      [firmware("1.5.0", [16], [1, 4])],
+      () => {},
+    );
+
+    expect(slots.every(slot => slot.provider.label === "P1")).toBe(true);
+  });
+
+  it("warns and skips when a device is absent from device_versions", () => {
+    const warnings: string[] = [];
+    const slots = planSlots([], [firmware("1.5.0")], message => warnings.push(message));
+
+    expect(slots).toEqual([]);
+    expect(warnings).toContain("device Nano X (id 9) absent from device_versions");
+  });
+
+  it("warns and skips a provider with no stable firmware", () => {
+    const warnings: string[] = [];
+    const slots = planSlots(
+      [{ id: 16, target_id: 856686596, providers: [1] }],
+      [firmware("1.6.0-rc1")],
+      message => warnings.push(message),
+    );
+
+    expect(slots).toEqual([]);
+    expect(warnings).toContain("nanosp/P1: no stable firmware listed — slot skipped");
+  });
+});
+
+describe("buildMatrix", () => {
+  const slot = (key: string, deviceKey: string, provider: string, track: "current" | "next") =>
+    ({
+      key,
+      device: { id: 16, key: deviceKey, label: deviceKey },
+      provider: { id: provider === "P1" ? 1 : 4, label: provider },
+      targetId: 856686596,
+      track,
+      candidates: [],
+      mayBeEmpty: track === "next",
+    }) as Slot;
+
+  const entry = (overrides: Partial<CatalogEntry> = {}): CatalogEntry => ({
+    versionName: "Concordium",
+    versionDisplayName: "Concordium",
+    version: "1.0.0",
+    sourceURL: "https://github.com/LedgerHQ/app-concordium",
+    dateModified: "2026-08-01T09:00:00Z",
+    ...overrides,
+  });
+
+  it("folds one app seen on two slots into a single row with both versions", () => {
+    const matrix = buildMatrix(
+      [
+        {
+          slot: slot("nanosp/P1/current", "nanosp", "P1", "current"),
+          result: { firmware: "1.5.0", catalog: [entry()] },
+        },
+        {
+          slot: slot("nanosp/P4/current", "nanosp", "P4", "current"),
+          result: { firmware: "1.5.0", catalog: [entry({ version: "1.1.0" })] },
+        },
+      ],
+      [],
+    );
+
+    expect(matrix.apps).toHaveLength(1);
+    expect(matrix.apps[0].versions).toEqual({
+      "nanosp/P1/current": { version: "1.0.0", modified: "2026-08-01" },
+      "nanosp/P4/current": { version: "1.1.0", modified: "2026-08-01" },
+    });
+    expect(matrix.apps[0].repo).toBe("LedgerHQ/app-concordium");
+  });
+
+  it("orders columns by provider, and a provider's current track before its next", () => {
+    const matrix = buildMatrix(
+      [
+        {
+          slot: slot("nanosp/P4/next", "nanosp", "P4", "next"),
+          result: { firmware: "1.6.0-rc1", catalog: [entry()] },
+        },
+        {
+          slot: slot("nanosp/P4/current", "nanosp", "P4", "current"),
+          result: { firmware: "1.5.0", catalog: [entry()] },
+        },
+        {
+          slot: slot("nanosp/P1/current", "nanosp", "P1", "current"),
+          result: { firmware: "1.5.0", catalog: [entry()] },
+        },
+      ],
+      [],
+    );
+
+    expect(matrix.columns.nanosp.map(column => column.key)).toEqual([
+      "nanosp/P1/current",
+      "nanosp/P4/current",
+      "nanosp/P4/next",
+    ]);
+  });
+
+  it("keeps the first non-empty sourceURL when another slot omits it", () => {
+    const matrix = buildMatrix(
+      [
+        {
+          slot: slot("nanosp/P1/current", "nanosp", "P1", "current"),
+          result: { firmware: "1.5.0", catalog: [entry({ sourceURL: "" })] },
+        },
+        {
+          slot: slot("nanosp/P4/current", "nanosp", "P4", "current"),
+          result: { firmware: "1.5.0", catalog: [entry()] },
+        },
+      ],
+      [],
+    );
+
+    expect(matrix.apps[0].repo).toBe("LedgerHQ/app-concordium");
+  });
+
+  it("sorts apps by display name", () => {
+    const matrix = buildMatrix(
+      [
+        {
+          slot: slot("nanosp/P1/current", "nanosp", "P1", "current"),
+          result: {
+            firmware: "1.5.0",
+            catalog: [
+              entry({ versionName: "Zcash", versionDisplayName: "Zcash" }),
+              entry({ versionName: "Aptos", versionDisplayName: "Aptos" }),
+            ],
+          },
+        },
+      ],
+      [],
+    );
+
+    expect(matrix.apps.map(app => app.name)).toEqual(["Aptos", "Zcash"]);
+  });
+
+  it("falls back to versionName when the catalog has no display name", () => {
+    const matrix = buildMatrix(
+      [
+        {
+          slot: slot("nanosp/P1/current", "nanosp", "P1", "current"),
+          result: { firmware: "1.5.0", catalog: [entry({ versionDisplayName: undefined })] },
+        },
+      ],
+      [],
+    );
+
+    expect(matrix.apps[0].name).toBe("Concordium");
+  });
+
+  it("keys columns by device and carries the warnings through", () => {
+    const matrix = buildMatrix(
+      [
+        {
+          slot: slot("stax/P1/current", "stax", "P1", "current"),
+          result: { firmware: "1.5.0", catalog: [entry()] },
+        },
+        {
+          slot: slot("nanosp/P1/current", "nanosp", "P1", "current"),
+          result: { firmware: "1.5.0", catalog: [entry()] },
+        },
+      ],
+      ["something was skipped"],
+    );
+
+    expect(Object.keys(matrix.columns).sort()).toEqual(["nanosp", "stax"]);
+    expect(matrix.warnings).toEqual(["something was skipped"]);
+  });
+});
+
+describe("devicesInMatrix", () => {
+  it("returns devices in DEVICES order, not the order the matrix was built in", () => {
+    const devices = devicesInMatrix({ stax: [], nanosp: [], nanox: [] });
+    expect(devices.map(device => device.key)).toEqual(["nanosp", "nanox", "stax"]);
+  });
+
+  it("labels devices from the configuration rather than from the data", () => {
+    expect(devicesInMatrix({ apex: [] })).toEqual([{ key: "apex", label: "Gen5" }]);
+  });
+
+  it("drops a device the configuration no longer lists, as a stale cache would hold", () => {
+    expect(devicesInMatrix({ nanosp: [], blue: [] }).map(device => device.key)).toEqual(["nanosp"]);
+  });
+
+  it("returns nothing for an absent matrix", () => {
+    expect(devicesInMatrix(undefined)).toEqual([]);
+  });
+});
+
+describe("errorMessage", () => {
+  it("reads the message off an Error", () => {
+    expect(errorMessage(new Error("503 Service Unavailable"))).toBe("503 Service Unavailable");
+  });
+
+  it.each([
+    ["a string", "boom", "boom"],
+    ["a plain object", { code: 42 }, "[object Object]"],
+    ["undefined", undefined, "undefined"],
+  ])("stringifies %s", (_label, thrown, expected) => {
+    expect(errorMessage(thrown)).toBe(expected);
+  });
+});
+
+describe("isUsableMatrix", () => {
+  const cached = (overrides: Partial<Matrix> = {}): Matrix => ({
+    collectedAt: "2026-09-11T07:00:00.000Z",
+    columns: { nanosp: [{ key: "nanosp/P1/current" }] as Matrix["columns"][string] },
+    apps: [{ name: "Concordium", repo: null, versions: {} }],
+    warnings: [],
+    ...overrides,
+  });
+
+  it("accepts a matrix with apps and at least one populated device", () => {
+    expect(isUsableMatrix(cached())).toBe(true);
+  });
+
+  it.each([null, undefined])("rejects %s", value => {
+    expect(isUsableMatrix(value as Matrix | null)).toBe(false);
+  });
+
+  it("rejects a matrix with no apps", () => {
+    expect(isUsableMatrix(cached({ apps: [] }))).toBe(false);
+  });
+
+  it("rejects a matrix with no devices", () => {
+    expect(isUsableMatrix(cached({ columns: {} }))).toBe(false);
+  });
+
+  // An empty array is truthy, so this is the case a plain truthiness check lets through.
+  it("rejects a device whose column list is empty", () => {
+    expect(isUsableMatrix(cached({ columns: { nanosp: [] } }))).toBe(false);
+  });
+
+  it("rejects a device whose column list is not an array", () => {
+    const corrupt = { nanosp: 5 } as unknown as Matrix["columns"];
+    expect(isUsableMatrix(cached({ columns: corrupt }))).toBe(false);
+  });
+});
+
+describe("incompleteCollectionNotice", () => {
+  const matrix = (warnings: string[]): Matrix => ({
+    collectedAt: "2026-09-11T07:00:00.000Z",
+    columns: { nanosp: [] },
+    apps: [],
+    warnings,
+  });
+
+  // Regression: readCache hydrates a partial matrix and the mount effect skips fetching,
+  // so a notice written only while collecting would never appear.
+  it("reports the warnings a cached partial collection carries", () => {
+    expect(
+      incompleteCollectionNotice(matrix(["nanosp/P4/next: firmware 1.7.0-rc2 failed"])),
+    ).toEqual({
+      appearance: "warning",
+      title: "Collection was incomplete — some slots are missing.",
+      details: ["nanosp/P4/next: firmware 1.7.0-rc2 failed"],
+    });
+  });
+
+  it("reports nothing for a complete collection", () => {
+    expect(incompleteCollectionNotice(matrix([]))).toBeNull();
+  });
+
+  it("reports nothing before any matrix is loaded", () => {
+    expect(incompleteCollectionNotice(null)).toBeNull();
+  });
+});
+
+describe("device selection in the URL", () => {
+  const set = (...keys: string[]) => new Set(keys);
+
+  it("reads the default selection when the parameter is absent", () => {
+    expect(parseDeviceSelection(null)).toEqual(set("nanosp"));
+  });
+
+  it("writes no parameter for the default selection, so a plain link stays plain", () => {
+    expect(serialiseDeviceSelection(set("nanosp"))).toBeNull();
+  });
+
+  it("round-trips an explicit selection", () => {
+    const value = serialiseDeviceSelection(set("stax", "flex"));
+    expect(value).toBe("stax,flex");
+    expect(parseDeviceSelection(value)).toEqual(set("stax", "flex"));
+  });
+
+  it("writes DEVICES order regardless of the order boxes were ticked", () => {
+    expect(serialiseDeviceSelection(set("apex", "nanosp", "stax"))).toBe("nanosp,stax,apex");
+  });
+
+  it("spells the empty selection so it is not read back as the default", () => {
+    expect(serialiseDeviceSelection(set())).toBe("none");
+    expect(parseDeviceSelection("none")).toEqual(set());
+  });
+
+  it("ignores keys that name no configured device", () => {
+    expect(parseDeviceSelection("stax,blue,,nanosp")).toEqual(set("nanosp", "stax"));
+  });
+});
+
+describe("matchesFilter", () => {
+  const app = { name: "Concordium", repo: "LedgerHQ/app-concordium", versions: {} };
+
+  it.each(["concord", "ledgerhq/app"])("matches on %s", needle => {
+    expect(matchesFilter(app, needle)).toBe(true);
+  });
+
+  it("does not match an unrelated needle", () => {
+    expect(matchesFilter(app, "tezos")).toBe(false);
+  });
+
+  it("tolerates an app with no repository", () => {
+    expect(matchesFilter({ ...app, repo: null }, "concord")).toBe(true);
+  });
+});

--- a/apps/web-tools/src/pages/firmware-app-deployments/logic.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/logic.ts
@@ -1,0 +1,294 @@
+import { DEFAULT_DEVICE, DEVICES, PROVIDERS, STALE_DAYS } from "./constants";
+import type {
+  CatalogEntry,
+  Notice,
+  DeviceVersion,
+  FinalFirmwareVersion,
+  Matrix,
+  MatrixApp,
+  MatrixColumn,
+  ShownDevice,
+  Slot,
+} from "./types";
+
+/**
+ * The message from a thrown value, which is not guaranteed to be an Error. A rejected
+ * fetch would otherwise reach the reader as "undefined" — these messages are shown, in a
+ * collection warning and in the failure banner.
+ */
+export const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+export const isStale = (isoDate: string): boolean =>
+  Date.now() - Date.parse(isoDate) > STALE_DAYS * 86_400_000;
+
+/*
+ * Timestamps stay ISO-ordered and in UTC rather than localised. This is a machine
+ * readout — versions, OS names, hashes — and an ISO date sorts by eye, aligns in a
+ * column, and cannot be misread between locales. It also keeps every date on the page in
+ * one timezone, so the header and the cells can be compared directly.
+ */
+export const formatInstant = (isoDate: string): string => isoDate.slice(0, 16).replace("T", " ");
+
+export const isStableFirmware = (name: string): boolean => /^\d+\.\d+\.\d+$/.test(name);
+
+const firmwareCore = (name: string): [number, number, number] | null => {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(name);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+};
+
+const compareFirmwareCore = (a: [number, number, number], b: [number, number, number]): number => {
+  for (let index = 0; index < 3; index++) {
+    if (a[index] !== b[index]) return a[index] - b[index];
+  }
+  return 0;
+};
+
+/**
+ * Digit-aware string compare, so -rc10 sorts above -rc2 rather than below it the way a
+ * plain lexicographic compare would.
+ */
+const naturalCompare = new Intl.Collator("en", { numeric: true }).compare;
+
+/**
+ * Firmware candidates, best first: stable releases before prereleases, then by number,
+ * then by name so -rc10 outranks -rc2. This sets preference order only — which firmware
+ * is actually right is settled by fetchSlotCatalog trying them.
+ */
+export const rankFirmware = (versions: FinalFirmwareVersion[]): FinalFirmwareVersion[] =>
+  versions
+    .filter(version => firmwareCore(version.name))
+    .sort(
+      (a, b) =>
+        Number(isStableFirmware(b.name)) - Number(isStableFirmware(a.name)) ||
+        compareFirmwareCore(firmwareCore(b.name)!, firmwareCore(a.name)!) ||
+        naturalCompare(b.name, a.name),
+    );
+
+/**
+ * The two firmware tracks worth reading for a device and provider:
+ *
+ *   current — the newest stable OS, i.e. what devices in the field run;
+ *   next    — the newest prerelease OS ranked above it, when one is published.
+ *
+ * The catalog is scoped to a firmware version and an app only appears once it has been
+ * rebuilt against that OS, which makes the next track a direct readout of what is ready
+ * for the upcoming release.
+ */
+export const pickFirmwareTracks = (
+  candidates: FinalFirmwareVersion[],
+): { current: FinalFirmwareVersion | null; next: FinalFirmwareVersion | null } => {
+  const current = candidates.find(version => isStableFirmware(version.name));
+  if (!current) return { current: null, next: null };
+
+  const next = candidates.find(
+    version => compareFirmwareCore(firmwareCore(version.name)!, firmwareCore(current.name)!) > 0,
+  );
+  return { current, next: next ?? null };
+};
+
+/** github.com/LedgerHQ/app-foo -> LedgerHQ/app-foo */
+export const repoFromSourceUrl = (sourceUrl: string | undefined): string | null => {
+  const match = /github\.com\/([^/]+\/[^/#?]+)/.exec(sourceUrl ?? "");
+  return match ? match[1].replace(/\.git$/, "") : null;
+};
+
+/** Every device × provider × track combination worth fetching. */
+export const planSlots = (
+  deviceVersions: DeviceVersion[],
+  firmwareVersions: FinalFirmwareVersion[],
+  addWarning: (message: string) => void,
+): Slot[] => {
+  const slots: Slot[] = [];
+
+  for (const device of DEVICES) {
+    const apiDevice = deviceVersions.find(candidate => candidate.id === device.id);
+    if (!apiDevice) {
+      addWarning(`device ${device.label} (id ${device.id}) absent from device_versions`);
+      continue;
+    }
+
+    for (const provider of PROVIDERS) {
+      if (!apiDevice.providers.includes(provider.id)) continue;
+
+      const candidates = rankFirmware(
+        firmwareVersions.filter(
+          firmware =>
+            firmware.device_versions.includes(device.id) &&
+            firmware.providers.includes(provider.id),
+        ),
+      );
+
+      const { current, next } = pickFirmwareTracks(candidates);
+      if (!current) {
+        addWarning(`${device.key}/${provider.label}: no stable firmware listed — slot skipped`);
+        continue;
+      }
+
+      const common = { device, provider, targetId: apiDevice.target_id };
+
+      slots.push({
+        ...common,
+        key: `${device.key}/${provider.label}/current`,
+        track: "current",
+        // An empty current track means the firmware choice was wrong, so allow fallbacks.
+        candidates: candidates.filter(version => isStableFirmware(version.name)),
+        mayBeEmpty: false,
+      });
+
+      if (next) {
+        slots.push({
+          ...common,
+          key: `${device.key}/${provider.label}/next`,
+          track: "next",
+          candidates: [next],
+          mayBeEmpty: true,
+        });
+      }
+    }
+  }
+
+  return slots;
+};
+
+/**
+ * Whether a parsed cache entry can be rendered. The cache is the only untrusted input the
+ * page has, and an empty column array passes a truthiness check while breaking the header:
+ * the device survives into the group row with `colSpan={0}` and contributes no cells to
+ * the track row below, so the two rows disagree on column count.
+ */
+export const isUsableMatrix = (value: Matrix | null): boolean => {
+  const columns: Record<string, unknown> = value?.columns ?? {};
+  const groups = Object.values(columns);
+
+  return Boolean(
+    value &&
+    value.apps?.length > 0 &&
+    groups.length > 0 &&
+    groups.every(group => Array.isArray(group) && group.length > 0),
+  );
+};
+
+/**
+ * Warnings belong to the matrix, not to the collection that produced it: a partial result
+ * is cached with its warnings, and reopening the page hydrates it without collecting
+ * again. Derived here so a missing column never reads as an absent app.
+ */
+export const incompleteCollectionNotice = (matrix: Matrix | null): Notice | null =>
+  matrix && matrix.warnings.length > 0
+    ? {
+        appearance: "warning",
+        title: "Collection was incomplete — some slots are missing.",
+        details: matrix.warnings,
+      }
+    : null;
+
+/**
+ * Which devices are shown is view state, and this page is made to be linked, so it lives
+ * in the URL.
+ *
+ * The default selection writes no parameter, so a plain link stays plain. An empty
+ * selection is deliberate rather than default, so it needs a spelling of its own —
+ * `none`, which no device key can collide with.
+ */
+export const DEVICES_PARAM = "devices";
+const NO_DEVICES = "none";
+
+const isDefaultSelection = (selected: Set<string>) =>
+  selected.size === 1 && selected.has(DEFAULT_DEVICE);
+
+export const parseDeviceSelection = (raw: string | null): Set<string> => {
+  if (raw === null) return new Set([DEFAULT_DEVICE]);
+  if (raw === NO_DEVICES) return new Set();
+
+  const keys = new Set(raw.split(",").filter(Boolean));
+  return new Set(DEVICES.filter(device => keys.has(device.key)).map(device => device.key));
+};
+
+/** The parameter value for a selection, or `null` when it is the default and can be omitted. */
+export const serialiseDeviceSelection = (selected: Set<string>): string | null => {
+  if (isDefaultSelection(selected)) return null;
+  if (selected.size === 0) return NO_DEVICES;
+
+  // DEVICES order, so the link reads the same however the boxes were clicked.
+  return DEVICES.filter(device => selected.has(device.key))
+    .map(device => device.key)
+    .join(",");
+};
+
+/**
+ * The devices a matrix can show, in DEVICES order. Derived rather than stored, so the one
+ * constant decides both which devices appear and in what order — a cached matrix cannot
+ * disagree with the configuration, and reordering DEVICES needs no cache invalidation.
+ */
+export const devicesInMatrix = (columns: Matrix["columns"] | undefined): ShownDevice[] =>
+  DEVICES.filter(device => columns?.[device.key]).map(({ key, label }) => ({ key, label }));
+
+/** Folds fetched catalogs into the shape the table renders from. */
+export const buildMatrix = (
+  fetched: { slot: Slot; result: { firmware: string; catalog: CatalogEntry[] } }[],
+  warnings: string[],
+): Matrix => {
+  const columnsBySlot: MatrixColumn[] = fetched.map(({ slot, result }) => ({
+    key: slot.key,
+    deviceKey: slot.device.key,
+    provider: slot.provider.label,
+    track: slot.track,
+    firmware: result.firmware,
+  }));
+
+  const providerOrder = new Map(PROVIDERS.map((provider, index) => [provider.label, index]));
+
+  const byDevice = new Map<string, MatrixColumn[]>();
+  for (const column of columnsBySlot) {
+    const bucket = byDevice.get(column.deviceKey);
+    if (bucket) bucket.push(column);
+    else byDevice.set(column.deviceKey, [column]);
+  }
+
+  const devices = DEVICES.filter(device => byDevice.has(device.key));
+
+  // Providers in configured order, and each provider's current OS before its next.
+  const columns = Object.fromEntries(
+    devices.map(device => [
+      device.key,
+      byDevice
+        .get(device.key)!
+        .sort(
+          (a, b) =>
+            providerOrder.get(a.provider)! - providerOrder.get(b.provider)! ||
+            Number(a.track === "next") - Number(b.track === "next"),
+        ),
+    ]),
+  );
+
+  const byName = new Map<string, MatrixApp>();
+  for (const { slot, result } of fetched) {
+    for (const entry of result.catalog) {
+      let app = byName.get(entry.versionName);
+      if (!app) {
+        app = {
+          name: entry.versionDisplayName || entry.versionName,
+          repo: repoFromSourceUrl(entry.sourceURL),
+          versions: {},
+        };
+        byName.set(entry.versionName, app);
+      }
+
+      // sourceURL is empty on some slots, so keep the first non-empty one seen.
+      app.repo ??= repoFromSourceUrl(entry.sourceURL);
+
+      app.versions[slot.key] = {
+        version: entry.version,
+        modified: entry.dateModified?.slice(0, 10) ?? "",
+      };
+    }
+  }
+
+  const apps = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+
+  return { collectedAt: new Date().toISOString(), columns, apps, warnings };
+};
+
+export const matchesFilter = (app: MatrixApp, needle: string): boolean =>
+  `${app.name} ${app.repo ?? ""}`.toLowerCase().includes(needle);

--- a/apps/web-tools/src/pages/firmware-app-deployments/types.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/types.ts
@@ -1,0 +1,76 @@
+export type DeviceSpec = {
+  /** `device_versions[].id` in the Manager API. */
+  id: number;
+  key: string;
+  label: string;
+};
+
+export type ProviderSpec = {
+  id: number;
+  label: string;
+};
+
+export type DeviceVersion = {
+  id: number;
+  target_id: number;
+  providers: number[];
+};
+
+export type FinalFirmwareVersion = {
+  name: string;
+  device_versions: number[];
+  providers: number[];
+};
+
+export type CatalogEntry = {
+  versionName: string;
+  versionDisplayName?: string;
+  version: string;
+  sourceURL?: string;
+  dateModified?: string;
+};
+
+/** One device × provider × firmware track worth fetching a catalog for. */
+export type Slot = {
+  key: string;
+  device: DeviceSpec;
+  provider: ProviderSpec;
+  targetId: number;
+  track: "current" | "next";
+  candidates: FinalFirmwareVersion[];
+  /** Nothing built for this track yet is a real answer, not a failure. */
+  mayBeEmpty: boolean;
+};
+
+/** A rendered column: one provider's catalog on one firmware track of one device. */
+export type MatrixColumn = {
+  key: string;
+  deviceKey: string;
+  provider: string;
+  track: "current" | "next";
+  firmware: string;
+};
+
+export type MatrixApp = {
+  name: string;
+  repo: string | null;
+  /** Keyed by `MatrixColumn.key`. */
+  versions: Record<string, { version: string; modified: string }>;
+};
+
+/** The banner shown above the table. */
+export type Notice = { appearance: "warning" | "error"; title: string; details?: string[] };
+
+/** A device as the page presents it, resolved from DEVICES rather than from the data. */
+export type ShownDevice = { key: string; label: string };
+
+export type Matrix = {
+  collectedAt: string;
+  /**
+   * Keyed by device key. The order the devices appear in is not stored — it comes from
+   * DEVICES at render time, so the one constant governs both the controls and the table.
+   */
+  columns: Record<string, MatrixColumn[]>;
+  apps: MatrixApp[];
+  warnings: string[];
+};

--- a/apps/web-tools/src/pages/firmware-app-deployments/useFirmwareAppDeploymentsViewModel.ts
+++ b/apps/web-tools/src/pages/firmware-app-deployments/useFirmwareAppDeploymentsViewModel.ts
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { readCache, writeCache } from "./cache";
+import { collectMatrix } from "./collect";
+import { DEVICES } from "./constants";
+import {
+  DEVICES_PARAM,
+  devicesInMatrix,
+  errorMessage,
+  incompleteCollectionNotice,
+  matchesFilter,
+  parseDeviceSelection,
+  serialiseDeviceSelection,
+} from "./logic";
+import type { Matrix, MatrixApp, MatrixColumn, Notice, ShownDevice } from "./types";
+
+/** A column plus whether it opens a new device group, so rows need no per-row grouping. */
+export type VisibleColumn = { column: MatrixColumn; startsGroup: boolean };
+
+export type FirmwareAppDeploymentsViewModel = {
+  matrix: Matrix | null;
+  /** Devices in configured order, with the ones the current matrix cannot show disabled. */
+  deviceOptions: { key: string; label: string; selected: boolean; disabled: boolean }[];
+  devices: ShownDevice[];
+  shownDevices: ShownDevice[];
+  /** Every shown device's columns, flattened once so each row can map straight over it. */
+  visibleColumns: VisibleColumn[];
+  selectedKeys: Set<string>;
+  /** Rows matching the text filter, and the whole catalogue it is matched against. */
+  visibleApps: MatrixApp[];
+  visibleCount: number;
+  totalCount: number;
+  filter: string;
+  status: string | null;
+  notice: Notice | null;
+  refreshing: boolean;
+  onFilterChange: (value: string) => void;
+  onToggleDevice: (key: string) => void;
+  onRefresh: () => void;
+};
+
+export const useFirmwareAppDeploymentsViewModel = (): FirmwareAppDeploymentsViewModel => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = searchParams.get("search") ?? "";
+
+  const [matrix, setMatrix] = useState<Matrix | null>(() => readCache());
+
+  const selectedDevices = useMemo(
+    () => parseDeviceSelection(searchParams.get(DEVICES_PARAM)),
+    [searchParams],
+  );
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  // Only failures live in state; the incomplete-collection notice is derived from the matrix.
+  const [failure, setFailure] = useState<Notice | null>(null);
+
+  // Read inside refresh() without making the callback depend on the matrix, so a
+  // refresh in flight is never restarted by the state it is about to replace.
+  const matrixRef = useRef(matrix);
+  matrixRef.current = matrix;
+
+  const refreshingRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (refreshingRef.current) return;
+
+    refreshingRef.current = true;
+    setRefreshing(true);
+    setFailure(null);
+
+    const hadData = matrixRef.current !== null;
+
+    try {
+      const collected = await collectMatrix(setStatus);
+      const cacheError = writeCache(collected);
+
+      setMatrix(collected);
+      setFailure(cacheError ? { appearance: "warning", title: cacheError } : null);
+    } catch (error) {
+      const message = errorMessage(error);
+      setFailure(
+        hadData
+          ? {
+              appearance: "warning",
+              title: "Refresh failed — showing the cached copy.",
+              details: [message],
+            }
+          : {
+              appearance: "error",
+              title: "Could not load the catalog.",
+              details: [
+                message,
+                "The API is read directly from your browser, so an offline machine or a " +
+                  "blocked network will do this. Press Refresh to try again.",
+              ],
+            },
+      );
+    } finally {
+      setStatus(null);
+      setRefreshing(false);
+      refreshingRef.current = false;
+    }
+  }, []);
+
+  // A usable cache renders immediately and is refreshed by hand; only a cold start fetches.
+  useEffect(() => {
+    if (matrixRef.current === null) void refresh();
+  }, [refresh]);
+
+  const onToggleDevice = useCallback(
+    (key: string) => {
+      setSearchParams(
+        previous => {
+          const selected = parseDeviceSelection(previous.get(DEVICES_PARAM));
+          if (!selected.delete(key)) selected.add(key);
+
+          const next = new URLSearchParams(previous);
+          const value = serialiseDeviceSelection(selected);
+          if (value === null) next.delete(DEVICES_PARAM);
+          else next.set(DEVICES_PARAM, value);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const onFilterChange = useCallback(
+    (value: string) => {
+      // `replace`, not push: typing must not fill the back button.
+      setSearchParams(
+        previous => {
+          const next = new URLSearchParams(previous);
+          if (value.trim()) next.set("search", value);
+          else next.delete("search");
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const deviceOptions = useMemo(
+    () =>
+      DEVICES.map(({ key, label }) => ({
+        key,
+        label,
+        selected: selectedDevices.has(key),
+        disabled: !matrix?.columns[key],
+      })),
+    [matrix, selectedDevices],
+  );
+
+  /** Every device the matrix holds, in DEVICES order — the config, not the cached data. */
+  const devices = useMemo(() => devicesInMatrix(matrix?.columns), [matrix]);
+
+  const shownDevices = useMemo(
+    () => devices.filter(device => selectedDevices.has(device.key)),
+    [devices, selectedDevices],
+  );
+
+  const visibleColumns = useMemo(
+    () =>
+      shownDevices.flatMap((device, deviceIndex) =>
+        (matrix?.columns[device.key] ?? []).map((column, columnIndex) => ({
+          column,
+          startsGroup: deviceIndex > 0 && columnIndex === 0,
+        })),
+      ),
+    [matrix, shownDevices],
+  );
+
+  const selectedKeys = useMemo(
+    () => new Set(shownDevices.map(device => device.key)),
+    [shownDevices],
+  );
+
+  /*
+   * Only the text filter decides which rows exist. Hiding a device must not remove apps:
+   * an app missing from a shown device is the gap the table exists to report.
+   */
+  const visibleApps = useMemo(() => {
+    if (!matrix) return [];
+
+    const needle = filter.trim().toLowerCase();
+    return needle ? matrix.apps.filter(app => matchesFilter(app, needle)) : matrix.apps;
+  }, [matrix, filter]);
+
+  // A failure is about this moment and outranks the standing warning about the matrix on
+  // screen. One banner is rendered, so the order matters.
+  const notice = failure ?? incompleteCollectionNotice(matrix);
+
+  return {
+    matrix,
+    deviceOptions,
+    devices,
+    shownDevices,
+    visibleColumns,
+    selectedKeys,
+    visibleApps,
+    visibleCount: visibleApps.length,
+    totalCount: matrix?.apps.length ?? 0,
+    filter,
+    status,
+    notice,
+    refreshing,
+    onFilterChange,
+    onToggleDevice,
+    onRefresh: refresh,
+  };
+};

--- a/apps/web-tools/src/pages/index.tsx
+++ b/apps/web-tools/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { Tile, TileContent, TileTitle, TileDescription, Spot } from "@ledgerhq/lumen-ui-react";
 import {
+  Apps,
   ChartPie,
   ColorPalette,
   LedgerLogo,
@@ -15,7 +16,8 @@ import {
 type Tool = {
   to: string;
   title: string;
-  description: string;
+  /** Omit when the title already says what the tool does. */
+  description?: string;
   icon: typeof Tools;
 };
 
@@ -68,6 +70,11 @@ const tools: Tool[] = [
     description: "Feature flags and developer settings.",
     icon: Tools,
   },
+  {
+    to: "/firmware-app-deployments",
+    title: "Firmware App Deployments",
+    icon: Apps,
+  },
 ];
 
 export default function Home() {
@@ -95,7 +102,7 @@ export default function Home() {
               <Spot appearance="icon" icon={tool.icon} />
               <TileContent>
                 <TileTitle>{tool.title}</TileTitle>
-                <TileDescription>{tool.description}</TileDescription>
+                {tool.description ? <TileDescription>{tool.description}</TileDescription> : null}
               </TileContent>
             </Tile>
           ))}

--- a/apps/web-tools/src/routes.tsx
+++ b/apps/web-tools/src/routes.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from "react-router-dom";
 import CryptoIcons from "./pages/crypto-icons";
 import DevToolsPage from "./pages/dev-tools";
+import FirmwareAppDeployments from "./pages/firmware-app-deployments";
 import Home from "./pages/index";
 import LldSignatures from "./pages/lld-signatures";
 import LogsViewer from "./pages/logsviewer";
@@ -14,6 +15,7 @@ const NotFound = () => <main>Not found</main>;
 export const AppRoutes = () => (
   <Routes>
     <Route path="/" element={<Home />} />
+    <Route path="/firmware-app-deployments" element={<FirmwareAppDeployments />} />
     <Route path="/lld-signatures" element={<LldSignatures />} />
     <Route path="/logsviewer" element={<LogsViewer />} />
     <Route path="/networkTroubleshoot" element={<NetworkTroubleshoot />} />


### PR DESCRIPTION
Adds **Firmware App Deployments** to web-tools at `/firmware-app-deployments`: a matrix of which device app version is published on each device, provider and OS track.

It answers the everyday rollout questions without a device in hand: is app X promoted to P1 yet, and which version exactly is on P1 right now. The `next` track extends the same read to an OS that has not shipped.

It has been running as a private one-off page; this ports it in so the team can reach it.

## How it works

- `/device_versions` and `/firmware_final_versions` enumerate the fleet and pick two firmware tracks per device and provider — newest stable (`current`) and the newest prerelease above it (`next`).
- `/v2/apps/by-target` then fetches each slot's catalogue, 4 requests in flight.
- Providers P1 (production) and P4 (pre-production). Results cached in `localStorage`; **Refresh** recollects.
- Device visibility and the text filter are both URL state, so a view can be shared.

## Screenshots

| Tile on the tools index |
| --- |
| <img src="https://lysyi3m-pluto.s3.amazonaws.com/dropshare/Screen-Capture-2026-09-11-17-57-42.png" width="900"> |

| The matrix |
| --- |
| <img src="https://lysyi3m-pluto.s3.amazonaws.com/dropshare/Screen-Capture-2026-09-11-17-59-01.png" width="900"> |

## Notes for review

Three deliberate departures, each with a reason:

- **`api.ts` uses `fetch`, not live-common's `HttpManagerApiRepository`.** That repository LRU-caches `catalogForDevice` for 5 minutes, which would make **Refresh** replay stale responses, and it only exposes single-device lookups — this page enumerates the whole fleet. The base URL still comes from `MANAGER_API_BASE`, so the staging switch works as usual.
- **The table body is plain `<tr>`/`<td>`, not Lumen's `TableRow`/`TableCell`.** A device toggle re-renders ~1400 cells. Profiled on a production build: 38ms with them, 30ms without. The header keeps its Lumen components.
- **`PageShell` is local, not the shared `ToolPage`.** This page needs a wider container and a single-line header; no other tool does. `ToolPage` is unchanged.

45 unit tests cover the pure logic: firmware ranking and track selection, slot planning, matrix folding, and the URL round-trip.

## Follow-up, not in this PR

`max-w-960` is absent from the generated CSS — Lumen's `max-w` scale stops at 560 — so it silently does nothing in `ToolPage`, the web-tools home grid, `PnlCalculatorView` and the trustchain shell.
