### PR TITLE
feat(analytics): add trackPage (LIVE-37164)

### DIFF
--- a/.changeset/shared-analytics-track-page.md
+++ b/.changeset/shared-analytics-track-page.md
@@ -1,0 +1,5 @@
+---
+"@shared/analytics": minor
+---
+
+Add trackPage for shared page-view analytics.

--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -19,6 +19,7 @@ import {
   setMandatoryExtraPropsFn,
   setPropsFilter,
   track,
+  trackPage,
   type LoggableEvent,
 } from "@shared/analytics";
 // register analytics functions
@@ -35,6 +36,14 @@ setAnalytics({
 
 // track events
 track("Your Event", { foo: "bar" });
+
+// track page views
+trackPage(
+  "Modal send",
+  "step recipient",
+  { flow: "send" },
+  { updateRoutes: true }
+);
 
 // subscribe to the event bus, e.g. for a dev console
 const myDebug: LoggableEvent[] = [];
@@ -66,9 +75,30 @@ When you need to wait until an event is enqueued, await the call, e.g.
 
 ```ts
 await track("My Crucial Event", { foo: "bar" });
+await trackPage("Market");
 ```
 
 The registered analytics client may be sync or async.
+
+### Page views
+
+`trackPage` emits events named `Page ${category} ${name}`. Use `updateRoutes` and `refreshSource` to keep route refs in sync for subsequent `page` and `source` props on other events.
+
+```ts
+trackPage(
+  "Modal send",
+  "step recipient",
+  { flow: "send" },
+  {
+    updateRoutes: true,
+    refreshSource: true,
+  }
+);
+
+trackPage("Mandatory Page", null, null, { mandatory: true });
+```
+
+Use `avoidDuplicates: true` when a screen component may remount and emit the same page event twice.
 
 ### Filtering and enriching
 

--- a/shared/analytics/src/index.ts
+++ b/shared/analytics/src/index.ts
@@ -2,4 +2,5 @@ export * from "./analyticsEvents";
 export * from "./registry";
 export * from "./screenRefs";
 export * from "./track";
+export * from "./trackPage";
 export type * from "./types";

--- a/shared/analytics/src/internals/trackPage.internals.ts
+++ b/shared/analytics/src/internals/trackPage.internals.ts
@@ -1,0 +1,25 @@
+let lastPageEventName: string | undefined;
+
+export function buildFullScreenName(category?: string, name?: string | null): string {
+  return (category || "") + (category && name ? " " : "") + (name || "");
+}
+
+export function buildPageEventName(fullScreenName: string): string {
+  return `Page ${fullScreenName}`;
+}
+
+export function getLastPageEventName(): string | undefined {
+  return lastPageEventName;
+}
+
+export function setLastPageEventName(eventName: string): void {
+  lastPageEventName = eventName;
+}
+
+export function resetLastPageEventName(): void {
+  lastPageEventName = undefined;
+}
+
+export function shouldSkipDuplicatePageEvent(eventName: string, avoidDuplicates: boolean): boolean {
+  return avoidDuplicates && eventName === lastPageEventName;
+}

--- a/shared/analytics/src/trackPage.test.ts
+++ b/shared/analytics/src/trackPage.test.ts
@@ -1,0 +1,205 @@
+jest.mock("./internals/trackEvent", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import { setEnabledFn } from "./registry";
+import {
+  currentRouteNameRef,
+  getCurrentTrackingPage,
+  getPreviousTrackingPage,
+  previousRouteNameRef,
+} from "./screenRefs";
+import { trackEvent } from "./internals/trackEvent";
+import { resetLastPageEventName } from "./internals/trackPage.internals";
+import { trackPage } from "./trackPage";
+
+const register = () => {
+  setEnabledFn(() => true);
+};
+
+beforeEach(() => {
+  jest.mocked(trackEvent).mockReset();
+  setEnabledFn(() => true);
+  currentRouteNameRef.current = undefined;
+  previousRouteNameRef.current = undefined;
+  resetLastPageEventName();
+});
+
+describe("trackPage", () => {
+  it("delegates to trackEvent when tracking is enabled", () => {
+    register();
+
+    trackPage("Market");
+
+    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: false });
+  });
+
+  it("does not delegate when tracking is disabled", () => {
+    register();
+    setEnabledFn(() => false);
+
+    trackPage("Market");
+
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("delegates mandatory page events even when tracking is disabled", () => {
+    register();
+    setEnabledFn(() => false);
+
+    trackPage("Market", null, null, { mandatory: true });
+
+    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: true });
+  });
+
+  it("builds the event name from category only", () => {
+    register();
+
+    trackPage("Market");
+
+    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: false });
+  });
+
+  it("builds the event name from category and name", () => {
+    register();
+
+    trackPage("Modal send", "step recipient");
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "page",
+      "Page Modal send step recipient",
+      {},
+      { mandatory: false },
+    );
+  });
+
+  it("builds the event name from name only", () => {
+    register();
+
+    trackPage(undefined, "step recipient");
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "page",
+      "Page step recipient",
+      {},
+      { mandatory: false },
+    );
+  });
+
+  it("builds the event name when category and name are empty", () => {
+    register();
+
+    trackPage();
+
+    expect(trackEvent).toHaveBeenCalledWith("page", "Page ", {}, { mandatory: false });
+  });
+
+  it("updates previous and current route when updateRoutes and refreshSource are true", () => {
+    register();
+    currentRouteNameRef.current = "Page Portfolio";
+
+    trackPage("Market", null, null, { updateRoutes: true, refreshSource: true });
+
+    expect(getPreviousTrackingPage()).toBe("Page Portfolio");
+    expect(getCurrentTrackingPage()).toBe("Market");
+  });
+
+  it("does not update current route when refreshSource is not true", () => {
+    register();
+    currentRouteNameRef.current = "Page Portfolio";
+
+    trackPage("Market", null, null, { updateRoutes: true });
+
+    expect(getPreviousTrackingPage()).toBe("Page Portfolio");
+    expect(getCurrentTrackingPage()).toBe("Page Portfolio");
+  });
+
+  it("injects source from the previous tracking page", () => {
+    register();
+    previousRouteNameRef.current = "Page Portfolio";
+
+    trackPage("Market");
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "page",
+      "Page Market",
+      { source: "Page Portfolio" },
+      { mandatory: false },
+    );
+  });
+
+  it("omits source when the previous tracking page is unknown", () => {
+    register();
+
+    trackPage("Market");
+
+    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: false });
+  });
+
+  it("allows caller to override source prop", () => {
+    register();
+    previousRouteNameRef.current = "Page Portfolio";
+
+    trackPage("Market", null, { source: "Custom source" });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "page",
+      "Page Market",
+      { source: "Custom source" },
+      { mandatory: false },
+    );
+  });
+
+  it("skips duplicate page events when avoidDuplicates is true", () => {
+    register();
+
+    trackPage("Market", null, null, { avoidDuplicates: true });
+    trackPage("Market", null, null, { avoidDuplicates: true });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("records duplicate page events when avoidDuplicates is false", () => {
+    register();
+
+    trackPage("Market");
+    trackPage("Market");
+
+    expect(trackEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a promise that settles when trackEvent resolves", async () => {
+    register();
+    let resolveTrackEvent: (() => void) | undefined;
+    jest.mocked(trackEvent).mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTrackEvent = resolve;
+        }),
+    );
+
+    let settled = false;
+    const pending = trackPage("Market");
+    expect(pending).toBeInstanceOf(Promise);
+
+    void pending?.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveTrackEvent?.();
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it("returns undefined when tracking is disabled and the event is not mandatory", () => {
+    register();
+    setEnabledFn(() => false);
+
+    const result = trackPage("Market");
+
+    expect(result).toBeUndefined();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/shared/analytics/src/trackPage.ts
+++ b/shared/analytics/src/trackPage.ts
@@ -1,0 +1,64 @@
+/**
+ * @module analytics/trackPage
+ * @description
+ * This module exports the trackPage function.
+ *
+ * @example
+ * ```ts
+ * import { trackPage } from "@shared/analytics";
+ *
+ * trackPage("Market");
+ * trackPage("Modal send", "step recipient", { flow: "send" }, { updateRoutes: true });
+ * trackPage("Mandatory Page", null, null, { mandatory: true });
+ * ```
+ */
+
+import { normalizeProps } from "./internals/normalizeProps";
+import { trackEvent } from "./internals/trackEvent";
+import { isEnabled } from "./registry";
+import { currentRouteNameRef, getPreviousTrackingPage, previousRouteNameRef } from "./screenRefs";
+import {
+  buildFullScreenName,
+  buildPageEventName,
+  setLastPageEventName,
+  shouldSkipDuplicatePageEvent,
+} from "./internals/trackPage.internals";
+import type { Props, TrackPageOptions } from "./types";
+
+export function trackPage(
+  category?: string,
+  name?: string | null,
+  props?: Error | Props | null,
+  {
+    mandatory = false,
+    updateRoutes = false,
+    refreshSource = false,
+    avoidDuplicates = false,
+  }: TrackPageOptions = {},
+): void | Promise<void> {
+  if (!(mandatory || isEnabled())) {
+    return;
+  }
+
+  const fullScreenName = buildFullScreenName(category, name);
+  const eventName = buildPageEventName(fullScreenName);
+
+  if (shouldSkipDuplicatePageEvent(eventName, avoidDuplicates)) {
+    return;
+  }
+
+  setLastPageEventName(eventName);
+
+  if (updateRoutes) {
+    previousRouteNameRef.current = currentRouteNameRef.current;
+    if (refreshSource) {
+      currentRouteNameRef.current = fullScreenName;
+    }
+  }
+
+  const normalizedProps = normalizeProps(props);
+  const source = getPreviousTrackingPage();
+  const eventProps = source ? { source, ...normalizedProps } : normalizedProps;
+
+  return trackEvent("page", eventName, eventProps, { mandatory });
+}

--- a/shared/analytics/src/types.ts
+++ b/shared/analytics/src/types.ts
@@ -36,4 +36,10 @@ export type TrackOptions = {
   mandatory?: boolean;
 };
 
+export type TrackPageOptions = TrackOptions & {
+  updateRoutes?: boolean;
+  refreshSource?: boolean;
+  avoidDuplicates?: boolean;
+};
+
 export type TrackingRouteRef = { current: string | null | undefined };


### PR DESCRIPTION
### 📝 Description

- **Add `trackPage` to shared analytics**
    Keep surface of change minimal for now – stay consistent with current usage of `trackPage`/`trackScreen` in desktop and mobile - and save design improvements for after migration

### 🔗 Context

- **JIRA issue**: [LIVE-37164](https://ledgerhq.atlassian.net/browse/LIVE-37164)


[LIVE-37164]: https://ledgerhq.atlassian.net/browse/LIVE-37164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ