### PR TITLE
chore(analytics): prefer parameter objects

### DIFF
--- a/shared/analytics/README.md
+++ b/shared/analytics/README.md
@@ -37,18 +37,36 @@ setAnalytics({
 // track events
 track("Your Event", { foo: "bar" });
 
-// track page views
-trackPage(
-  "Modal send",
-  "step recipient",
-  { flow: "send" },
-  { updateRoutes: true }
-);
+trackPage({
+  category: "Modal send",
+  name: "step recipient",
+  props: { flow: "send" },
+});
 
 // subscribe to the event bus, e.g. for a dev console
 const myDebug: LoggableEvent[] = [];
 const sub = analyticsEvents$.subscribe((event) => myDebug.push(event));
 const unsubscribe = () => sub.unsubscribe();
+```
+
+### Track
+
+`track` emits events with a payload of props, e.g.
+
+```ts
+track("Your Event", { foo: "bar" });
+```
+
+### Track Page
+
+`trackPage` emits events named `Page ${category} ${name}` and a payload of props.
+
+```ts
+trackPage({
+  category: "Modal send",
+  name: "step recipient",
+  props: { flow: "send" },
+});
 ```
 
 ### Enabling and mandatory
@@ -61,12 +79,6 @@ In the example above it is switched on by default but more often you will store 
 setEnabledFn(() => myAnalyticsEnabledSelector(store.getState()));
 ```
 
-For events that do not require consent use the mandatory option, e.g.
-
-```ts
-track("Mandatory Event", { foo: "bar" }, { mandatory: true });
-```
-
 ### Async and await
 
 `track` can be fire-and-forget – async enrichment and delivery will run inside the package. The final delivery status is published on `analyticsEvents$`.
@@ -75,30 +87,10 @@ When you need to wait until an event is enqueued, await the call, e.g.
 
 ```ts
 await track("My Crucial Event", { foo: "bar" });
-await trackPage("Market");
+await trackPage({ category: "Market" });
 ```
 
 The registered analytics client may be sync or async.
-
-### Page views
-
-`trackPage` emits events named `Page ${category} ${name}`. Use `updateRoutes` and `refreshSource` to keep route refs in sync for subsequent `page` and `source` props on other events.
-
-```ts
-trackPage(
-  "Modal send",
-  "step recipient",
-  { flow: "send" },
-  {
-    updateRoutes: true,
-    refreshSource: true,
-  }
-);
-
-trackPage("Mandatory Page", null, null, { mandatory: true });
-```
-
-Use `avoidDuplicates: true` when a screen component may remount and emit the same page event twice.
 
 ### Filtering and enriching
 
@@ -129,7 +121,34 @@ import {
 
 Tracking routes are used in analytics to provide props like `page` and `source`. They are **ref objects** (similar to React refs) e.g. `currentRouteNameRef.current`.
 
-`track()` adds `page` from `getCurrentTrackingPage()` when a current page is set. Callers can still pass their own `page`.
+`track` adds `page` from `getCurrentTrackingPage()` when a current page is set. Callers can still pass their own `page`.
 
-- Exporting the raw refs is **interim** – [LIVE-36002](https://ledgerhq.atlassian.net/browse/LIVE-36002) narrows this to a function-only API
-- Names are overly-varied (`screenRef`, `routeName` and `trackingSource`) – [LIVE-37304](https://ledgerhq.atlassian.net/browse/LIVE-37304) addresses ambigious names and duplicate logic
+> [!Note]
+> Exporting the raw refs is **interim** – [LIVE-36002](https://ledgerhq.atlassian.net/browse/LIVE-36002) narrows this to a function-only API. Also, names are overly-varied (`screenRef`, `routeName` and `trackingSource`) – [LIVE-37304](https://ledgerhq.atlassian.net/browse/LIVE-37304) addresses ambigious names and duplicate logic
+
+### Additional options
+
+```ts
+// Track options
+track("Mandatory Event", { foo: "bar" }, { mandatory: true });
+
+// Track Page options
+trackPage(
+  { category: "Unmissable page" },
+  {
+    avoidDuplicates: true,
+    mandatory: true,
+    refreshSource: true,
+    updateRoutes: true,
+  }
+);
+```
+
+#### General options – for `track` and `trackPage`
+
+- `mandatory` – for events that do not require consent and should always be sent
+
+#### Route options: for `trackPage`
+
+- `avoidDuplicates` - to avoid resend the same event when a component mounts repeatedly
+- `updateRoutes` and `refreshSource` – to keep `page` and `source` values up to data

--- a/shared/analytics/src/internals/trackEvent.test.ts
+++ b/shared/analytics/src/internals/trackEvent.test.ts
@@ -49,7 +49,7 @@ describe("trackEvent", () => {
       setAnalytics(analyticsClient);
       setExtraPropsFn(() => ({ appVersion: "1.2.3" }));
 
-      await trackEvent("track", "Sync Event", {});
+      await trackEvent({ kind: "track", eventName: "Sync Event", props: {} });
 
       expect(analyticsClient.track).toHaveBeenCalledWith("Sync Event", {
         appVersion: "1.2.3",
@@ -67,7 +67,7 @@ describe("trackEvent", () => {
           }),
       );
 
-      const pending = trackEvent("track", "Async Event", {});
+      const pending = trackEvent({ kind: "track", eventName: "Async Event", props: {} });
 
       expect(analyticsClient.track).not.toHaveBeenCalled();
       resolveExtras({ appVersion: "1.2.3" });
@@ -83,7 +83,7 @@ describe("trackEvent", () => {
       const extraProps = jest.fn(() => ({}));
       setExtraPropsFn(extraProps);
 
-      await trackEvent("track", "Stateful", {});
+      await trackEvent({ kind: "track", eventName: "Stateful", props: {} });
 
       expect(extraProps).toHaveBeenCalledWith();
     });
@@ -93,7 +93,11 @@ describe("trackEvent", () => {
       setAnalytics(analyticsClient);
       setExtraPropsFn(() => ({ platform: "desktop" }));
 
-      await trackEvent("track", "Collision", { platform: "caller-supplied" });
+      await trackEvent({
+        kind: "track",
+        eventName: "Collision",
+        props: { platform: "caller-supplied" },
+      });
 
       expect(analyticsClient.track).toHaveBeenCalledWith("Collision", {
         platform: "desktop",
@@ -105,7 +109,12 @@ describe("trackEvent", () => {
       setAnalytics(analyticsClient);
       setMandatoryExtraPropsFn(() => ({ mandatory: "props" }));
 
-      await trackEvent("track", "Mandatory Event", { flow: "onboarding" }, { mandatory: true });
+      await trackEvent({
+        kind: "track",
+        eventName: "Mandatory Event",
+        props: { flow: "onboarding" },
+        mandatory: true,
+      });
 
       expect(analyticsClient.track).toHaveBeenCalledWith("Mandatory Event", {
         flow: "onboarding",
@@ -118,7 +127,9 @@ describe("trackEvent", () => {
       setAnalytics(analyticsClient);
       setExtraPropsFn(() => Promise.reject(new Error("permission read failed")));
 
-      await expect(trackEvent("track", "Unenrichable", { foo: "bar" })).resolves.toBeUndefined();
+      await expect(
+        trackEvent({ kind: "track", eventName: "Unenrichable", props: { foo: "bar" } }),
+      ).resolves.toBeUndefined();
 
       expect(analyticsClient.track).not.toHaveBeenCalled();
       expect(events).toEqual([
@@ -138,7 +149,7 @@ describe("trackEvent", () => {
         throw new Error("permission read failed");
       });
 
-      await trackEvent("track", "Unenrichable", { foo: "bar" });
+      await trackEvent({ kind: "track", eventName: "Unenrichable", props: { foo: "bar" } });
 
       expect(analyticsClient.track).not.toHaveBeenCalled();
       expect(events).toEqual([
@@ -158,7 +169,11 @@ describe("trackEvent", () => {
       setAnalytics(analyticsClient);
       setPropsFilter(scrubSensitive);
 
-      await trackEvent("track", "Tracking Event", { sensitive: "data to filter", theme: "light" });
+      await trackEvent({
+        kind: "track",
+        eventName: "Tracking Event",
+        props: { sensitive: "data to filter", theme: "light" },
+      });
 
       expect(analyticsClient.track).toHaveBeenCalledWith("Tracking Event", {
         theme: "light",
@@ -171,7 +186,7 @@ describe("trackEvent", () => {
       setExtraPropsFn(() => ({ sensitive: "from-enricher", appVersion: "1.2.3" }));
       setPropsFilter(scrubSensitive);
 
-      await trackEvent("track", "Enriched Event", { theme: "light" });
+      await trackEvent({ kind: "track", eventName: "Enriched Event", props: { theme: "light" } });
 
       expect(analyticsClient.track).toHaveBeenCalledWith("Enriched Event", {
         theme: "light",
@@ -184,7 +199,7 @@ describe("trackEvent", () => {
       setExtraPropsFn(() => ({ sensitive: "from-enricher", appVersion: "1.2.3" }));
       setPropsFilter(scrubSensitive);
 
-      await trackEvent("track", "Subject Event", { theme: "light" });
+      await trackEvent({ kind: "track", eventName: "Subject Event", props: { theme: "light" } });
 
       expect(events[0]).toEqual(
         expect.objectContaining({
@@ -200,7 +215,11 @@ describe("trackEvent", () => {
       setExtraPropsFn(() => Promise.reject(new Error("permission read failed")));
       setPropsFilter(scrubSensitive);
 
-      await trackEvent("track", "Unenrichable", { sensitive: "data to filter", theme: "light" });
+      await trackEvent({
+        kind: "track",
+        eventName: "Unenrichable",
+        props: { sensitive: "data to filter", theme: "light" },
+      });
 
       expect(events).toEqual([
         expect.objectContaining({
@@ -219,7 +238,7 @@ describe("trackEvent", () => {
         throw new Error("filter failed");
       });
 
-      await trackEvent("track", "Filtered Event", { theme: "light" });
+      await trackEvent({ kind: "track", eventName: "Filtered Event", props: { theme: "light" } });
 
       expect(analyticsClient.track).not.toHaveBeenCalled();
       expect(events).toEqual([
@@ -241,7 +260,11 @@ describe("trackEvent", () => {
         return scrubSensitive(props);
       });
 
-      await trackEvent("track", "Enriched Filter Failure", { theme: "light" });
+      await trackEvent({
+        kind: "track",
+        eventName: "Enriched Filter Failure",
+        props: { theme: "light" },
+      });
 
       expect(analyticsClient.track).not.toHaveBeenCalled();
       expect(events).toEqual([

--- a/shared/analytics/src/internals/trackEvent.ts
+++ b/shared/analytics/src/internals/trackEvent.ts
@@ -1,14 +1,16 @@
 import { applyPropsFilter, resolveExtraProps } from "../registry";
-import type { EventType, Props, TrackOptions } from "../types";
+import type { EventType, Props } from "../types";
 import { deliver } from "./deliver";
 import { publishEvent } from "./eventLog";
 
-export async function trackEvent(
-  kind: EventType,
-  eventName: string,
-  props: Props,
-  { mandatory = false }: TrackOptions = {},
-) {
+type TrackEvent = {
+  kind: EventType;
+  eventName: string;
+  props: Props;
+  mandatory?: boolean;
+};
+
+export async function trackEvent({ kind, eventName, props, mandatory = false }: TrackEvent) {
   let filteredProps: Props;
 
   try {

--- a/shared/analytics/src/internals/trackPage.internals.ts
+++ b/shared/analytics/src/internals/trackPage.internals.ts
@@ -20,6 +20,9 @@ export function resetLastPageEventName(): void {
   lastPageEventName = undefined;
 }
 
-export function shouldSkipDuplicatePageEvent(eventName: string, avoidDuplicates: boolean): boolean {
-  return avoidDuplicates && eventName === lastPageEventName;
+export function shouldSkipDuplicatePageEvent(
+  eventName: string,
+  avoidDuplicates: boolean | undefined,
+): boolean {
+  return Boolean(avoidDuplicates) && eventName === lastPageEventName;
 }

--- a/shared/analytics/src/track.test.ts
+++ b/shared/analytics/src/track.test.ts
@@ -23,12 +23,12 @@ describe("track", () => {
 
     track("Analytics Event", { event: "props" });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "track",
-      "Analytics Event",
-      { event: "props" },
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "track",
+      eventName: "Analytics Event",
+      props: { event: "props" },
+      mandatory: false,
+    });
   });
 
   it("does not delegate when tracking is disabled", () => {
@@ -46,12 +46,12 @@ describe("track", () => {
 
     track("Analytics Consent", { flow: "onboarding" }, { mandatory: true });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "track",
-      "Analytics Consent",
-      { flow: "onboarding" },
-      { mandatory: true },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "track",
+      eventName: "Analytics Consent",
+      props: { flow: "onboarding" },
+      mandatory: true,
+    });
   });
 
   it("returns a promise that settles when trackEvent resolves", async () => {
@@ -95,12 +95,12 @@ describe("track", () => {
 
     track("Analytics Event", { event: "props" });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "track",
-      "Analytics Event",
-      { page: "Page Market", event: "props" },
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "track",
+      eventName: "Analytics Event",
+      props: { page: "Page Market", event: "props" },
+      mandatory: false,
+    });
   });
 
   it("allows caller to override page prop", () => {
@@ -109,11 +109,11 @@ describe("track", () => {
 
     track("Analytics Event", { page: "Page from event", event: "props" });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "track",
-      "Analytics Event",
-      { page: "Page from event", event: "props" },
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "track",
+      eventName: "Analytics Event",
+      props: { page: "Page from event", event: "props" },
+      mandatory: false,
+    });
   });
 });

--- a/shared/analytics/src/track.ts
+++ b/shared/analytics/src/track.ts
@@ -27,7 +27,10 @@ export function track(
     const normalizedProps = normalizeProps(props);
     const page = getCurrentTrackingPage();
 
-    return trackEvent("track", event, page ? { page, ...normalizedProps } : normalizedProps, {
+    return trackEvent({
+      kind: "track",
+      eventName: event,
+      props: page ? { page, ...normalizedProps } : normalizedProps,
       mandatory,
     });
   }

--- a/shared/analytics/src/trackPage.test.ts
+++ b/shared/analytics/src/trackPage.test.ts
@@ -29,16 +29,21 @@ describe("trackPage", () => {
   it("delegates to trackEvent when tracking is enabled", () => {
     register();
 
-    trackPage("Market");
+    trackPage({ category: "Market" });
 
-    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: false });
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Market",
+      props: {},
+      mandatory: false,
+    });
   });
 
   it("does not delegate when tracking is disabled", () => {
     register();
     setEnabledFn(() => false);
 
-    trackPage("Market");
+    trackPage({ category: "Market" });
 
     expect(trackEvent).not.toHaveBeenCalled();
   });
@@ -47,58 +52,73 @@ describe("trackPage", () => {
     register();
     setEnabledFn(() => false);
 
-    trackPage("Market", null, null, { mandatory: true });
+    trackPage({ category: "Market" }, { mandatory: true });
 
-    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: true });
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Market",
+      props: {},
+      mandatory: true,
+    });
   });
 
   it("builds the event name from category only", () => {
     register();
 
-    trackPage("Market");
+    trackPage({ category: "Market" });
 
-    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: false });
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Market",
+      props: {},
+      mandatory: false,
+    });
   });
 
   it("builds the event name from category and name", () => {
     register();
 
-    trackPage("Modal send", "step recipient");
+    trackPage({ category: "Modal send", name: "step recipient" });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "page",
-      "Page Modal send step recipient",
-      {},
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Modal send step recipient",
+      props: {},
+      mandatory: false,
+    });
   });
 
   it("builds the event name from name only", () => {
     register();
 
-    trackPage(undefined, "step recipient");
+    trackPage({ name: "step recipient" });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "page",
-      "Page step recipient",
-      {},
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page step recipient",
+      props: {},
+      mandatory: false,
+    });
   });
 
   it("builds the event name when category and name are empty", () => {
     register();
 
-    trackPage();
+    trackPage({});
 
-    expect(trackEvent).toHaveBeenCalledWith("page", "Page ", {}, { mandatory: false });
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page ",
+      props: {},
+      mandatory: false,
+    });
   });
 
   it("updates previous and current route when updateRoutes and refreshSource are true", () => {
     register();
     currentRouteNameRef.current = "Page Portfolio";
 
-    trackPage("Market", null, null, { updateRoutes: true, refreshSource: true });
+    trackPage({ category: "Market" }, { updateRoutes: true, refreshSource: true });
 
     expect(getPreviousTrackingPage()).toBe("Page Portfolio");
     expect(getCurrentTrackingPage()).toBe("Market");
@@ -108,7 +128,7 @@ describe("trackPage", () => {
     register();
     currentRouteNameRef.current = "Page Portfolio";
 
-    trackPage("Market", null, null, { updateRoutes: true });
+    trackPage({ category: "Market" }, { updateRoutes: true });
 
     expect(getPreviousTrackingPage()).toBe("Page Portfolio");
     expect(getCurrentTrackingPage()).toBe("Page Portfolio");
@@ -118,43 +138,48 @@ describe("trackPage", () => {
     register();
     previousRouteNameRef.current = "Page Portfolio";
 
-    trackPage("Market");
+    trackPage({ category: "Market" });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "page",
-      "Page Market",
-      { source: "Page Portfolio" },
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Market",
+      props: { source: "Page Portfolio" },
+      mandatory: false,
+    });
   });
 
   it("omits source when the previous tracking page is unknown", () => {
     register();
 
-    trackPage("Market");
+    trackPage({ category: "Market" });
 
-    expect(trackEvent).toHaveBeenCalledWith("page", "Page Market", {}, { mandatory: false });
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Market",
+      props: {},
+      mandatory: false,
+    });
   });
 
   it("allows caller to override source prop", () => {
     register();
     previousRouteNameRef.current = "Page Portfolio";
 
-    trackPage("Market", null, { source: "Custom source" });
+    trackPage({ category: "Market", props: { source: "Custom source" } });
 
-    expect(trackEvent).toHaveBeenCalledWith(
-      "page",
-      "Page Market",
-      { source: "Custom source" },
-      { mandatory: false },
-    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      kind: "page",
+      eventName: "Page Market",
+      props: { source: "Custom source" },
+      mandatory: false,
+    });
   });
 
   it("skips duplicate page events when avoidDuplicates is true", () => {
     register();
 
-    trackPage("Market", null, null, { avoidDuplicates: true });
-    trackPage("Market", null, null, { avoidDuplicates: true });
+    trackPage({ category: "Market" }, { avoidDuplicates: true });
+    trackPage({ category: "Market" }, { avoidDuplicates: true });
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
   });
@@ -162,8 +187,8 @@ describe("trackPage", () => {
   it("records duplicate page events when avoidDuplicates is false", () => {
     register();
 
-    trackPage("Market");
-    trackPage("Market");
+    trackPage({ category: "Market" });
+    trackPage({ category: "Market" });
 
     expect(trackEvent).toHaveBeenCalledTimes(2);
   });
@@ -179,7 +204,7 @@ describe("trackPage", () => {
     );
 
     let settled = false;
-    const pending = trackPage("Market");
+    const pending = trackPage({ category: "Market" });
     expect(pending).toBeInstanceOf(Promise);
 
     void pending?.then(() => {
@@ -197,7 +222,7 @@ describe("trackPage", () => {
     register();
     setEnabledFn(() => false);
 
-    const result = trackPage("Market");
+    const result = trackPage({ category: "Market" });
 
     expect(result).toBeUndefined();
     expect(trackEvent).not.toHaveBeenCalled();

--- a/shared/analytics/src/trackPage.ts
+++ b/shared/analytics/src/trackPage.ts
@@ -7,9 +7,12 @@
  * ```ts
  * import { trackPage } from "@shared/analytics";
  *
- * trackPage("Market");
- * trackPage("Modal send", "step recipient", { flow: "send" }, { updateRoutes: true });
- * trackPage("Mandatory Page", null, null, { mandatory: true });
+ * trackPage({ category: "Market" });
+ * trackPage(
+ *   { category: "Modal send", name: "step recipient", props: { flow: "send" } },
+ *   { updateRoutes: true },
+ * );
+ * trackPage({ category: "Mandatory Page" }, { mandatory: true });
  * ```
  */
 
@@ -23,12 +26,10 @@ import {
   setLastPageEventName,
   shouldSkipDuplicatePageEvent,
 } from "./internals/trackPage.internals";
-import type { Props, TrackPageOptions } from "./types";
+import type { TrackPageOptions, TrackPagePayload } from "./types";
 
 export function trackPage(
-  category?: string,
-  name?: string | null,
-  props?: Error | Props | null,
+  { category, name, props }: TrackPagePayload,
   {
     mandatory = false,
     updateRoutes = false,
@@ -42,11 +43,11 @@ export function trackPage(
 
   const fullScreenName = buildFullScreenName(category, name);
   const eventName = buildPageEventName(fullScreenName);
+  const shouldSkip = shouldSkipDuplicatePageEvent(eventName, avoidDuplicates);
 
-  if (shouldSkipDuplicatePageEvent(eventName, avoidDuplicates)) {
+  if (shouldSkip) {
     return;
   }
-
   setLastPageEventName(eventName);
 
   if (updateRoutes) {
@@ -60,5 +61,5 @@ export function trackPage(
   const source = getPreviousTrackingPage();
   const eventProps = source ? { source, ...normalizedProps } : normalizedProps;
 
-  return trackEvent("page", eventName, eventProps, { mandatory });
+  return trackEvent({ kind: "page", eventName, props: eventProps, mandatory });
 }

--- a/shared/analytics/src/types.ts
+++ b/shared/analytics/src/types.ts
@@ -36,10 +36,17 @@ export type TrackOptions = {
   mandatory?: boolean;
 };
 
-export type TrackPageOptions = TrackOptions & {
-  updateRoutes?: boolean;
-  refreshSource?: boolean;
+export type TrackPageOptions = {
   avoidDuplicates?: boolean;
+  mandatory?: boolean;
+  refreshSource?: boolean;
+  updateRoutes?: boolean;
+};
+
+export type TrackPagePayload = {
+  category?: string;
+  name?: string | null;
+  props?: Error | Props | null;
 };
 
 export type TrackingRouteRef = { current: string | null | undefined };


### PR DESCRIPTION
### 📝 Description

I was already preferring a parameter object for the `mandatory` option. With the addition of `trackPage` (see #21893) I want to extend this kind of interface further, including to the internal `trackEvent` function.

When we introduce these new function to the apps we can do it in two stages:
1. Import the new functions and wrap them so they match the existing interface, without parameter objects
2. Next, remove the wrapper and call the shared analytics functions directly, benefiting from the improved interface

### 🔗 Context

- **JIRA**: No JIRA – pure redesign/refactoring